### PR TITLE
Implemented new commands for setting player properties.

### DIFF
--- a/Source/NexusForever.Shared/Network/Message/GameMessageOpcode.cs
+++ b/Source/NexusForever.Shared/Network/Message/GameMessageOpcode.cs
@@ -81,6 +81,7 @@
         ServerPlayerCurrencyChanged     = 0x0919,
         ServerItemVisualUpdate          = 0x0933,
         Server0934                      = 0x0934,
+        ServerEntityPropertyBatchUpdate = 0x093A,
         ServerEmote                     = 0x093C,
         ClientWhoRequest                = 0x0959,
         ServerWhoResponse               = 0x095A,

--- a/Source/NexusForever.WorldServer/Command/Handler/CommandCategory.cs
+++ b/Source/NexusForever.WorldServer/Command/Handler/CommandCategory.cs
@@ -69,8 +69,8 @@ namespace NexusForever.WorldServer.Command.Handler
                     return;
                 }
 
-                await (commandCallback?.Invoke(context, parameters[0], parameters.Skip(1).ToArray()) ??
-                      Task.CompletedTask);
+                await commandCallback?.Invoke(context, parameters[0], parameters.Skip(1).ToArray()) ??
+                      Task.CompletedTask;
             }
             else
                 await SendHelpAsync(context);

--- a/Source/NexusForever.WorldServer/Command/Handler/CommandCategory.cs
+++ b/Source/NexusForever.WorldServer/Command/Handler/CommandCategory.cs
@@ -69,8 +69,8 @@ namespace NexusForever.WorldServer.Command.Handler
                     return;
                 }
 
-                await commandCallback?.Invoke(context, parameters[0], parameters.Skip(1).ToArray()) ??
-                      Task.CompletedTask;
+                await (commandCallback?.Invoke(context, parameters[0], parameters.Skip(1).ToArray()) ??
+                      Task.CompletedTask);
             }
             else
                 await SendHelpAsync(context);

--- a/Source/NexusForever.WorldServer/Command/Handler/GoHandler.cs
+++ b/Source/NexusForever.WorldServer/Command/Handler/GoHandler.cs
@@ -2,7 +2,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using NexusForever.Shared.GameTable;
 using NexusForever.Shared.GameTable.Model;
-using NexusForever.Shared.GameTable.Static;
 using NexusForever.WorldServer.Command.Contexts;
 using NexusForever.WorldServer.Game;
 
@@ -19,15 +18,15 @@ namespace NexusForever.WorldServer.Command.Handler
         {
             string zoneName = string.Join(" ", parameters);
 
-            WorldLocation2Entry zone = SearchManager.Search<WorldLocation2Entry>(zoneName, context.Language, 
-                i => 
-                GameTableManager.WorldZone.GetEntry(i.WorldZoneId)?.LocalizedTextIdName ?? 
-                GameTableManager.World.GetEntry(i.WorldId)?.LocalizedTextIdName ?? 
-                0).FirstOrDefault();
+            WorldLocation2Entry zone = SearchManager.Search<WorldLocation2Entry>(zoneName, context.Language,
+                i =>
+                    GameTableManager.WorldZone.GetEntry(i.WorldZoneId)?.LocalizedTextIdName ??
+                    GameTableManager.World.GetEntry(i.WorldId)?.LocalizedTextIdName ??
+                    0).FirstOrDefault();
             if (zone == null)
                 await context.SendErrorAsync($"Unknown zone: {zoneName}");
             else
-                context.Session.Player.TeleportTo((ushort)zone.WorldId, zone.Position0, zone.Position1,
+                context.Session.Player.TeleportTo((ushort) zone.WorldId, zone.Position0, zone.Position1,
                     zone.Position2);
         }
     }

--- a/Source/NexusForever.WorldServer/Command/Handler/GravityCommandHandler.cs
+++ b/Source/NexusForever.WorldServer/Command/Handler/GravityCommandHandler.cs
@@ -1,0 +1,16 @@
+﻿using NexusForever.WorldServer.Command.Attributes;
+
+namespace NexusForever.WorldServer.Command.Handler
+{
+    [Name("Game Master")]
+    public class GravityCommandHandler : PlayerPropertyChangeCommand
+    {
+
+        public override string HelpText => "gravity <value> - Set gravity multiplier";
+
+        public GravityCommandHandler()
+            : base(p => p.GravityMultiplier, "gravity")
+        {
+        }
+    }
+}

