### PR TITLE
Reduce the maximum number of decors that can be sent at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A server emulator for WildStar written in C# that supports build 16042.
 [Server Setup Guide](https://github.com/Rawaho/NexusForever/wiki/Installation)
 
 ### Requirements
- * Visual Studio 2017 (.NET Core 2.1 and C# 7.3 support required)
+ * Visual Studio 2017 (.NET Core 2.2 and C# 7.3 support required)
  * MySQL Server (or equivalent, eg: MariaDB)
  * WildStar 16042 client
 

--- a/Source/NexusForever.WorldServer/Game/Map/ResidenceMap.cs
+++ b/Source/NexusForever.WorldServer/Game/Map/ResidenceMap.cs
@@ -136,8 +136,8 @@ namespace NexusForever.WorldServer.Game.Map
             Decor[] decors = residence.GetDecor().ToArray();
             for (uint i = 0u; i < decors.Length; i++)
             {
-                // client freaks out if too much decor is sent in a single message, limit to 500
-                if (i != 0u && i % 500u == 0u)
+                // client freaks out if too much decor is sent in a single message, limit to 100
+                if (i != 0u && i % 100u == 0u)
                 {
                     player.Session.EnqueueMessageEncrypted(residenceDecor);
                     residenceDecor = new ServerHousingResidenceDecor();


### PR DESCRIPTION
This fixes a client disconnect issue with large plots. On live decor came down in batches of 100 maximum, this change reduces the maximum number of decors sent at once from 500 to 100