### PR TITLE
Wrap commands in blanket try catch

### DIFF
--- a/Source/NexusForever.WorldServer/Command/Handler/AccountHandler.cs
+++ b/Source/NexusForever.WorldServer/Command/Handler/AccountHandler.cs
@@ -12,31 +12,17 @@ namespace NexusForever.WorldServer.Command.Handler
         [CommandHandler("accountcreate")]
         public static void HandleAccountCreate(WorldSession session, string[] parameters)
         {
-            try
-            {
-                AuthDatabase.CreateAccount(parameters[0], parameters[1]);
-                log.Info($"Account {parameters[0]} succesfully created!");
-            }
-            catch (Exception exception)
-            {
-                log.Error(exception);
-            }
+            AuthDatabase.CreateAccount(parameters[0], parameters[1]);
+            log.Info($"Account {parameters[0]} succesfully created!");
         }
 
         [CommandHandler("accountdelete")]
         public static void HandleAccountDelete(WorldSession session, string[] parameters)
         {
-            try
-            {
-                if (AuthDatabase.DeleteAccount(parameters[0]))
-                    log.Info($"Account {parameters[0]} succesfully removed!");
-                else
-                    log.Error($"Cannot find account with Email : {parameters[0]}");
-            }
-            catch (Exception exception)
-            {
-                log.Error(exception);
-            }
+            if (AuthDatabase.DeleteAccount(parameters[0]))
+                log.Info($"Account {parameters[0]} succesfully removed!");
+            else
+                log.Error($"Cannot find account with Email : {parameters[0]}");
         }
     }
 }

--- a/Source/NexusForever.WorldServer/WorldServer.cs
+++ b/Source/NexusForever.WorldServer/WorldServer.cs
@@ -67,7 +67,14 @@ namespace NexusForever.WorldServer
 
                 CommandHandlerDelegate handler = CommandManager.GetCommandHandler(command);
                 if (handler != null)
-                    handler.Invoke(null, parameters);
+                    try
+                    {
+                        handler.Invoke(null, parameters);
+                    }
+                    catch (Exception exception)
+                    {
+                        log.Error(exception);
+                    }
                 else
                     Console.WriteLine("Invalid command!");
             }

--- a/Source/NexusForever.WorldServer/WorldServer.cs
+++ b/Source/NexusForever.WorldServer/WorldServer.cs
@@ -67,6 +67,7 @@ namespace NexusForever.WorldServer
 
                 CommandHandlerDelegate handler = CommandManager.GetCommandHandler(command);
                 if (handler != null)
+                {
                     try
                     {
                         handler.Invoke(null, parameters);
@@ -75,6 +76,7 @@ namespace NexusForever.WorldServer
                     {
                         log.Error(exception);
                     }
+                }
                 else
                     Console.WriteLine("Invalid command!");
             }


### PR DESCRIPTION
Exceptions from server commands definitely should not crash the server. While each command should have it's own error handling, wrapping them all is a (barely) acceptable precaution to ease development.

Also removing the existing blanket try/catch blocks, as they are no longer needed and add extra bulk.