### PR TITLE
Reputation manager

### DIFF
--- a/Database/Updates/Character/2018_04_15_character_reputation.sql
+++ b/Database/Updates/Character/2018_04_15_character_reputation.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS `character_reputation` (
+    `id` BIGINT(20) UNSIGNED NOT NULL DEFAULT '0',
+    `factionId` MEDIUMINT(8) UNSIGNED NOT NULL DEFAULT '0',
+    `value` INT(10) UNSIGNED NOT NULL DEFAULT '0',
+    PRIMARY KEY (`id`, `factionId`),
+    CONSTRAINT `FK_character_faction_id__character_id` FOREIGN KEY (`id`) REFERENCES `character` (`id`) ON DELETE CASCADE
+);

--- a/Database/Updates/Character/2018_12_11_character_reputation.sql
+++ b/Database/Updates/Character/2018_12_11_character_reputation.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS `character_reputation` (
+    `id` BIGINT(20) UNSIGNED NOT NULL DEFAULT '0',
+    `factionId` MEDIUMINT(8) UNSIGNED NOT NULL DEFAULT '0',
+    `value` INT(10) UNSIGNED NOT NULL DEFAULT '0',
+    PRIMARY KEY (`id`, `factionId`),
+    CONSTRAINT `FK_character_faction_id__character_id` FOREIGN KEY (`id`) REFERENCES `character` (`id`) ON DELETE CASCADE
+);

--- a/Source/NexusForever.Shared/Network/Message/GameMessageOpcode.cs
+++ b/Source/NexusForever.Shared/Network/Message/GameMessageOpcode.cs
@@ -78,6 +78,7 @@ namespace NexusForever.Shared.Network.Message
         ServerStanceChanged             = 0x019F,
         ServerAbilities                 = 0x01A0,
         ServerAmpList                   = 0x01A3,
+        ServerReputationUpdate          = 0x01A5,
         ServerPathUpdateXP              = 0x01AA,
         ServerExperienceGained          = 0x01AC,
         ServerUnlockVanityPet           = 0x01AE,

--- a/Source/NexusForever.WorldServer/Command/Handler/ReputationCommandHandler.cs
+++ b/Source/NexusForever.WorldServer/Command/Handler/ReputationCommandHandler.cs
@@ -1,0 +1,30 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using NexusForever.Shared.GameTable;
+using NexusForever.WorldServer.Command.Attributes;
+using NexusForever.WorldServer.Command.Contexts;
+
+namespace NexusForever.WorldServer.Command.Handler
+{
+    [Name("Reputation")]
+    public class ReputationCommandHandler : CommandCategory
+    {
+        public ReputationCommandHandler()
+            : base(true, "reputation")
+        {
+        }
+
+        [SubCommandHandler("add", "factionId value - Add value to the faction")]
+        public Task AddReputationSubCommand(CommandContext context, string command, string[] parameters)
+        {
+            if (parameters.Length <= 1)
+                return Task.CompletedTask;
+
+            uint factionId = uint.Parse(parameters[0]);
+            uint factionValue = uint.Parse(parameters[1]);
+
+            context.Session.Player.ReputationManager.AddValue(factionId, factionValue);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Source/NexusForever.WorldServer/Database/Character/CharacterDatabase.cs
+++ b/Source/NexusForever.WorldServer/Database/Character/CharacterDatabase.cs
@@ -85,6 +85,7 @@ namespace NexusForever.WorldServer.Database.Character
                         .Include(c => c.CharacterZonemapHexgroup)
                         .Include(c => c.CharacterQuest)
                             .ThenInclude(q => q.CharacterQuestObjective)
+                        .Include(c => c.CharacterReputation)
                     .ToListAsync();
             }
         }

--- a/Source/NexusForever.WorldServer/Database/Character/Model/Character.cs
+++ b/Source/NexusForever.WorldServer/Database/Character/Model/Character.cs
@@ -26,6 +26,7 @@ namespace NexusForever.WorldServer.Database.Character.Model
             CharacterTitle = new HashSet<CharacterTitle>();
             CharacterZonemapHexgroup = new HashSet<CharacterZonemapHexgroup>();
             Item = new HashSet<Item>();
+            CharacterReputation = new HashSet<CharacterReputation>();
         }
 
         public ulong Id { get; set; }
