### PR TITLE
Add Support for Emotes

### DIFF
--- a/Source/NexusForever.Shared/GameTable/GameTable.cs
+++ b/Source/NexusForever.Shared/GameTable/GameTable.cs
@@ -197,11 +197,11 @@ namespace NexusForever.Shared.GameTable
         public T GetEntry(ulong id)
         {
             if (id >= header.MaxId)
-                throw new GameTableException("Invalid id for this GameTable!");
+                return null;
 
             int lookupId = lookup[id];
             if (lookupId == -1)
-                throw new GameTableException("Invalid id for this GameTable!");
+                return null;
 
             return Entries[lookupId];
         }

--- a/Source/NexusForever.Shared/GameTable/GameTableManager.cs
+++ b/Source/NexusForever.Shared/GameTable/GameTableManager.cs
@@ -20,6 +20,7 @@ namespace NexusForever.Shared.GameTable
         public static GameTable<Item2TypeEntry> ItemType { get; private set; }
         public static GameTable<ItemDisplaySourceEntryEntry> ItemDisplaySource { get; private set; }
         public static GameTable<WorldEntry> World { get; private set; }
+        public static GameTable<EmotesEntry> Emotes { get; private set; }
 
         public static void Initialise()
         {
@@ -39,6 +40,7 @@ namespace NexusForever.Shared.GameTable
                 ItemType               = new GameTable<Item2TypeEntry>("tbl\\Item2Type.tbl");
                 ItemDisplaySource      = new GameTable<ItemDisplaySourceEntryEntry>("tbl\\ItemDisplaySourceEntry.tbl");
                 World                  = new GameTable<WorldEntry>("tbl\\World.tbl");
+                Emotes                 = new GameTable<EmotesEntry>("tbl\\Emotes.tbl");
             }
             catch (Exception exception)
             {

--- a/Source/NexusForever.Shared/Network/Message/GameMessageOpcode.cs
+++ b/Source/NexusForever.Shared/Network/Message/GameMessageOpcode.cs
@@ -74,6 +74,7 @@
         ServerVendor                    = 0x090B,
         ServerItemVisualUpdate          = 0x0933,
         Server0934                      = 0x0934,
+        ServerEmote                     = 0x093C,
         ServerAccountEntitlements       = 0x0968
     }
 }

--- a/Source/NexusForever.WorldServer/Network/Message/Handler/SocialHandler.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Handler/SocialHandler.cs
@@ -1,6 +1,10 @@
-﻿using NexusForever.Shared.Network.Message;
+﻿using System;
+using NexusForever.Shared.Network.Message;
 using NexusForever.WorldServer.Command;
 using NexusForever.WorldServer.Network.Message.Model;
+using NexusForever.Shared.GameTable;
+using NexusForever.Shared.GameTable.Model;
+using NexusForever.Shared.Network;
 
 namespace NexusForever.WorldServer.Network.Message.Handler
 {
@@ -15,6 +19,27 @@ namespace NexusForever.WorldServer.Network.Message.Handler
                 CommandHandlerDelegate handler = CommandManager.GetCommandHandler(command);
                 handler?.Invoke(session, parameters);
             }
+        }
+
+        [MessageHandler(GameMessageOpcode.ClientEmote)]
+        public static void HandleEmote(WorldSession session, ClientEmote emote)
+        {
+            uint emoteId = emote.EmoteId;
+            uint standState = 0;
+            if (emoteId != 0)
+            {                
+                EmotesEntry entry = GameTableManager.Emotes.GetEntry(emoteId);
+                if (entry == null)                
+                    throw (new InvalidPacketValueException("HandleEmote: Invalid EmoteId"));
+
+                standState = entry.StandState;
+            }
+            session.Player.EnqueueToVisible(new ServerEmote
+            {
+                Guid = session.Player.Guid,
+                StandState = standState,
+                EmoteId = emoteId
+            });
         }
     }
 }

--- a/Source/NexusForever.WorldServer/Network/Message/Model/ClientEmote.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Model/ClientEmote.cs
@@ -1,0 +1,20 @@
+﻿using NexusForever.Shared.Network;
+using NexusForever.Shared.Network.Message;
+using NexusForever.WorldServer.Game.Social;
+
+
+namespace NexusForever.WorldServer.Network.Message.Model
+{
+    [Message(GameMessageOpcode.ClientEmote, MessageDirection.Client)]
+    public class ClientEmote : IReadable
+    {
+        public uint EmoteId { get; private set; }
+        public uint Unknown0 { get; set; }
+
+        public void Read(GamePacketReader reader)
+        {
+            EmoteId = reader.ReadUInt(14);
+            Unknown0 = reader.ReadUInt(32);
+        }
+    }
+}

--- a/Source/NexusForever.WorldServer/Network/Message/Model/ServerEmote.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Model/ServerEmote.cs
@@ -1,0 +1,21 @@
+﻿using NexusForever.Shared.Network;
+using NexusForever.Shared.Network.Message;
+using NexusForever.WorldServer.Game.Social;
+
+namespace NexusForever.WorldServer.Network.Message.Model
+{
+    [Message(GameMessageOpcode.ServerEmote, MessageDirection.Server)]
+    class ServerEmote : IWritable
+    {
+        public uint Guid { get; set; }
+        public uint StandState { get; set; }
+        public uint EmoteId { get; set; }
+
+        public void Write(GamePacketWriter writer)
+        {
+            writer.Write(Guid, 32);
+            writer.Write(StandState, 4); 
+            writer.Write(EmoteId, 14);
+        }
+    }
+}


### PR DESCRIPTION
Changes GameTable.GetEntry to return null when an entry isn't found rather than throw an exception to better facilitate lookups within the tables.

Adds support for chat emotes, which can be seen by other players.