### PR TITLE
Updated travis release scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,22 +13,23 @@ before_deploy:
   - export TRAVIS_TAG="Travis-"$(git log --format=%H -1)
   - git tag $TRAVIS_TAG
   - baseDir=$(pwd)
-  - dotnet publish -c Release -r win-x64 $baseDir/Source/NexusForever.AuthServer
-  - cd $baseDir/Source/NexusForever.AuthServer/bin/Release/netcoreapp*.*/win-x64/
-  - zip -9 AuthServer * -x */
-  - dotnet publish -c Release -r win-x64 $baseDir/Source/NexusForever.StsServer
-  - cd $baseDir/Source/NexusForever.StsServer/bin/Release/netcoreapp*.*/win-x64/
-  - zip -9 StsServer * -x */
-  - dotnet publish -c Release -r win-x64 $baseDir/Source/NexusForever.WorldServer
-  - cd $baseDir/Source/NexusForever.WorldServer/bin/Release/netcoreapp*.*/win-x64/
-  - zip -9 WorldServer * -x */
+  - dotnet publish -c Release -r win-x64 $baseDir/Source/NexusForever.AuthServer --self-contained=false
+  - cd $baseDir/Source/NexusForever.AuthServer/bin/Release/netcoreapp*.*/win-x64/publish/
+  - zip -9 AuthServer *
+  - dotnet publish -c Release -r win-x64 $baseDir/Source/NexusForever.StsServer --self-contained=false
+  - cd $baseDir/Source/NexusForever.StsServer/bin/Release/netcoreapp*.*/win-x64/publish/
+  - zip -9 StsServer *
+  - dotnet publish -c Release -r win-x64 $baseDir/Source/NexusForever.WorldServer --self-contained=false
+  - cd $baseDir/Source/NexusForever.WorldServer/bin/Release/netcoreapp*.*/win-x64/publish/
+  - zip -9 WorldServer *
   - cd $baseDir
 deploy:
   provider: releases
   api_key:
     secure: xCyivUEGRr0FbdJlJ0uwt2V6Eg25p7bMTpstzd1HvHEOjzz0bj2xMfhUorHs5RAF1XFe1x9HQPMCUGVfzr6WlGH/QfzNJpmc0BKegUX32NDfGEyFSyS32Jh97mrolzLqoO3ry4bmAyIo01Wje++IL1r+W9kGLRqOtcXz0GVocWM56kWJ0QV6r6KxbaZKoxu/7GKPKBPNdiEXqO/8tvw2t3xM1qEy69QlJGjYmEOutg/GPYB1nq14UbqFR5rvMqCdRd8dJiIrZYx44ypXW08assQMPDaHjXKZh62uQ4kEvm2jtKMGkWURdZ9tuk4tBEoHyqpjzpXQG4zN2zzjdm2ckmDMD6O/ZlkdEKi6lY3VYdJQv/mA0DjfwkWfWUa+5TX6B4ayirraLK9s37GFHYkcroh+y2fX6jUGWjxTst3G69hHiaPtTCwnU01yoEyeaj+ZoBoLw/Ixf40pUuzsGoXTWdVgQjlbPJjFiobHXTjE0WQZyPxdN2MRoegb8aQ7Wgmwq0W8795BV4xvWCGdF4QAJ/7wgRoPkUU9KGncXYa94XSWylCf2oRDQAvAGiaefnn17LRL1F0AwccCqoF2HsiY1XQcVWTvIahv2BYVNAGZNX3BBiPh/5wZoEFPM1hGCc4+44bkAiWUIZ8VNpmTmt5LmrSDZKFlXZHPBKF95J/k2Lk=
   file_glob: true
-  file: ./Source/NexusForever.*/bin/Release/netcoreapp*.*/win-x64/*.zip
+  file: 
+    - ./Source/NexusForever.*/bin/Release/netcoreapp*.*/*-x64/publish/*.zip
   skip_cleanup: true
   on:
     branch: master


### PR DESCRIPTION
Publishes binaries, but non-self contained. This will require users to have the .NET Core runtime installed, but will stop complaints about failure to start due to deps.json.
This also keeps the size of the release reasonable.

Fixes #77 