### PR TITLE
Social: Whisper & Chat Channel Message Handling

### DIFF
--- a/Source/NexusForever.Shared/Network/GameSession.cs
+++ b/Source/NexusForever.Shared/Network/GameSession.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -23,7 +22,7 @@ namespace NexusForever.Shared.Network
 
         private FragmentedBuffer onDeck;
         private readonly ConcurrentQueue<ClientGamePacket> incomingPackets = new ConcurrentQueue<ClientGamePacket>();
-        private readonly Queue<ServerGamePacket> outgoingPackets = new Queue<ServerGamePacket>();
+        private readonly ConcurrentQueue<ServerGamePacket> outgoingPackets = new ConcurrentQueue<ServerGamePacket>();
 
         /// <summary>
         /// Enqueue <see cref="IWritable"/> to be sent to the client.

--- a/Source/NexusForever.Shared/Network/Message/GameMessageOpcode.cs
+++ b/Source/NexusForever.Shared/Network/Message/GameMessageOpcode.cs
@@ -94,6 +94,8 @@ namespace NexusForever.Shared.Network.Message
         ServerChatAccept                = 0x01C2,
         ClientChat                      = 0x01C3,
         ServerChat                      = 0x01C8,
+        ClientChatWhisper               = 0x01D4,
+        ServerChatZoneChange            = 0x01DA,
         Server0237                      = 0x0237, // UI related, opens or closes different UI windows (bank, barber, ect...)
         ClientPing                      = 0x0241,
         ClientEncrypted                 = 0x0244,

--- a/Source/NexusForever.WorldServer/Command/Contexts/WorldSessionCommandContext.cs
+++ b/Source/NexusForever.WorldServer/Command/Contexts/WorldSessionCommandContext.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
-using NexusForever.WorldServer.Game.Social;
+using NexusForever.WorldServer.Game.Social.Static;
 using NexusForever.WorldServer.Network;
 using NexusForever.WorldServer.Network.Message.Model;
 

--- a/Source/NexusForever.WorldServer/Game/Entity/Player.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/Player.cs
@@ -369,6 +369,7 @@ namespace NexusForever.WorldServer.Game.Entity
 
         private void SendPacketsAfterAddToMap()
         {
+            SocialManager.Instance.JoinChatChannels(Session);
             SendInGameTime();
             PathManager.SendInitialPackets();
             BuybackManager.Instance.SendBuybackItems(this);
@@ -453,7 +454,6 @@ namespace NexusForever.WorldServer.Game.Entity
             }
 
             playerCreate.SpecIndex = SpellManager.ActiveActionSet;
-
             Session.EnqueueMessageEncrypted(playerCreate);
 
             TitleManager.SendTitles();
@@ -611,6 +611,7 @@ namespace NexusForever.WorldServer.Game.Entity
                 Save(() =>
                 {
                     RemoveFromMap();
+                    SocialManager.Instance.LeaveChatChannels(Session);
                     Session.Player = null;
                 });
             }

--- a/Source/NexusForever.WorldServer/Game/Entity/Player.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/Player.cs
@@ -24,9 +24,8 @@ using NexusForever.WorldServer.Game.Quest.Static;
 using NexusForever.WorldServer.Game.Setting;
 using NexusForever.WorldServer.Game.Setting.Static;
 using NexusForever.WorldServer.Game.Social;
+using NexusForever.WorldServer.Game.Social.Static;
 using NexusForever.WorldServer.Game.Static;
-using NexusForever.WorldServer.Game.Spell;
-using NexusForever.WorldServer.Game.Spell.Static;
 using NexusForever.WorldServer.Network;
 using NexusForever.WorldServer.Network.Message.Model;
 using NexusForever.WorldServer.Network.Message.Model.Shared;
@@ -369,7 +368,6 @@ namespace NexusForever.WorldServer.Game.Entity
 
         private void SendPacketsAfterAddToMap()
         {
-            SocialManager.Instance.JoinChatChannels(Session);
             SendInGameTime();
             PathManager.SendInitialPackets();
             BuybackManager.Instance.SendBuybackItems(this);
@@ -611,7 +609,6 @@ namespace NexusForever.WorldServer.Game.Entity
                 Save(() =>
                 {
                     RemoveFromMap();
-                    SocialManager.Instance.LeaveChatChannels(Session);
                     Session.Player = null;
                 });
             }

