### PR TITLE
Fixed crashes when parameters are omitted.

### DIFF
--- a/Source/NexusForever.WorldServer/Command/Handler/AccountCommandHandler.cs
+++ b/Source/NexusForever.WorldServer/Command/Handler/AccountCommandHandler.cs
@@ -16,6 +16,12 @@ namespace NexusForever.WorldServer.Command.Handler
         [SubCommandHandler("create", "email password - Create a new account")]
         public async Task HandleAccountCreate(CommandContext context, string subCommand, string[] parameters)
         {
+            if (parameters.Length < 2)
+            {
+                await SendHelpAsync(context).ConfigureAwait(false);
+                return;
+            }
+
             AuthDatabase.CreateAccount(parameters[0], parameters[1]);
             await context.SendMessageAsync($"Account {parameters[0]} created successfully")
                 .ConfigureAwait(false);
@@ -24,6 +30,12 @@ namespace NexusForever.WorldServer.Command.Handler
         [SubCommandHandler("delete", "email - Delete an account")]
         public async Task HandleAccountDeleteAsync(CommandContext context, string subCommand, string[] parameters)
         {
+            if (parameters.Length < 1)
+            {
+                await SendHelpAsync(context).ConfigureAwait(false);
+                return;
+            }
+
             if (AuthDatabase.DeleteAccount(parameters[0]))
                 await context.SendMessageAsync($"Account {parameters[0]} successfully removed!")
                     .ConfigureAwait(false);


### PR DESCRIPTION
When creating an account, with too less parameters, the world server should not crash.