### PR TITLE
Create Travis Config for Build and Migrations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: csharp
+solution: Source/NexusForever.sln

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: csharp
+mono: none
+dotnet: 2.1.500
 solution: Source/NexusForever.sln
 services:
   - mysql

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,6 @@
 language: csharp
 solution: Source/NexusForever.sln
+services:
+  - mysql
+before_script:
+  - ./Database/scripts/bootstrap.sh

--- a/Database/scripts/bootstrap.sh
+++ b/Database/scripts/bootstrap.sh
@@ -3,31 +3,30 @@
 # Find dir script is running in
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
-# Clean existing DB
-mysql -u root -e "DROP DATABASE nexus_forever_auth;"
-mysql -u root -e "DROP DATABASE nexus_forever_character;"
-mysql -u root -e "DROP DATABASE nexus_forever_world;"
-mysql -u root -e "DROP USER nexusforever;"
+echo "Cleaning existing DB"
+mysql -v -u root -e "DROP DATABASE nexus_forever_auth;"
+mysql -v -u root -e "DROP DATABASE nexus_forever_character;"
+mysql -v -u root -e "DROP DATABASE nexus_forever_world;"
+mysql -v -u root -e "DROP USER nexusforever;"
 
+echo "Creating databases"
+mysql -v -u root -e "CREATE DATABASE nexus_forever_auth;"
+mysql -v -u root -e "CREATE DATABASE nexus_forever_character;"
+mysql -v -u root -e "CREATE DATABASE nexus_forever_world;"
 
-# Create Databases
-mysql -u root -e "CREATE DATABASE nexus_forever_auth;"
-mysql -u root -e "CREATE DATABASE nexus_forever_character;"
-mysql -u root -e "CREATE DATABASE nexus_forever_world;"
+echo "Creating user for tests to use"
+mysql -v -u root -e "CREATE USER nexusforever IDENTIFIED BY 'nexusforever';"
+mysql -v -u root -e "GRANT ALL ON *.* to nexusforever;"
 
-# Create user for servers to use
-mysql -u root -e "CREATE USER nexusforever IDENTIFIED BY 'nexusforever';"
-mysql -u root -e "GRANT ALL ON *.* to nexusforever;"
+echo "Running base scripts"
+mysql -v -u root -D nexus_forever_auth < $DIR/../Base/Auth.sql
+mysql -v -u root -D nexus_forever_character < $DIR/../Base/Character.sql
+mysql -v -u root -D nexus_forever_world < $DIR/../Base/World.sql
 
-# Initial DB setup
-mysql -u root -D nexus_forever_auth < $DIR/../Base/Auth.sql
-mysql -u root -D nexus_forever_character < $DIR/../Base/Character.sql
-mysql -u root -D nexus_forever_world < $DIR/../Base/World.sql
-
-# Run migrations
+echo "Running update scripts"
 find $DIR/../Updates/Auth/ -name '*.sql' -exec sh -c "mysql -u root -D nexus_forever_auth < {}" \;
 find $DIR/../Updates/Character/ -name '*.sql' -exec sh -c "mysql -u root -D nexus_forever_character < {}" \;
 find $DIR/../Updates/World/ -name '*.sql' -exec sh -c "mysql -u root -D nexus_forever_world < {}" \;
 
-# Insert server info into Auth DB
-mysql -u root -D nexus_forever_auth -e "INSERT INTO server (name, host, port, type) VALUES ('NexusForever', '127.0.0.1', 24000, 0);"
+echo "Inserting server information"
+mysql -v -u root -D nexus_forever_auth -e "INSERT INTO server (name, host, port, type) VALUES ('NexusForever', '127.0.0.1', 24000, 0);"