--- a/Source/NexusForever.WorldServer/Game/Social/Model/IChatFormat.cs
+++ b/Source/NexusForever.WorldServer/Game/Social/Model/IChatFormat.cs
@@ -1,6 +1,6 @@
 ﻿using NexusForever.Shared.Network.Message;
 
-namespace NexusForever.WorldServer.Game.Social.Static
+namespace NexusForever.WorldServer.Game.Social.Model
 {
     public interface IChatFormat : IReadable, IWritable
     {

--- a/Source/NexusForever.WorldServer/Game/Social/SocialManager.cs
+++ b/Source/NexusForever.WorldServer/Game/Social/SocialManager.cs
@@ -5,6 +5,8 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using NexusForever.Shared;
+using NexusForever.Shared.Configuration;
+using NexusForever.Shared.Network;
 using NexusForever.WorldServer.Game.Entity;
 using NexusForever.WorldServer.Game.Map.Search;
 using NexusForever.WorldServer.Game.Social.Model;
@@ -30,6 +32,14 @@ namespace NexusForever.WorldServer.Game.Social
 
         private delegate IChatFormat ChatFormatFactoryDelegate();
         private delegate void ChatChannelHandler(WorldSession session, ClientChat chat);
+
+        // TODO: Switch to caching session GUIDs and announce to each session by Guid.
+        private Dictionary<ChatChannel, List<WorldSession>> chatChannelSessions = new Dictionary<ChatChannel, List<WorldSession>>
+        {
+            { ChatChannel.Nexus, new List<WorldSession>() },
+            { ChatChannel.Trade, new List<WorldSession>() }
+        };
+        private readonly bool CrossFactionChat = ConfigurationManager<WorldServerConfiguration>.Instance.Config.CrossFactionChat;
 
         private SocialManager()
         {
@@ -115,6 +125,36 @@ namespace NexusForever.WorldServer.Game.Social
             });
         }
 
+        /// <summary>
+        /// Add the <see cref="WorldSession"/> to the chat channels sessions list for appropriate chat channels.
+        /// </summary>
+        /// <param name="session"></param>
+        public void JoinChatChannels(WorldSession session)
+        {
+            foreach(KeyValuePair<ChatChannel, List<WorldSession>> chatChannel in chatChannelSessions)
+            {
+                if (chatChannelSessions[chatChannel.Key].Contains(session) || chatChannelSessions[chatChannel.Key].FindAll(s => s.Player == session.Player).ToList().Count <= 0)
+                    chatChannelSessions[chatChannel.Key].Remove(session);
+
+                chatChannelSessions[chatChannel.Key].Add(session);
+
+                session.EnqueueMessageEncrypted(new ServerChatJoin
+                {
+                    Channel = chatChannel.Key
+                });
+            }
+        }
+
+        /// <summary>
+        /// Removes the <see cref="WorldSession"/> from appropriate chat channels.
+        /// </summary>
+        /// <param name="session"></param>
+        public void LeaveChatChannels(WorldSession session)
+        {
+            foreach (KeyValuePair<ChatChannel, List<WorldSession>> chatChannel in chatChannelSessions)
+                chatChannelSessions[chatChannel.Key].Remove(session);
+        }
+
         [ChatChannelHandler(ChatChannel.Say)]
         [ChatChannelHandler(ChatChannel.Yell)]
         [ChatChannelHandler(ChatChannel.Emote)]
@@ -140,33 +180,148 @@ namespace NexusForever.WorldServer.Game.Social
             SendChatAccept(session);            
         }
 