@@ -71,5 +72,6 @@ namespace NexusForever.WorldServer.Database.Character.Model
         public virtual ICollection<CharacterTitle> CharacterTitle { get; set; }
         public virtual ICollection<CharacterZonemapHexgroup> CharacterZonemapHexgroup { get; set; }
         public virtual ICollection<Item> Item { get; set; }
+        public ICollection<CharacterReputation> CharacterReputation { get; set; }
     }
 }

--- a/Source/NexusForever.WorldServer/Database/Character/Model/CharacterContext.cs
+++ b/Source/NexusForever.WorldServer/Database/Character/Model/CharacterContext.cs
@@ -36,6 +36,7 @@ namespace NexusForever.WorldServer.Database.Character.Model
         public virtual DbSet<CharacterPetFlair> CharacterPetFlair { get; set; }
         public virtual DbSet<CharacterQuest> CharacterQuest { get; set; }
         public virtual DbSet<CharacterQuestObjective> CharacterQuestObjective { get; set; }
+        public virtual DbSet<CharacterReputation> CharacterReputation { get; set; }
         public virtual DbSet<CharacterSpell> CharacterSpell { get; set; }
         public virtual DbSet<CharacterStats> CharacterStats { get; set; }
         public virtual DbSet<CharacterTitle> CharacterTitle { get; set; }
@@ -749,6 +750,26 @@ namespace NexusForever.WorldServer.Database.Character.Model
                     .WithMany(p => p.CharacterQuestObjective)
                     .HasForeignKey(d => new { d.Id, d.QuestId })
                     .HasConstraintName("FK__character_quest_objective_id__character_id");
+            });
+            
+            modelBuilder.Entity<CharacterReputation>(entity =>
+            {
+                entity.HasKey(e => new { e.Id, e.FactionId });
+
+                entity.ToTable("character_reputation");
+
+                entity.Property(e => e.FactionId)
+                    .HasColumnName("factionId")
+                    .HasDefaultValueSql("'0'");
+
+                entity.Property(e => e.Value)
+                    .HasColumnName("value")
+                    .HasDefaultValueSql("'0'");
+
+                entity.HasOne(d => d.Character)
+                    .WithMany(p => p.CharacterReputation)
+                    .HasForeignKey(d => d.Id)
+                    .HasConstraintName("FK_character_faction_id__character_id");
             });
 
             modelBuilder.Entity<CharacterSpell>(entity =>

--- a/Source/NexusForever.WorldServer/Database/Character/Model/CharacterReputation.cs
+++ b/Source/NexusForever.WorldServer/Database/Character/Model/CharacterReputation.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace NexusForever.WorldServer.Database.Character.Model
+{
+    public partial class CharacterReputation
+    {
+        public ulong Id { get; set; }
+        public uint FactionId { get; set; }
+        public uint Value { get; set; }
+
+        public Character Character { get; set; }
+    }
+}

--- a/Source/NexusForever.WorldServer/Game/Entity/Player.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/Player.cs
@@ -116,6 +116,7 @@ namespace NexusForever.WorldServer.Game.Entity
         public MailManager MailManager { get; }
         public ZoneMapManager ZoneMapManager { get; }
         public QuestManager QuestManager { get; }
+        public ReputationManager ReputationManager { get; }
 
         public VendorInfo SelectedVendorInfo { get; set; } // TODO unset this when too far away from vendor
 
@@ -160,6 +161,7 @@ namespace NexusForever.WorldServer.Game.Entity
             MailManager             = new MailManager(this, model);
             ZoneMapManager          = new ZoneMapManager(this, model);
             QuestManager            = new QuestManager(this, model);
+            ReputationManager       = new ReputationManager(this, model);
 
             // temp
             Properties.Add(Property.BaseHealth, new PropertyValue(Property.BaseHealth, 200f, 800f));
@@ -193,7 +195,7 @@ namespace NexusForever.WorldServer.Game.Entity
             SetStat(Stat.Sheathed, 1u);
 
             // temp
-            SetStat(Stat.Dash, 200F);
+            SetStat(Stat.Dash, 200f);
             // sprint
             SetStat(Stat.Resource0, 500f);
             SetStat(Stat.Shield, 450u);
@@ -375,6 +377,7 @@ namespace NexusForever.WorldServer.Game.Entity
                 ActiveCostumeIndex = CostumeIndex,
                 InputKeySet = (uint)InputKeySet
             };
