### PR TITLE
Some polishing on !itemadd and CommandHandlerAttribute

### DIFF
--- a/Source/NexusForever.WorldServer/Command/CommandHandlerAttribute.cs
+++ b/Source/NexusForever.WorldServer/Command/CommandHandlerAttribute.cs
@@ -2,7 +2,7 @@
 
 namespace NexusForever.WorldServer.Command
 {
-    [AttributeUsage(AttributeTargets.Method)]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)] // In case of commands like additem/itemadd
     public class CommandHandlerAttribute : Attribute
     {
         public string Command { get; set; }

--- a/Source/NexusForever.WorldServer/Command/CommandManager.cs
+++ b/Source/NexusForever.WorldServer/Command/CommandManager.cs
@@ -22,19 +22,19 @@ namespace NexusForever.WorldServer.Command
             {
                 foreach (MethodInfo method in type.GetMethods())
                 {
-                    CommandHandlerAttribute attribute = method.GetCustomAttribute<CommandHandlerAttribute>();
-                    if (attribute == null)
-                        continue;
+                    IEnumerable<CommandHandlerAttribute> attributes = method.GetCustomAttributes<CommandHandlerAttribute>();
+                    foreach(CommandHandlerAttribute att in attributes)
+                    {
+                        ParameterInfo[] parameterInfo = method.GetParameters();
 
-                    ParameterInfo[] parameterInfo = method.GetParameters();
+                        #region Debug
+                        Debug.Assert(parameterInfo.Length == 2);
+                        Debug.Assert(typeof(WorldSession) == parameterInfo[0].ParameterType);
+                        Debug.Assert(typeof(string[]) == parameterInfo[1].ParameterType);
+                        #endregion
 
-                    #region Debug
-                    Debug.Assert(parameterInfo.Length == 2);
-                    Debug.Assert(typeof(WorldSession) == parameterInfo[0].ParameterType);
-                    Debug.Assert(typeof(string[]) == parameterInfo[1].ParameterType);
-                    #endregion
-
-                    handlers.Add(attribute.Command, (CommandHandlerDelegate)Delegate.CreateDelegate(typeof(CommandHandlerDelegate), method));
+                        handlers.Add(att.Command, (CommandHandlerDelegate)Delegate.CreateDelegate(typeof(CommandHandlerDelegate), method));
+                    }
                 }
             }
 

--- a/Source/NexusForever.WorldServer/Command/Handler/ItemHandler.cs
+++ b/Source/NexusForever.WorldServer/Command/Handler/ItemHandler.cs
@@ -5,9 +5,19 @@ namespace NexusForever.WorldServer.Command.Handler
     public static class ItemHandler
     {
         [CommandHandler("itemadd")]
+        [CommandHandler("additem")]
         public static void HandleItemAdd(WorldSession session, string[] parameters)
         {
-            session.Player.Inventory.ItemCreate(uint.Parse(parameters[0]), uint.Parse(parameters[1]));
+            if(parameters.Length <= 0)
+            {
+                return;
+            }
+            uint amount = 1;
+            if(parameters.Length > 1)
+            {
+                amount = uint.Parse(parameters[1]);
+            }
+            session.Player.Inventory.ItemCreate(uint.Parse(parameters[0]), amount);
         }
     }
 }

--- a/Source/NexusForever.WorldServer/Command/Handler/ItemHandler.cs
+++ b/Source/NexusForever.WorldServer/Command/Handler/ItemHandler.cs
@@ -1,13 +1,24 @@
-﻿using NexusForever.WorldServer.Network;
+﻿using NexusForever.WorldServer.Game.Entity.Static;
+using NexusForever.WorldServer.Network;
 
 namespace NexusForever.WorldServer.Command.Handler
 {
     public static class ItemHandler
     {
         [CommandHandler("itemadd")]
+        [CommandHandler("additem")]
         public static void HandleItemAdd(WorldSession session, string[] parameters)
         {
-            session.Player.Inventory.ItemCreate(uint.Parse(parameters[0]), uint.Parse(parameters[1]));
+            if(parameters.Length <= 0)
+            {
+                return;
+            }
+            uint amount = 1;
+            if(parameters.Length > 1)
+            {
+                amount = uint.Parse(parameters[1]);
+            }
+            session.Player.Inventory.ItemCreate(uint.Parse(parameters[0]), amount);
         }
     }
 }

--- a/Source/NexusForever.WorldServer/Command/Handler/ItemHandler.cs
+++ b/Source/NexusForever.WorldServer/Command/Handler/ItemHandler.cs
@@ -1,5 +1,4 @@
-﻿using NexusForever.WorldServer.Game.Entity.Static;
-using NexusForever.WorldServer.Network;
+﻿using NexusForever.WorldServer.Network;
 
 namespace NexusForever.WorldServer.Command.Handler
 {


### PR DESCRIPTION
CommandHandlerAttribute can now be used multiple times on a method (for aliases like itemadd/additem). Itemadd now allows you to leave out the amount, assuming it to be one. It simply returns if there is no item ID.