+        /// <summary>
+        /// Handle's whisper messages between 2 clients
+        /// </summary>
+        /// <param name="session"></param>
+        /// <param name="whisper"></param>
+        public void HandleWhisperChat(WorldSession session, ClientChatWhisper whisper)
+        {
+            WorldSession targetSession = NetworkManager<WorldSession>.Instance.GetSession(s => s.Player?.Name == whisper.PlayerName);
+            if (targetSession != null)
+            {
+                if (targetSession == session)
+                {
+                    SendMessage(session, $"You cannot send a message to yourself.", "", ChatChannel.System);
+                    return;
+                }
+
+                if (targetSession.Player.Faction1 != session.Player.Faction1 && !CrossFactionChat)
+                {
+                    SendMessage(session, $"Player \"{whisper.PlayerName}\" not found.", "", ChatChannel.System);
+                    return;
+                }
+
+                // Echo Message
+                session.EnqueueMessageEncrypted(new ServerChat
+                {
+                    Channel = ChatChannel.Whisper,
+                    Name = whisper.PlayerName,
+                    Text = whisper.Message,
+                    Self = true,
+                    CrossFaction = targetSession.Player.Faction1 != session.Player.Faction1,
+                    Formats = ParseChatLinks(session, whisper).ToList(),
+                });
+
+                // Target Player Message
+                targetSession.EnqueueMessageEncrypted(new ServerChat
+                {
+                    Channel = ChatChannel.Whisper,
+                    Name = session.Player.Name,
+                    Text = whisper.Message,
+                    CrossFaction = targetSession.Player.Faction1 != session.Player.Faction1,
+                    Formats = ParseChatLinks(session, whisper).ToList(),
+                });
+            }
+            else
+            {
+                SendMessage(session, $"Player \"{whisper.PlayerName}\" not found.", "", ChatChannel.System);
+            }
+        }
+
+        /// <summary>
+        /// Handles server-wide <see cref="ChatChannel"/>
+        /// </summary>
+        /// <param name="session"></param>
+        /// <param name="chat"></param>
+        [ChatChannelHandler(ChatChannel.Nexus)]
+        [ChatChannelHandler(ChatChannel.Trade)]
+        private void HandleChannelChat(WorldSession session, ClientChat chat)
+        {
+            var serverChat = new ServerChat
+            {
+                Guid = session.Player.Guid,
+                Channel = chat.Channel,
+                Name = session.Player.Name,
+                Text = chat.Message,
+                Formats = ParseChatLinks(session, chat).ToList(),
+            };
+
+            foreach (WorldSession channelSession in chatChannelSessions[chat.Channel])
+            {
+                serverChat.CrossFaction = session.Player.Faction1 != channelSession.Player.Faction1;
+                channelSession.EnqueueMessageEncrypted(serverChat);
+            }
+        }
+
+        /// <summary>
+        /// Parses chat links from <see cref="ChatFormat"/> delivered by <see cref="ClientChat"/>
+        /// </summary>
+        /// <param name="session"></param>
+        /// <param name="chat"></param>
+        /// <returns></returns>
         private IEnumerable<ChatFormat> ParseChatLinks(WorldSession session, ClientChat chat)
         {
             foreach (ChatFormat format in chat.Formats)
             {
-                switch (format.FormatModel)
-                {
-                    case ChatFormatItemGuid chatFormatItemGuid:
+                yield return ParseChatFormat(session, format);
+            }
+        }
+
+        /// <summary>
+        /// Parses chat links from <see cref="ChatFormat"/> delivered by <see cref="ClientChatWhisper"/>
+        /// </summary>
+        /// <param name="session"></param>
+        /// <param name="chat"></param>
+        /// <returns></returns>
+        private IEnumerable<ChatFormat> ParseChatLinks(WorldSession session, ClientChatWhisper chat)
+        {
+            foreach (ChatFormat format in chat.Formats)
+            {
+                yield return ParseChatFormat(session, format);
+            }
+        }
+
+        /// <summary>
+        /// Parses a <see cref="ChatFormat"/> to return a formatted <see cref="ChatFormat"/>
+        /// </summary>
+        /// <param name="session"></param>
+        /// <param name="format"></param>
+        /// <returns></returns>
+        private ChatFormat ParseChatFormat(WorldSession session, ChatFormat format)
+        {
+            switch (format.FormatModel)
+            {
+                case ChatFormatItemGuid chatFormatItemGuid:
                     {
                         Item item = session.Player.Inventory.GetItem(chatFormatItemGuid.Guid);
-                        // TODO: this probably needs to be a full item response
-                        yield return new ChatFormat
-                        {
-                            Type        = ChatFormatType.ItemItemId,
-                            StartIndex  = 0,
-                            StopIndex   = 0,
-                            FormatModel = new ChatFormatItemId
-                            {
-                                ItemId = item.Entry.Id
-                            }
-                        };
-                        break;
+
+                        return GetChatFormatForItem(format, item);
                     }
-                    default:
-                        yield return format;
-                        break;
-                }
+                default:
+                    return format;
             }
+        }
+
+        /// <summary>
+        /// Returns formatted <see cref="ChatFormat"/> for an Item Link
+        /// </summary>
+        /// <param name="chatFormat"></param>
+        /// <param name="item"></param>
+        /// <returns></returns>
+        private ChatFormat GetChatFormatForItem(ChatFormat chatFormat, Item item)
+        {
+            // TODO: this probably needs to be a full item response
+            return new ChatFormat
+            {
+                Type = ChatFormatType.ItemItemId,
+                StartIndex = chatFormat.StartIndex,
+                StopIndex = chatFormat.StopIndex,
+                FormatModel = new ChatFormatItemId
+                {
+                    ItemId = item.Entry.Id
+                }
+            };
         }
 
         public void SendMessage(WorldSession session, string message, string name = "", ChatChannel channel = ChatChannel.System)

