### PR TITLE
Removed version number from AspNetCore.All

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: csharp
 mono: none
 dotnet: 2.2.100
+os: linux
+dist: xenial
 services:
   - mysql
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: csharp
 mono: none
-dotnet: 2.1.500
+dotnet: 2.2.100
 services:
   - mysql
 before_script:

--- a/Source/NexusForever.WorldServer/NexusForever.WorldServer.csproj
+++ b/Source/NexusForever.WorldServer/NexusForever.WorldServer.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
     <PackageReference Include="Microsoft.AspNetCore.WebSockets" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
     <PackageReference Include="NLog.Web.AspNetCore" Version="4.7.0" />


### PR DESCRIPTION
The version should not be specified.
This gets rid of a build warning when building the WorldServer