--- a/Source/NexusForever.WorldServer/Command/Handler/JumpHeightCommandHandler.cs
+++ b/Source/NexusForever.WorldServer/Command/Handler/JumpHeightCommandHandler.cs
@@ -1,0 +1,17 @@
+﻿using NexusForever.WorldServer.Command.Attributes;
+
+namespace NexusForever.WorldServer.Command.Handler
+{
+    [Name("Game Master")]
+    public class JumpHeightCommandHandler : PlayerPropertyChangeCommand
+    {
+
+        public override string HelpText =>
+            "jumpheight <value> - Set movement speed multiplier. Higher numbers are faster.";
+
+        public JumpHeightCommandHandler()
+            : base(p => p.JumpHeight, "jumpheight")
+        {
+        }
+    }
+}

--- a/Source/NexusForever.WorldServer/Command/Handler/PlayerPropertyChangeCommand.cs
+++ b/Source/NexusForever.WorldServer/Command/Handler/PlayerPropertyChangeCommand.cs
@@ -35,7 +35,6 @@ namespace NexusForever.WorldServer.Command.Handler
             }
 
             float originalValue = SetPropertyValue(context, newValue);
-            context.Session.Player.JumpHeight = newValue;
             await context.SendMessageAsync($"{property.Name} set to {newValue}, previous value: {originalValue}");
         }
 

--- a/Source/NexusForever.WorldServer/Command/Handler/PlayerPropertyChangeCommand.cs
+++ b/Source/NexusForever.WorldServer/Command/Handler/PlayerPropertyChangeCommand.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Threading.Tasks;
+using NexusForever.WorldServer.Command.Contexts;
+using NexusForever.WorldServer.Game.Entity;
+
+namespace NexusForever.WorldServer.Command.Handler
+{
+    public abstract class PlayerPropertyChangeCommand : NamedCommand
+    {
+        private readonly PropertyInfo property;
+
+        public PlayerPropertyChangeCommand(Expression<Func<Player, float>> propertyLambda, params string[] aliases)
+            : base(true, aliases)
+        {
+            property = GetPropertyFromExpression(propertyLambda);
+            if (!property.CanRead || !property.CanWrite)
+                throw new ArgumentException("Property specified must be readable and writable to use this base class.",
+                    nameof(propertyLambda));
+        }
+
+        protected override async Task HandleCommandAsync(CommandContext context, string command, string[] parameters)
+        {
+            if (parameters.Length != 1)
+            {
+                await SendHelpAsync(context);
+                return;
+            }
+
+            if (!float.TryParse(parameters[0], out float newValue) || newValue < 0.0f)
+            {
+                await SendHelpAsync(context);
+                return;
+            }
+
+            float originalValue = SetPropertyValue(context, newValue);
+            context.Session.Player.JumpHeight = newValue;
+            await context.SendMessageAsync($"{property.Name} set to {newValue}, previous value: {originalValue}");
+        }
+
+        protected virtual float GetPropertyValue(CommandContext context)
+        {
+            return (float) property.GetValue(context.Session.Player);
+        }
+
+        protected virtual float SetPropertyValue(CommandContext context, float newValue)
+        {
+            float originalValue = GetPropertyValue(context);
+            property.SetValue(context.Session.Player, newValue);
+            return originalValue;
+        }
+
+        private PropertyInfo GetPropertyFromExpression<T>(Expression<Func<T, float>> propertyLambda)
+        {
+            MemberExpression memberExpression = null;
+
+            //this line is necessary, because sometimes the expression comes in as Convert(originalexpression)
+            if (propertyLambda.Body is UnaryExpression)
+            {
+                var unaryExpression = (UnaryExpression) propertyLambda.Body;
+                if (unaryExpression.Operand is MemberExpression)
+                    memberExpression = (MemberExpression) unaryExpression.Operand;
+                else
+                    throw new ArgumentException();
+            }
+            else if (propertyLambda.Body is MemberExpression)
+                memberExpression = (MemberExpression) propertyLambda.Body;
+            else
+                throw new ArgumentException();
+
+            return (PropertyInfo) memberExpression.Member;
+        }
+    }
+}

--- a/Source/NexusForever.WorldServer/Command/Handler/RunSpeedCommandHandler.cs
+++ b/Source/NexusForever.WorldServer/Command/Handler/RunSpeedCommandHandler.cs
@@ -1,0 +1,17 @@
+﻿using NexusForever.WorldServer.Command.Attributes;
+
+namespace NexusForever.WorldServer.Command.Handler
+{
+    [Name("Game Master")]
+    public class RunSpeedCommandHandler : PlayerPropertyChangeCommand
+    {
+
+        public override string HelpText =>
+            "runspeed <value> - Set movement speed multiplier. Higher numbers are faster.";
+
+        public RunSpeedCommandHandler()
+            : base(p => p.MoveSpeedMultiplier, "runspeed", "speed")
+        {
+        }
+    }
+}