--- a/Source/NexusForever.WorldServer/Game/Social/SocialManager.cs
+++ b/Source/NexusForever.WorldServer/Game/Social/SocialManager.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using NexusForever.Shared;
 using NexusForever.Shared.Configuration;
-using NexusForever.Shared.Network;
+using NexusForever.WorldServer.Game.CharacterCache;
 using NexusForever.WorldServer.Game.Entity;
 using NexusForever.WorldServer.Game.Map.Search;
 using NexusForever.WorldServer.Game.Social.Model;
@@ -21,7 +21,7 @@ namespace NexusForever.WorldServer.Game.Social
 {
     public sealed class SocialManager : Singleton<SocialManager>
     {
-        private const float LocalChatDistace = 155f;
+        private const float LocalChatDistance = 155f;
 
         private static readonly ILogger log = LogManager.GetCurrentClassLogger();
 
@@ -32,14 +32,6 @@ namespace NexusForever.WorldServer.Game.Social
 
         private delegate IChatFormat ChatFormatFactoryDelegate();
         private delegate void ChatChannelHandler(WorldSession session, ClientChat chat);
-
-        // TODO: Switch to caching session GUIDs and announce to each session by Guid.
-        private Dictionary<ChatChannel, List<WorldSession>> chatChannelSessions = new Dictionary<ChatChannel, List<WorldSession>>
-        {
-            { ChatChannel.Nexus, new List<WorldSession>() },
-            { ChatChannel.Trade, new List<WorldSession>() }
-        };
-        private readonly bool CrossFactionChat = ConfigurationManager<WorldServerConfiguration>.Instance.Config.CrossFactionChat;
 
         private SocialManager()
         {
@@ -125,36 +117,6 @@ namespace NexusForever.WorldServer.Game.Social
             });
         }
 
