### PR TITLE
Added ability to get/set properties via commands

### DIFF
--- a/Source/NexusForever.WorldServer/Command/Handler/AccountCommandHandler.cs
+++ b/Source/NexusForever.WorldServer/Command/Handler/AccountCommandHandler.cs
@@ -5,6 +5,7 @@ using NexusForever.WorldServer.Command.Contexts;
 
 namespace NexusForever.WorldServer.Command.Handler
 {
+
     [Name("Account Management")]
     public class AccountCommandHandler : CommandCategory
     {

--- a/Source/NexusForever.WorldServer/Command/Handler/CommandCategory.cs
+++ b/Source/NexusForever.WorldServer/Command/Handler/CommandCategory.cs
@@ -69,8 +69,8 @@ namespace NexusForever.WorldServer.Command.Handler
                     return;
                 }
 
-                await (commandCallback?.Invoke(context, parameters[0], parameters.Skip(1).ToArray()) ??
-                      Task.CompletedTask);
+                await commandCallback?.Invoke(context, parameters[0], parameters.Skip(1).ToArray()) ??
+                      Task.CompletedTask;
             }
             else
                 await SendHelpAsync(context);

--- a/Source/NexusForever.WorldServer/Command/Handler/CommandCategory.cs
+++ b/Source/NexusForever.WorldServer/Command/Handler/CommandCategory.cs
@@ -69,8 +69,8 @@ namespace NexusForever.WorldServer.Command.Handler
                     return;
                 }
 
-                await commandCallback?.Invoke(context, parameters[0], parameters.Skip(1).ToArray()) ??
-                      Task.CompletedTask;
+                await (commandCallback?.Invoke(context, parameters[0], parameters.Skip(1).ToArray()) ??
+                      Task.CompletedTask);
             }
             else
                 await SendHelpAsync(context);

--- a/Source/NexusForever.WorldServer/Command/Handler/GetCommandHandler.cs
+++ b/Source/NexusForever.WorldServer/Command/Handler/GetCommandHandler.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Threading.Tasks;
+using NexusForever.WorldServer.Command.Attributes;
+using NexusForever.WorldServer.Command.Contexts;
+using NexusForever.WorldServer.Game.Entity.Static;
+
+namespace NexusForever.WorldServer.Command.Handler
+{
+    [Name("Game Master")]
+    public class GetCommandHandler : NamedCommand
+    {
+
+        public override string HelpText => "get <property>";
+
+        public GetCommandHandler()
+            : base(true, "get")
+        {
+        }
+
+        protected override async Task HandleCommandAsync(CommandContext context, string command, string[] parameters)
+        {
+            if (parameters.Length != 1)
+            {
+                await SendHelpAsync(context);
+                return;
+            }
+
+            if (!Enum.TryParse(parameters[0], out Property property))
+            {
+                await context.SendErrorAsync($"Unknown property: {parameters[0]}").ConfigureAwait(false);
+                return;
+            }
+
+            float? value = context.Session.Player.GetPropertyValue(property);
+            if (value == null)
+                await context.SendMessageAsync($"Property {property} is not set.");
+            else
+                await context.SendMessageAsync($"{property} = {value}");
+        }
+    }
+}

--- a/Source/NexusForever.WorldServer/Command/Handler/GoHandler.cs
+++ b/Source/NexusForever.WorldServer/Command/Handler/GoHandler.cs
@@ -25,6 +25,7 @@ namespace NexusForever.WorldServer.Command.Handler
                     $"Teleporting to {zone.WorldId} {zone.Position0} {zone.Position1} {zone.Position2}");
                 context.Session.Player.TeleportTo((ushort) zone.WorldId, zone.Position0, zone.Position1,
                     zone.Position2);
+            }
         }
     }
 }

--- a/Source/NexusForever.WorldServer/Command/Handler/GoHandler.cs
+++ b/Source/NexusForever.WorldServer/Command/Handler/GoHandler.cs
@@ -20,7 +20,10 @@ namespace NexusForever.WorldServer.Command.Handler
             if (zone == null)
                 await context.SendErrorAsync($"Unknown zone: {zoneName}");
             else
-                context.Session.Player.TeleportTo((ushort)zone.WorldId, zone.Position0, zone.Position1,
+            {
+                await context.SendMessageAsync(
+                    $"Teleporting to {zone.WorldId} {zone.Position0} {zone.Position1} {zone.Position2}");
+                context.Session.Player.TeleportTo((ushort) zone.WorldId, zone.Position0, zone.Position1,
                     zone.Position2);
         }
     }

--- a/Source/NexusForever.WorldServer/Command/Handler/SetCommandHandler.cs
+++ b/Source/NexusForever.WorldServer/Command/Handler/SetCommandHandler.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Threading.Tasks;
+using NexusForever.WorldServer.Command.Attributes;
+using NexusForever.WorldServer.Command.Contexts;
+using NexusForever.WorldServer.Game.Entity.Static;
+
+namespace NexusForever.WorldServer.Command.Handler
+{
+    [Name("Game Master")]
+    public class SetCommandHandler : NamedCommand
+    {
+
+        public override string HelpText => "set <property> <value>";
+
+        public SetCommandHandler()
+            : base(true, "set")
+        {
+        }
+
+        protected override async Task HandleCommandAsync(CommandContext context, string command, string[] parameters)
+        {
+            if (parameters.Length != 2)
+            {
+                await SendHelpAsync(context);
+                return;
+            }
+
+            if (!Enum.TryParse(parameters[0], out Property property))
+            {
+                await context.SendErrorAsync($"Unknown property: {parameters[0]}").ConfigureAwait(false);
+                return;
+            }
+
+            if (!float.TryParse(parameters[1], out float propertyValue))
+            {
+                await context.SendErrorAsync($"Invalid property value: {parameters[1]}").ConfigureAwait(false);
+                return;
+            }
+
+            context.Session.Player.SetProperty(property, propertyValue);
+            context.Session.Player.TeleportTo((ushort) context.Session.Player.Map.Entry.Id,
+                context.Session.Player.Position.X, context.Session.Player.Position.Y,
+                context.Session.Player.Position.Z);
+            await context.SendMessageAsync($"Set {property} to {propertyValue}. Teleporting in place to force update.");
+        }
+    }
+}

--- a/Source/NexusForever.WorldServer/Game/Entity/WorldEntity.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/WorldEntity.cs
@@ -73,7 +73,7 @@ namespace NexusForever.WorldServer.Game.Entity
             };
         }
 
-        protected void SetProperty(Property property, float value, float baseValue = 0.0f)
+        public void SetProperty(Property property, float value, float baseValue = 0.0f)
         {
             if (Properties.ContainsKey(property))
                 Properties[property].Value = value;
@@ -81,7 +81,7 @@ namespace NexusForever.WorldServer.Game.Entity
                 Properties.Add(property, new PropertyValue(property, baseValue, value));
         }
 
-        protected float? GetPropertyValue(Property property)
+        public float? GetPropertyValue(Property property)
         {
             return Properties.ContainsKey(property) ? Properties[property].Value : default;
         }


### PR DESCRIPTION
This is useful for exploring the map.
Commands are:
/c set <property> <value>
and
/c set <property>

Property is parsed using Enum.TryParse, allowing for either enum name, or numeric value.