--- a/Source/NexusForever.WorldServer/Game/Entity/Player.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/Player.cs
@@ -42,24 +42,7 @@ namespace NexusForever.WorldServer.Game.Entity
             }
         }
 
-        // Properties
-        public float MoveSpeedMultiplier
-        {
-            get => GetPropertyValue(Property.MoveSpeedMultiplier) ?? 0;
-            set => SetProperty(Property.MoveSpeedMultiplier, value, 1.0f);
-        }
 
-        public float JumpHeight
-        {
-            get => GetPropertyValue(Property.JumpHeight) ?? 0f;
-            set => SetProperty(Property.JumpHeight, value, 2.5f);
-        }
-
-        public float GravityMultiplier
-        {
-            get => GetPropertyValue(Property.GravityMultiplier) ?? 0f;
-            set => SetProperty(Property.GravityMultiplier, value, 1.0f);
-        }
 
         private byte level;
 

--- a/Source/NexusForever.WorldServer/Game/Entity/Player.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/Player.cs
@@ -42,6 +42,25 @@ namespace NexusForever.WorldServer.Game.Entity
             }
         }
 
+        // Properties
+        public float MoveSpeedMultiplier
+        {
+            get => GetPropertyValue(Property.MoveSpeedMultiplier) ?? 0;
+            set => SetProperty(Property.MoveSpeedMultiplier, value, 1.0f);
+        }
+
+        public float JumpHeight
+        {
+            get => GetPropertyValue(Property.JumpHeight) ?? 0f;
+            set => SetProperty(Property.JumpHeight, value, 2.5f);
+        }
+
+        public float GravityMultiplier
+        {
+            get => GetPropertyValue(Property.GravityMultiplier) ?? 0f;
+            set => SetProperty(Property.GravityMultiplier, value, 1.0f);
+        }
+
         private byte level;
 
         public Inventory Inventory { get; }
@@ -78,9 +97,10 @@ namespace NexusForever.WorldServer.Game.Entity
 
             // temp
             Properties.Add(Property.BaseHealth, new PropertyValue(Property.BaseHealth, 200f, 800f));
-            Properties.Add(Property.MoveSpeedMultiplier, new PropertyValue(Property.MoveSpeedMultiplier, 1f, 1f));
-            Properties.Add(Property.JumpHeight, new PropertyValue(Property.JumpHeight, 2.5f, 2.5f));
-            Properties.Add(Property.GravityMultiplier, new PropertyValue(Property.GravityMultiplier, 1f, 1f));
+            MoveSpeedMultiplier = 1f;
+            JumpHeight = 2.5f;
+            GravityMultiplier = 1f;
+            
 
             foreach (ItemVisual itemVisual in Inventory.GetItemVisuals())
                 itemVisuals.Add(itemVisual.Slot, itemVisual);
@@ -113,6 +133,7 @@ namespace NexusForever.WorldServer.Game.Entity
                 logoutManager.Update(lastTick);
             }
 
+            
             timeToSave -= lastTick;
             if (timeToSave <= 0d)
             {
@@ -126,6 +147,9 @@ namespace NexusForever.WorldServer.Game.Entity
                 // prevent packets from being processed until asynchronous player save task is complete
                 Session.CanProcessPackets = false;
             }
+
+            base.Update(lastTick);
+
         }
 
         protected override IEntityModel BuildEntityModel()

--- a/Source/NexusForever.WorldServer/Network/Message/Model/ServerEntityPropertyUpdate.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Model/ServerEntityPropertyUpdate.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.Generic;
+using NexusForever.Shared.Network;
+using NexusForever.Shared.Network.Message;
+using NexusForever.WorldServer.Game.Entity;
+
+namespace NexusForever.WorldServer.Network.Message.Model
+{
+    [Message(GameMessageOpcode.ServerEntityPropertyBatchUpdate, MessageDirection.Server)]
+    public class ServerEntityPropertyBatchUpdate : IWritable
+    {
+        public uint Guid { get; set; }
+        public List<PropertyValue> PropertyValues { get; } = new List<PropertyValue>();
+        public void Write(GamePacketWriter writer)
+        {
+            writer.Write(Guid);
+            writer.Write(PropertyValues.Count, 8);
+            foreach(PropertyValue value in PropertyValues)
+                value.Write(writer);
+        }
+    }
+}


### PR DESCRIPTION
runspeed - Set MoveSpeedMultiplier
jumpheight - Set JumpHeightMultiplier
gravity - Set GravityMultiplier.

Exposed properties via C# float properties on player. The commands exist to test packet 0x093A

Implemented packet 0x093a - ServerEntityPropertyBatchUpdate
This packet updates entity properties on the client.

Changed SetProperty method on base class to queue up property changes, and send them to visible entities on the next Update tick.