-        /// <summary>
-        /// Add the <see cref="WorldSession"/> to the chat channels sessions list for appropriate chat channels.
-        /// </summary>
-        /// <param name="session"></param>
-        public void JoinChatChannels(WorldSession session)
-        {
-            foreach(KeyValuePair<ChatChannel, List<WorldSession>> chatChannel in chatChannelSessions)
-            {
-                if (chatChannelSessions[chatChannel.Key].Contains(session) || chatChannelSessions[chatChannel.Key].FindAll(s => s.Player == session.Player).ToList().Count <= 0)
-                    chatChannelSessions[chatChannel.Key].Remove(session);
-
-                chatChannelSessions[chatChannel.Key].Add(session);
-
-                session.EnqueueMessageEncrypted(new ServerChatJoin
-                {
-                    Channel = chatChannel.Key
-                });
-            }
-        }
-
-        /// <summary>
-        /// Removes the <see cref="WorldSession"/> from appropriate chat channels.
-        /// </summary>
-        /// <param name="session"></param>
-        public void LeaveChatChannels(WorldSession session)
-        {
-            foreach (KeyValuePair<ChatChannel, List<WorldSession>> chatChannel in chatChannelSessions)
-                chatChannelSessions[chatChannel.Key].Remove(session);
-        }
-
         [ChatChannelHandler(ChatChannel.Say)]
         [ChatChannelHandler(ChatChannel.Yell)]
         [ChatChannelHandler(ChatChannel.Emote)]
@@ -166,13 +128,13 @@ namespace NexusForever.WorldServer.Game.Social
                 Channel = chat.Channel,
                 Name    = session.Player.Name,
                 Text    = chat.Message,
-                Formats = ParseChatLinks(session, chat).ToList(),
+                Formats = ParseChatLinks(session, chat.Formats).ToList()
             };
 
             session.Player.Map.Search(
                 session.Player.Position,
-                LocalChatDistace,
-                new SearchCheckRangePlayerOnly(session.Player.Position, LocalChatDistace, session.Player),
+                LocalChatDistance,
+                new SearchCheckRangePlayerOnly(session.Player.Position, LocalChatDistance, session.Player),
                 out List<GridEntity> intersectedEntities
             );
 
@@ -183,121 +145,70 @@ namespace NexusForever.WorldServer.Game.Social
         /// <summary>
         /// Handle's whisper messages between 2 clients
         /// </summary>
-        /// <param name="session"></param>
-        /// <param name="whisper"></param>
         public void HandleWhisperChat(WorldSession session, ClientChatWhisper whisper)
         {
-            WorldSession targetSession = NetworkManager<WorldSession>.Instance.GetSession(s => s.Player?.Name == whisper.PlayerName);
-            if (targetSession != null)
+            ICharacter character = CharacterManager.Instance.GetCharacterInfo(whisper.PlayerName);
+            if (character == null || !(character is Player player))
             {
-                if (targetSession == session)
-                {
-                    SendMessage(session, $"You cannot send a message to yourself.", "", ChatChannel.System);
-                    return;
-                }
-
-                if (targetSession.Player.Faction1 != session.Player.Faction1 && !CrossFactionChat)
-                {
-                    SendMessage(session, $"Player \"{whisper.PlayerName}\" not found.", "", ChatChannel.System);
-                    return;
-                }
-
-                // Echo Message
-                session.EnqueueMessageEncrypted(new ServerChat
-                {
-                    Channel = ChatChannel.Whisper,
-                    Name = whisper.PlayerName,
-                    Text = whisper.Message,
-                    Self = true,
-                    CrossFaction = targetSession.Player.Faction1 != session.Player.Faction1,
-                    Formats = ParseChatLinks(session, whisper).ToList(),
-                });
-
-                // Target Player Message
-                targetSession.EnqueueMessageEncrypted(new ServerChat
-                {
-                    Channel = ChatChannel.Whisper,
-                    Name = session.Player.Name,
-                    Text = whisper.Message,
-                    CrossFaction = targetSession.Player.Faction1 != session.Player.Faction1,
-                    Formats = ParseChatLinks(session, whisper).ToList(),
-                });
+                SendMessage(session, $"Player \"{whisper.PlayerName}\" not found.");
+                return;
             }
-            else
+
+            if (session.Player.Name == character.Name)
+            {
+                SendMessage(session, "You cannot send a message to yourself.");
+                return;
+            }
+
+            bool crossFactionChat = ConfigurationManager<WorldServerConfiguration>.Instance.Config.CrossFactionChat;
+            if (session.Player.Faction1 != character.Faction1 && !crossFactionChat)
             {
                 SendMessage(session, $"Player \"{whisper.PlayerName}\" not found.", "", ChatChannel.System);
+                return;
             }
-        }
 
