### PR TITLE
Grant Account Currency packet

### DIFF
--- a/Source/NexusForever.Shared/Network/Message/GameMessageOpcode.cs
+++ b/Source/NexusForever.Shared/Network/Message/GameMessageOpcode.cs
@@ -84,6 +84,7 @@
         ServerEmote                     = 0x093C,
         ClientWhoRequest                = 0x0959,
         ServerWhoResponse               = 0x095A,
+        ServerGrantAccountCurrency      = 0x0967,
         ServerAccountEntitlements       = 0x0968
     }
 }

--- a/Source/NexusForever.WorldServer/Network/Message/Model/ServerGrantAccountCurrency.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Model/ServerGrantAccountCurrency.cs
@@ -8,18 +8,16 @@ namespace NexusForever.WorldServer.Network.Message.Model
     public class ServerGrantAccountCurrency : IWritable
     {
         public byte Type { get; set; }
-        public ulong Amount { get; set; }
-        public ulong BonusAmount { get; set; } // This is used to say how many of the Amount were granted by a bonus (like Signature status).
+        public ulong TotalAmount { get; set; } // This is the new total of chosen currency. Subtract or Adding currency should send a new total.
+        public ulong BonusAmount { get; set; } // This is used to say how many of the TotalAmount were granted by signature bonus on this "transaction".
         public ulong Unk4 { get; set; }
-        public ulong Unk5 { get; set; }
 
         public void Write(GamePacketWriter writer)
         {
             writer.Write(Type, 5);
-            writer.Write(Amount);
+            writer.Write(TotalAmount);
             writer.Write(BonusAmount);
             writer.Write(Unk4);
-            writer.Write(Unk5);
         }
     }
 }

--- a/Source/NexusForever.WorldServer/Network/Message/Model/ServerGrantAccountCurrency.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Model/ServerGrantAccountCurrency.cs
@@ -1,0 +1,25 @@
+﻿using NexusForever.Shared.Network;
+using NexusForever.Shared.Network.Message;
+
+namespace NexusForever.WorldServer.Network.Message.Model
+{
+
+    [Message(GameMessageOpcode.ServerGrantAccountCurrency, MessageDirection.Server)]
+    public class ServerGrantAccountCurrency : IWritable
+    {
+        public byte Type { get; set; }
+        public ulong Amount { get; set; }
+        public ulong BonusAmount { get; set; } // This is used to say how many of the Amount were granted by a bonus (like Signature status).
+        public ulong Unk4 { get; set; }
+        public ulong Unk5 { get; set; }
+
+        public void Write(GamePacketWriter writer)
+        {
+            writer.Write(Type, 5);
+            writer.Write(Amount);
+            writer.Write(BonusAmount);
+            writer.Write(Unk4);
+            writer.Write(Unk5);
+        }
+    }
+}

--- a/Source/NexusForever.WorldServer/Network/Message/Model/ServerGrantAccountCurrency.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Model/ServerGrantAccountCurrency.cs
@@ -3,7 +3,6 @@ using NexusForever.Shared.Network.Message;
 
 namespace NexusForever.WorldServer.Network.Message.Model
 {
-
     [Message(GameMessageOpcode.ServerGrantAccountCurrency, MessageDirection.Server)]
     public class ServerGrantAccountCurrency : IWritable
     {


### PR DESCRIPTION
Related to #74 

This packet allows you to set the player's currency on load.

I add the following to the `Player.cs`'s `SendPacketsAfterAddToMap()` method which grants my character's 200 service tokens to test out the Path unlock/activation features.
```
Session.EnqueueMessageEncrypted(new ServerGrantAccountCurrency
{
       Type = 9,
       Amount = 200
});
```