+            playerCreate.FactionData.FactionReputations = ReputationManager.LoadReputations();
 
             foreach (Currency currency in CurrencyManager)
                 playerCreate.Money[(byte)currency.Id - 1] = currency.Amount;
@@ -712,6 +715,7 @@ namespace NexusForever.WorldServer.Game.Entity
             MailManager.Save(context);
             ZoneMapManager.Save(context);
             QuestManager.Save(context);
+            ReputationManager.Save(context);
         }
 
         /// <summary>

--- a/Source/NexusForever.WorldServer/Game/Entity/Reputation.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/Reputation.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using NexusForever.Shared.GameTable;
+using NexusForever.Shared.GameTable.Model;
+using NexusForever.WorldServer.Database;
+using NexusForever.WorldServer.Database.Character.Model;
+using NexusForever.WorldServer.Game.Entity.Static;
+using NLog;
+using CharacterReputation = NexusForever.WorldServer.Database.Character.Model.CharacterReputation;
+
+namespace NexusForever.WorldServer.Game.Entity
+{
+    public class Reputation : ISaveCharacter
+    {
+        private static readonly ILogger log = LogManager.GetCurrentClassLogger();
+
+        public Faction2Entry Entry { get; set; }
+        public ulong Id { get; }
+        public ulong CharacterId { get; set; }
+        public uint Amount
+        {
+            get => amount;
+            set
+            {
+                amount = value;
+                saveMask |= ReputationSaveMask.Amount;
+            }
+        }
+        public uint amount;
+
+        private ReputationSaveMask saveMask;
+
+        /// <summary>
+        /// Create a new <see cref="Reputation"/> from an existing database model.
+        /// </summary>
+        public Reputation(CharacterReputation model)
+        {
+            CharacterId = model.Id;
+            Id = model.FactionId;
+            Entry = GameTableManager.Faction2.GetEntry(model.FactionId);
+            Amount = model.Value;
+
+            saveMask = ReputationSaveMask.None;
+        }
+
+        /// <summary>
+        /// Create a new <see cref="Reputation"/> from an <see cref="Faction2Entry"/> template.
+        /// </summary>
+        public Reputation(ulong owner, Faction2Entry entry, uint value = 0u)
+        {
+            Id = entry.Id;
+            CharacterId = owner;
+            Entry = entry;
+            Amount = value;
+
+            saveMask = ReputationSaveMask.Create;
+        }
+
+        public void Save(CharacterContext context)
+        {
+            if (saveMask == ReputationSaveMask.None)
+                return;
+
+            if ((saveMask & ReputationSaveMask.Create) != 0)
+            {
+                // Reputation doesn't exist in database, all infomation must be saved
+                context.Add(new CharacterReputation
+                {
+                    Id = CharacterId,
+                    FactionId = Entry.Id,
+                    Value = Amount,
+                });
+            }
+            else
+            {
+                // Currency already exists in database, save only data that has been modified
+                var model = new CharacterReputation
+                {
+                    Id = CharacterId,
+                    FactionId = Entry.Id,
+                };
+
+                // could probably clean this up with reflection, works for the time being
+                EntityEntry<CharacterReputation> entity = context.Attach(model);
+                if ((saveMask & ReputationSaveMask.Amount) != 0)
+                {
+                    model.Value = Amount;
+                    entity.Property(p => p.Value).IsModified = true;
+                }
+            }
+
+            saveMask = ReputationSaveMask.None;
+        }
+    }
+}