-        /// <summary>
-        /// Handles server-wide <see cref="ChatChannel"/>
-        /// </summary>
-        /// <param name="session"></param>
-        /// <param name="chat"></param>
-        [ChatChannelHandler(ChatChannel.Nexus)]
-        [ChatChannelHandler(ChatChannel.Trade)]
-        private void HandleChannelChat(WorldSession session, ClientChat chat)
-        {
-            var serverChat = new ServerChat
+            // echo message
+            session.EnqueueMessageEncrypted(new ServerChat
             {
-                Guid = session.Player.Guid,
-                Channel = chat.Channel,
-                Name = session.Player.Name,
-                Text = chat.Message,
-                Formats = ParseChatLinks(session, chat).ToList(),
-            };
+                Channel      = ChatChannel.Whisper,
+                Name         = whisper.PlayerName,
+                Text         = whisper.Message,
+                Self         = true,
+                CrossFaction = session.Player.Faction1 != character.Faction1,
+                Formats      = ParseChatLinks(session, whisper.Formats).ToList()
+            });
 
-            foreach (WorldSession channelSession in chatChannelSessions[chat.Channel])
+            // target player message
+            player.Session.EnqueueMessageEncrypted(new ServerChat
             {
-                serverChat.CrossFaction = session.Player.Faction1 != channelSession.Player.Faction1;
-                channelSession.EnqueueMessageEncrypted(serverChat);
-            }
+                Channel      = ChatChannel.Whisper,
+                Name         = session.Player.Name,
+                Text         = whisper.Message,
+                CrossFaction = session.Player.Faction1 != character.Faction1,
+                Formats      = ParseChatLinks(session, whisper.Formats).ToList(),
+            });
         }
 
         /// <summary>
         /// Parses chat links from <see cref="ChatFormat"/> delivered by <see cref="ClientChat"/>
         /// </summary>
-        /// <param name="session"></param>
-        /// <param name="chat"></param>
-        /// <returns></returns>
-        private IEnumerable<ChatFormat> ParseChatLinks(WorldSession session, ClientChat chat)
+        private IEnumerable<ChatFormat> ParseChatLinks(WorldSession session, IEnumerable<ChatFormat> formats)
         {
-            foreach (ChatFormat format in chat.Formats)
-            {
-                yield return ParseChatFormat(session, format);
-            }
-        }
-
-        /// <summary>
-        /// Parses chat links from <see cref="ChatFormat"/> delivered by <see cref="ClientChatWhisper"/>
-        /// </summary>
-        /// <param name="session"></param>
-        /// <param name="chat"></param>
-        /// <returns></returns>
-        private IEnumerable<ChatFormat> ParseChatLinks(WorldSession session, ClientChatWhisper chat)
-        {
-            foreach (ChatFormat format in chat.Formats)
-            {
-                yield return ParseChatFormat(session, format);
-            }
+            return formats.Select(f => ParseChatFormat(session, f));
         }
 
         /// <summary>
         /// Parses a <see cref="ChatFormat"/> to return a formatted <see cref="ChatFormat"/>
         /// </summary>