--- a/Database/scripts/bootstrap.sh
+++ b/Database/scripts/bootstrap.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Create Databases
+mysql -u root -e "CREATE DATABASE nexus_forever_auth;"
+mysql -u root -e "CREATE DATABASE nexus_forever_character;"
+mysql -u root -e "CREATE DATABASE nexus_forever_world;"
+
+# Create user for servers to use
+mysql -u root -e "CREATE USER nexusforever;"
+mysql -u root -e "GRANT ALL ON *.* to nexusforever IDENTIFIED BY nexusforever"
+
+# Initial DB setup
+mysql -u root -D nexus_forever_auth < ../Base/Auth.sql
+mysql -u root -D nexus_forever_character < ../Base/Character.sql
+mysql -u root -D nexus_forever_world < ../Base/World.sql
+
+# Run Auth migrations
+for filename in ../Updates/Auth/*.sql; do
+    mysql -u root -D nexus_forever_auth < "$filename"
+done
+
+# Run Character migrations
+for filename in ../Updates/Character/*.sql; do
+    mysql -u root -D nexus_forever_character < "$filename"
+done
+
+# Run World migrations
+for filename in ../Updates/World/*.sql; do
+    mysql -u root -D nexus_forever_world < "$filename"
+done
+
+# Insert server info into Auth DB
+mysql -u root -D nexus_forever_auth -e "INSERT INTO `server` VALUES ('NexusForever', '127.0.0.1', 24000, 0);"

--- a/Database/scripts/bootstrap.sh
+++ b/Database/scripts/bootstrap.sh
@@ -1,33 +1,33 @@
 #!/bin/bash
 
+# Find dir script is running in
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+
+# Clean existing DB
+mysql -u root -e "DROP DATABASE nexus_forever_auth;"
+mysql -u root -e "DROP DATABASE nexus_forever_character;"
+mysql -u root -e "DROP DATABASE nexus_forever_world;"
+mysql -u root -e "DROP USER nexusforever;"
+
+
 # Create Databases
 mysql -u root -e "CREATE DATABASE nexus_forever_auth;"
 mysql -u root -e "CREATE DATABASE nexus_forever_character;"
 mysql -u root -e "CREATE DATABASE nexus_forever_world;"
 
 # Create user for servers to use
-mysql -u root -e "CREATE USER nexusforever;"
-mysql -u root -e "GRANT ALL ON *.* to nexusforever IDENTIFIED BY nexusforever"
+mysql -u root -e "CREATE USER nexusforever IDENTIFIED BY 'nexusforever';"
+mysql -u root -e "GRANT ALL ON *.* to nexusforever;"
 
 # Initial DB setup
-mysql -u root -D nexus_forever_auth < ../Base/Auth.sql
-mysql -u root -D nexus_forever_character < ../Base/Character.sql
-mysql -u root -D nexus_forever_world < ../Base/World.sql
+mysql -u root -D nexus_forever_auth < $DIR/../Base/Auth.sql
+mysql -u root -D nexus_forever_character < $DIR/../Base/Character.sql
+mysql -u root -D nexus_forever_world < $DIR/../Base/World.sql
 
-# Run Auth migrations
-for filename in ../Updates/Auth/*.sql; do
-    mysql -u root -D nexus_forever_auth < "$filename"
-done
-
-# Run Character migrations
-for filename in ../Updates/Character/*.sql; do
-    mysql -u root -D nexus_forever_character < "$filename"
-done
-
-# Run World migrations
-for filename in ../Updates/World/*.sql; do
-    mysql -u root -D nexus_forever_world < "$filename"
-done
+# Run migrations
+find $DIR/../Updates/Auth/ -name '*.sql' -exec sh -c "mysql -u root -D nexus_forever_auth < {}" \;
+find $DIR/../Updates/Character/ -name '*.sql' -exec sh -c "mysql -u root -D nexus_forever_character < {}" \;
+find $DIR/../Updates/World/ -name '*.sql' -exec sh -c "mysql -u root -D nexus_forever_world < {}" \;
 
 # Insert server info into Auth DB
-mysql -u root -D nexus_forever_auth -e "INSERT INTO `server` VALUES ('NexusForever', '127.0.0.1', 24000, 0);"
+mysql -u root -D nexus_forever_auth -e "INSERT INTO server (name, host, port, type) VALUES ('NexusForever', '127.0.0.1', 24000, 0);"


### PR DESCRIPTION
This config will ensure that the project builds correctly, and that all the DB migrations work properly.

Currently using mono as the build matrix, but dotnet core is also available. 

Important note from https://docs.travis-ci.com/user/languages/csharp/#build-environment

> Note that these runtimes do not implement the entire .NET framework, so Windows .NET framework programs may not be fully compatible and require porting.

This sets up an environment that will allow for both unit and integration testing.