### PR TITLE
Debug packet.

### DIFF
--- a/Source/NexusForever.AuthServer/Network/AuthSession.cs
+++ b/Source/NexusForever.AuthServer/Network/AuthSession.cs
@@ -20,7 +20,7 @@ namespace NexusForever.AuthServer.Network
             });
         }
 
-        protected override IWritable BuildEncryptedMessage(byte[] data)
+        public override IWritable BuildEncryptedMessage(byte[] data)
         {
             return new ServerAuthEncrypted
             {

--- a/Source/NexusForever.Shared/Network/GameSession.cs
+++ b/Source/NexusForever.Shared/Network/GameSession.cs
@@ -17,7 +17,7 @@ namespace NexusForever.Shared.Network
         /// </summary>
         public bool CanProcessPackets { get; set; } = true;
 
-        protected PacketCrypt encryption;
+        public PacketCrypt Encryption;
 
         private FragmentedBuffer onDeck;
         private readonly ConcurrentQueue<ClientGamePacket> incomingPackets = new ConcurrentQueue<ClientGamePacket>();
@@ -61,21 +61,21 @@ namespace NexusForever.Shared.Network
                 writer.FlushBits();
 
                 byte[] data      = stream.ToArray();
-                byte[] encrypted = encryption.Encrypt(data, data.Length);
+                byte[] encrypted = Encryption.Encrypt(data, data.Length);
                 EnqueueMessage(BuildEncryptedMessage(encrypted));
             }
 
             log.Trace($"Sent packet {opcode}(0x{opcode:X}).");
         }
 
-        protected abstract IWritable BuildEncryptedMessage(byte[] data);
+        public abstract IWritable BuildEncryptedMessage(byte[] data);
 
         public override void OnAccept(Socket newSocket)
         {
             base.OnAccept(newSocket);
 
             ulong key = PacketCrypt.GetKeyFromAuthBuildAndMessage();
-            encryption = new PacketCrypt(key);
+            Encryption = new PacketCrypt(key);
         }
 
         protected override void OnData(byte[] data)
@@ -176,7 +176,7 @@ namespace NexusForever.Shared.Network
         [MessageHandler(GameMessageOpcode.ClientEncrypted)]
         public void HandleEncryptedPacket(ClientEncrypted encrypted)
         {
-            byte[] data = encryption.Decrypt(encrypted.Data, encrypted.Data.Length);
+            byte[] data = Encryption.Decrypt(encrypted.Data, encrypted.Data.Length);
 
             // TODO: research this...
             if (data[0] == 0x8C)

--- a/Source/NexusForever.WorldServer/Command/Handler/DebugHandler.cs
+++ b/Source/NexusForever.WorldServer/Command/Handler/DebugHandler.cs
@@ -1,0 +1,61 @@
+using System;
+using System.IO;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using NexusForever.Shared.Network;
+using NexusForever.WorldServer.Command.Attributes;
+using NexusForever.WorldServer.Command.Contexts;
+
+namespace NexusForever.WorldServer.Command.Handler
+{
+    [Name("Debug")]
+    public class DebugHandler : CommandCategory
+    {
+        public DebugHandler()
+            : base(true, "debug")
+        {
+        }
+
+        [SubCommandHandler("packet", "packet opcode [bytes in hex] - Send debug packet")]
+        public async Task HandleDebugPacket(CommandContext context, string subCommand, string[] parameters)
+        {
+            if (parameters.Length < 1)
+                return;
+
+            using (MemoryStream stream = new MemoryStream())
+            using (GamePacketWriter writer = new GamePacketWriter(stream))
+            {
+                for (int i = 0; i < parameters.Length; i++)
+                {
+                    if (i == 0)
+                        writer.Write(Convert.ToUInt64(parameters[i], 16), 16);
+                    else
+                    {
+                        string[] parts = parameters[i].Split("|");
+                        ulong value;
+
+                        if (Regex.IsMatch(parts[0], "^[0-9]+$"))
+                            value = Convert.ToUInt64(parts[0], 10);
+                        else if (Regex.IsMatch(parts[0], "^0b[0-1]+$"))
+                            value = Convert.ToUInt64(parts[0].Substring(2), 2);
+                        else if (Regex.IsMatch(parts[0], "^0x[0-9A-F]+$"))
+                            value = Convert.ToUInt64(parts[0].Substring(2), 16);
+                        else if (parts[0] == "PLAYER")
+                            value = context.Session.Player.Guid;
+                        else
+                            continue;
+
+                        writer.Write(value, parts.Length > 1 ? Convert.ToUInt32(parts[1], 10) : 64);
+                    }
+                }
+
+                writer.FlushBits();
+
+                byte[] data      = stream.ToArray();
+                byte[] encrypted = context.Session.Encryption.Encrypt(data, data.Length);
+
+                context.Session.EnqueueMessage(context.Session.BuildEncryptedMessage(encrypted));
+            }
+        }
+    }
+}

--- a/Source/NexusForever.WorldServer/Network/WorldSession.cs
+++ b/Source/NexusForever.WorldServer/Network/WorldSession.cs
@@ -32,7 +32,7 @@ namespace NexusForever.WorldServer.Network
             });
         }
 
-        protected override IWritable BuildEncryptedMessage(byte[] data)
+        public override IWritable BuildEncryptedMessage(byte[] data)
         {
             return new ServerRealmEncrypted
             {
@@ -43,7 +43,7 @@ namespace NexusForever.WorldServer.Network
         public void SetEncryptionKey(byte[] sessionKey)
         {
             ulong key = PacketCrypt.GetKeyFromTicket(sessionKey);
-            encryption = new PacketCrypt(key);
+            Encryption = new PacketCrypt(key);
         }
     }
 }


### PR DESCRIPTION
Usefull for ingame testing of packet data.
Values can be defined as decimal numbers, binary numbers using a ```0b``` prefix or hexadecimal numbers using ```0x``` prefix. Additionaly the suffix ```|123``` can be used to specify the amount of send bits. Also i added a value ```PLAYER``` which references the current players guid.

Example to make the character dance:
```
!debug packet 093C PLAYER|32 7|4 34|14
```