-        /// <param name="session"></param>
-        /// <param name="format"></param>
-        /// <returns></returns>
         private ChatFormat ParseChatFormat(WorldSession session, ChatFormat format)
         {
             switch (format.FormatModel)
             {
                 case ChatFormatItemGuid chatFormatItemGuid:
-                    {
-                        Item item = session.Player.Inventory.GetItem(chatFormatItemGuid.Guid);
-
-                        return GetChatFormatForItem(format, item);
-                    }
+                {
+                    Item item = session.Player.Inventory.GetItem(chatFormatItemGuid.Guid);
+                    return GetChatFormatForItem(format, item);
+                }
                 default:
                     return format;
             }
@@ -306,20 +217,17 @@ namespace NexusForever.WorldServer.Game.Social
         /// <summary>
         /// Returns formatted <see cref="ChatFormat"/> for an Item Link
         /// </summary>
-        /// <param name="chatFormat"></param>
-        /// <param name="item"></param>
-        /// <returns></returns>
-        private ChatFormat GetChatFormatForItem(ChatFormat chatFormat, Item item)
+        private static ChatFormat GetChatFormatForItem(ChatFormat chatFormat, Item item)
         {
             // TODO: this probably needs to be a full item response
             return new ChatFormat
             {
-                Type = ChatFormatType.ItemItemId,
-                StartIndex = chatFormat.StartIndex,
-                StopIndex = chatFormat.StopIndex,
+                Type        = ChatFormatType.ItemItemId,
+                StartIndex  = chatFormat.StartIndex,
+                StopIndex   = chatFormat.StopIndex,
                 FormatModel = new ChatFormatItemId
                 {
-                    ItemId = item.Entry.Id
+                    ItemId  = item.Entry.Id
                 }
             };
         }

--- a/Source/NexusForever.WorldServer/Game/Social/Static/ChatChannel.cs
+++ b/Source/NexusForever.WorldServer/Game/Social/Static/ChatChannel.cs
@@ -1,4 +1,4 @@
-﻿namespace NexusForever.WorldServer.Game.Social
+﻿namespace NexusForever.WorldServer.Game.Social.Static
 {
     public enum ChatChannel
     {

--- a/Source/NexusForever.WorldServer/Network/Message/Handler/SocialHandler.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Handler/SocialHandler.cs
@@ -83,5 +83,11 @@ namespace NexusForever.WorldServer.Network.Message.Handler
                 Players = players
             });
         }
+
+        [MessageHandler(GameMessageOpcode.ClientChatWhisper)]
+        public static void HandleWhisper(WorldSession session, ClientChatWhisper whisper)
+        {
+            SocialManager.Instance.HandleWhisperChat(session, whisper);
+        }
     }
 }

--- a/Source/NexusForever.WorldServer/Network/Message/Model/ClientChat.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Model/ClientChat.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using NexusForever.Shared.Network;
 using NexusForever.Shared.Network.Message;
-using NexusForever.WorldServer.Game.Social;
+using NexusForever.WorldServer.Game.Social.Static;
 using NexusForever.WorldServer.Network.Message.Model.Shared;
 
 namespace NexusForever.WorldServer.Network.Message.Model

--- a/Source/NexusForever.WorldServer/Network/Message/Model/ClientChatWhisper.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Model/ClientChatWhisper.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections.Generic;
+using NexusForever.Shared.Network;
+using NexusForever.Shared.Network.Message;
+using NexusForever.WorldServer.Game.Social;
+using NexusForever.WorldServer.Network.Message.Model.Shared;
+
+namespace NexusForever.WorldServer.Network.Message.Model
+{
+    [Message(GameMessageOpcode.ClientChatWhisper)]
+    public class ClientChatWhisper : IReadable
+    {
+        public string PlayerName { get; private set; }
+        public string Unknown0 { get; private set; }
+
+        public string Message { get; private set; }
+        public List<ChatFormat> Formats { get; } = new List<ChatFormat>();
+
+        public bool Unknown1 { get; set; }
+
+        public void Read(GamePacketReader reader)
+        {
+            PlayerName = reader.ReadWideString();
+            Unknown0 = reader.ReadWideString();
+
+            Message  = reader.ReadWideString();
+            byte formatCount = reader.ReadByte(5u);
+            for (int i = 0; i < formatCount; i++)
+            {
+                var format = new ChatFormat();
+                format.Read(reader);
+                Formats.Add(format);
+            }
+
+            Unknown1 = reader.ReadBit();
+        }
+    }
+}

--- a/Source/NexusForever.WorldServer/Network/Message/Model/ClientChatWhisper.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Model/ClientChatWhisper.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using NexusForever.Shared.Network;
 using NexusForever.Shared.Network.Message;
-using NexusForever.WorldServer.Game.Social;
 using NexusForever.WorldServer.Network.Message.Model.Shared;
 
 namespace NexusForever.WorldServer.Network.Message.Model