--- a/Source/NexusForever.WorldServer/Game/Entity/ReputationManager.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/ReputationManager.cs
@@ -1,0 +1,164 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using NexusForever.Shared.GameTable;
+using NexusForever.Shared.GameTable.Model;
+using NexusForever.WorldServer.Database;
+using NexusForever.WorldServer.Database.Character.Model;
+using NexusForever.WorldServer.Network.Message.Model;
+using NLog;
+
+namespace NexusForever.WorldServer.Game.Entity
+{
+    public class ReputationManager : ISaveCharacter, IEnumerable<Reputation>
+    {
+        private static readonly ILogger log = LogManager.GetCurrentClassLogger();
+
+        private readonly Player player;
+        private readonly Dictionary<uint, Reputation> reputations = new Dictionary<uint, Reputation>();
+
+        /// <summary>
+        /// Create a new <see cref="ReputationManager"/> from <see cref="Player"/> database model.
+        /// </summary>
+        public ReputationManager(Player owner, Character model)
+        {
+            player = owner;
+
+            foreach (var characterReputation in model.CharacterReputation)
+                reputations.Add(characterReputation.FactionId, new Reputation(characterReputation));
+        }
+
+        /// <summary>
+        /// Create a new <see cref="CharacterReputation"/>.
+        /// </summary>
+        public Reputation ReputationCreate(uint factionId, uint value = 0)
+        {
+            Faction2Entry reputationEntry = GameTableManager.Faction2.GetEntry(factionId);
+            if (reputationEntry == null)
+                return null;
+
+            return ReputationCreate(reputationEntry);
+        }
+
+        /// <summary>
+        /// Create a new <see cref="CharacterReputation"/>.
+        /// </summary>
+        public Reputation ReputationCreate(Faction2Entry reputationEntry, uint value = 0)
+        {
+            if (reputationEntry == null)
+                return null;
+
+            if (reputations.ContainsKey(reputationEntry.Id))
+                throw new ArgumentException($"Reputation {reputationEntry.Id} is already added to the player!");
+
+            Reputation reputation = new Reputation(
+                player.CharacterId,
+                reputationEntry,
+                value
+            );
+            reputations.Add(reputationEntry.Id, reputation);
+            ReputationValueUpdate(reputation, value);
+            return reputation;
+        }
+
+        /// <summary>
+        /// Create a new <see cref="CharacterReputation"/>.
+        /// </summary>
+        public void AddValue(uint reputationId, uint value)
+        {
+            Faction2Entry reputationEntry = GameTableManager.Faction2.GetEntry(reputationId);
+            if (reputationEntry == null)
+                throw new ArgumentNullException();
+
+            AddValue(reputationEntry, value);
+        }
+
+        /// <summary>
+        /// Create a new <see cref="CharacterReputation"/>.
+        /// </summary>
+        public void AddValue(Faction2Entry reputationEntry, uint value)
+        {
+            if (reputationEntry == null)
+                throw new ArgumentNullException();
+
+            if (!reputations.TryGetValue(reputationEntry.Id, out Reputation reputation))
+                ReputationCreate(reputationEntry, value);
+            else
+            {
+                float valueToSend = 0f;
+                if (reputation.Amount + value > 32000)
+                    valueToSend = 32000 - reputation.Amount;
+                else
+                    valueToSend = value;
+
+                if (valueToSend > 0)
+                {
+                    reputation.Amount += (uint)valueToSend;
+                    ReputationValueUpdate(reputation, valueToSend);
+                }
+            }
+
+            // TODO: Add to a parent value, if necessary.
+        }
+
+        public Reputation GetReputation(uint reputationId)
+        {
+            if (!reputations.TryGetValue(reputationId, out Reputation reputation))
+                return ReputationCreate(reputationId);
+            return reputation;
+        }
+
+        /// <summary>
+        /// Used to load the <see cref="CharacterReputation"/> to the player on entering world
+        /// </s ummary>
+        /// <returns></returns>
+        public List<ServerPlayerCreate.Faction.FactionReputation> LoadReputations()
+        {
+            List<ServerPlayerCreate.Faction.FactionReputation> factionList = new List<ServerPlayerCreate.Faction.FactionReputation>();
+
+            // TODO: Not sure if this should actually happen
+            // if (reputations.Count <= 0)
+            //    ReputationCreate((uint)player.Faction1);
+
+            foreach (KeyValuePair<uint, Reputation> reputation in reputations)
+                factionList.Add(new ServerPlayerCreate.Faction.FactionReputation
+                {
+                    FactionId = (ushort)reputation.Value.Id,
+                    Value = reputation.Value.Amount
+                });
+
+            return factionList;
+        }
+
+        public void Save(CharacterContext context)
+        {
+            foreach (Reputation reputation in reputations.Values)
+                reputation.Save(context);
+        }
+
+        /// <summary>
+        /// Update <see cref="Reputation"/> with supplied amount.
+        /// </summary>
+        private void ReputationValueUpdate(Reputation reputation, float value)
+        {
+            if (reputation == null)
+                throw new ArgumentNullException();
+
+            player.Session.EnqueueMessageEncrypted(new ServerReputationUpdate
+            {
+                FactionId = (ushort)reputation.Id,
+                Value = value,
+            });
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        public IEnumerator<Reputation> GetEnumerator()
+        {
+            return reputations.Values.GetEnumerator();
+        }
+    }
+}

--- a/Source/NexusForever.WorldServer/Game/Entity/Static/ReputationSaveMask.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/Static/ReputationSaveMask.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace NexusForever.WorldServer.Game.Entity.Static
+{
+    /// <summary>
+    /// Determines which fields need saving for <see cref="Reputation"/> when being saved to the database.
+    /// </summary>
+    [Flags]
+    public enum ReputationSaveMask
+    {
+        None               = 0x0000,
+        Create             = 0x0001,
+        Delete             = 0x0002,
+        Amount             = 0x0004,
+    }
+}

--- a/Source/NexusForever.WorldServer/Network/Message/Model/ServerPlayerCreate.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Model/ServerPlayerCreate.cs
@@ -14,7 +14,7 @@ namespace NexusForever.WorldServer.Network.Message.Model
         {
             public class FactionReputation : IWritable
             {
-                public FactionId FactionId { get; set; }
+                public ushort FactionId { get; set; }
                 public float Value { get; set; }
 
                 public void Write(GamePacketWriter writer)
@@ -25,7 +25,7 @@ namespace NexusForever.WorldServer.Network.Message.Model
             }
 
             public FactionId FactionId { get; set; }
-            public List<FactionReputation> FactionReputations { get; } = new List<FactionReputation>();
+            public List<FactionReputation> FactionReputations { get; set; } = new List<FactionReputation>();
 
             public void Write(GamePacketWriter writer)
             {

--- a/Source/NexusForever.WorldServer/Network/Message/Model/ServerReputationUpdate.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Model/ServerReputationUpdate.cs
@@ -1,0 +1,18 @@
+﻿using NexusForever.Shared.Network;
+using NexusForever.Shared.Network.Message;
+
+namespace NexusForever.WorldServer.Network.Message.Model
+{
+    [Message(GameMessageOpcode.ServerReputationUpdate)]
+    public class ServerReputationUpdate : IWritable
+    {
+        public ushort FactionId { get; set; }
+        public float Value { get; set; }
+
+        public void Write(GamePacketWriter writer)
+        {
+            writer.Write(FactionId, 14);
+            writer.Write(Value);
+        }
+    }
+}


### PR DESCRIPTION
Replaces #89 - Updated 3rd March 2019

Contributes to #24 

Features
- Adding Reputations to player
- Updating of reputation values to player
- Database table for storage of values
- Commands available to add reputation values to player

Commands
- `!reputation add <factionId> <value>`
  - Adds `<value>` of `<factionId>` to the player.