--- a/Source/NexusForever.WorldServer/Network/Message/Model/ServerChat.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Model/ServerChat.cs
@@ -8,7 +8,7 @@ using NexusForever.WorldServer.Network.Message.Model.Shared;
 namespace NexusForever.WorldServer.Network.Message.Model
 {
     [Message(GameMessageOpcode.ServerChat)]
-    class ServerChat : IWritable
+    public class ServerChat : IWritable
     {
         public ChatChannel Channel { get; set; }
         public ulong ChatId { get; set; }
@@ -48,7 +48,7 @@ namespace NexusForever.WorldServer.Network.Message.Model
             writer.WriteStringWide(Text);
             writer.Write(Formats.Count, 5u);
 
-            Formats.ForEach(linkedItem => linkedItem.Write(writer));
+            Formats.ForEach(f => f.Write(writer));
 
             writer.Write(CrossFaction);
             writer.Write(0, 16u);

--- a/Source/NexusForever.WorldServer/Network/Message/Model/ServerChatJoin.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Model/ServerChatJoin.cs
@@ -1,11 +1,11 @@
 ﻿using NexusForever.Shared.Network;
 using NexusForever.Shared.Network.Message;
-using NexusForever.WorldServer.Game.Social;
+using NexusForever.WorldServer.Game.Social.Static;
 
 namespace NexusForever.WorldServer.Network.Message.Model
 {
     [Message(GameMessageOpcode.ServerChatJoin)]
-    class ServerChatJoin : IWritable
+    public class ServerChatJoin : IWritable
     {
         public ChatChannel Channel { get; set; }
         public ulong ChannelId { get; set; }

--- a/Source/NexusForever.WorldServer/Network/Message/Model/ServerChatZoneChange.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Model/ServerChatZoneChange.cs
@@ -1,0 +1,17 @@
+﻿using NexusForever.Shared.Network;
+using NexusForever.Shared.Network.Message;
+
+namespace NexusForever.WorldServer.Network.Message.Model
+{
+
+    [Message(GameMessageOpcode.ServerChatZoneChange)]
+    public class ServerChatZoneChange : IWritable
+    {
+       public ushort WorldZoneId { get; set; }
+
+       public void Write(GamePacketWriter writer)
+       {
+           writer.Write(WorldZoneId, 15u);
+       }
+    }
+}

--- a/Source/NexusForever.WorldServer/Network/Message/Model/Shared/ChatFormat.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Model/Shared/ChatFormat.cs
@@ -2,6 +2,7 @@
 using NexusForever.Shared.Network;
 using NexusForever.Shared.Network.Message;
 using NexusForever.WorldServer.Game.Social;
+using NexusForever.WorldServer.Game.Social.Model;
 using NexusForever.WorldServer.Game.Social.Static;
 
 namespace NexusForever.WorldServer.Network.Message.Model.Shared

--- a/Source/NexusForever.WorldServer/WorldServer.example.json
+++ b/Source/NexusForever.WorldServer/WorldServer.example.json
@@ -33,5 +33,6 @@
         "GridUnloadTimer": 3600
     },
     "RealmId": 1,
-    "LengthOfInGameDay": 12600
+    "LengthOfInGameDay": 12600,
+    "CrossFactionChat":  true
 }

--- a/Source/NexusForever.WorldServer/WorldServerConfiguration.cs
+++ b/Source/NexusForever.WorldServer/WorldServerConfiguration.cs
@@ -21,5 +21,6 @@ namespace NexusForever.WorldServer
         public bool UseCache { get; set; } = false;
         public ushort RealmId { get; set; }
         public uint LengthOfInGameDay { get; set; }
+        public bool CrossFactionChat { get; set; } = true;
     }
 }


### PR DESCRIPTION
- Handles whisper messages between 2 clients.
- Handles Nexus & Trade chat channels and related messaging
- Handles formatting chat links.
- Abstracted chat link handling for use in other channel types if they use different opcodes, like whispers do.
- Added `Rules` object to WorldServer configuration. (Optional Parameter)
   - Added `CrossFactionChat` parameter to WorldServer configuration. To be used to enable/disable whispers cross faction. Defaults to Enabled. (Optional Parameter)