### PR TITLE
Path Rewards: Spell reward support

### DIFF
--- a/Database/Updates/Character/2018_12_17_character_path.sql
+++ b/Database/Updates/Character/2018_12_17_character_path.sql
@@ -10,5 +10,5 @@ CREATE TABLE IF NOT EXISTS `character_path` (
 );
 
 ALTER TABLE `character` 
-ADD `activePath` int(10) unsigned NOT NULL DEFAULT '0',
-ADD `pathActivatedTimestamp` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP;
+ADD `activePath` int(10) unsigned NOT NULL DEFAULT '0' AFTER `title`,
+ADD `pathActivatedTimestamp` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP AFTER `activePath`;

--- a/Source/NexusForever.WorldServer/Game/Entity/PathEntry.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/PathEntry.cs
@@ -62,9 +62,9 @@ namespace NexusForever.WorldServer.Game.Entity
         {
             CharacterId = model.Id;
             Path = (Path)model.Path;
-            Unlocked = Convert.ToBoolean(model.Unlocked);
-            TotalXp = model.TotalXp;
-            LevelRewarded = model.LevelRewarded;
+            unlocked = Convert.ToBoolean(model.Unlocked);
+            totalXp = model.TotalXp;
+            levelRewarded = model.LevelRewarded;
             
             saveMask = PathSaveMask.None;
         }
@@ -76,7 +76,7 @@ namespace NexusForever.WorldServer.Game.Entity
         {
             CharacterId = owner;
             Path = path;
-            Unlocked = isUnlocked;
+            unlocked = isUnlocked;
 
             saveMask = PathSaveMask.Create;
         }

--- a/Source/NexusForever.WorldServer/Game/Entity/PathManager.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/PathManager.cs
@@ -219,6 +219,9 @@ namespace NexusForever.WorldServer.Game.Entity
                 if (pathRewardEntry.PathRewardFlags > 0)
                     continue;
 
+                if (pathRewardEntry.PathRewardTypeEnum != 0)
+                    continue;
+
                 if (pathRewardEntry.Item2Id == 0 && pathRewardEntry.Spell4Id == 0 && pathRewardEntry.CharacterTitleId == 0)
                     continue;
 
@@ -229,10 +232,10 @@ namespace NexusForever.WorldServer.Game.Entity
                     continue;
 
                 GrantPathReward(pathRewardEntry);
-                GetPathEntry(path).LevelRewarded = (byte)level;
-                // TODO: Play Level up effect
-                break;
             }
+
+            GetPathEntry(path).LevelRewarded = (byte)level;
+            player.CastSpell(53234, new Spell.SpellParameters());
         }
 
         /// <summary>
@@ -247,8 +250,12 @@ namespace NexusForever.WorldServer.Game.Entity
             // TODO: Check if there's bag space. Otherwise queue? Or is there an overflow inventory?
             if (pathRewardEntry.Item2Id > 0)
                 player.Inventory.ItemCreate(pathRewardEntry.Item2Id, 1, 4);
-            
-            // TODO: Grant Spell rewards (needs PR #76)
+
+            if (pathRewardEntry.Spell4Id > 0)
+            {
+                Spell4Entry spell4Entry = GameTableManager.Spell4.GetEntry(pathRewardEntry.Spell4Id);
+                player.SpellManager.AddSpell(spell4Entry.Spell4BaseIdBaseSpell);
+            }
 
             if (pathRewardEntry.CharacterTitleId > 0)
                 player.TitleManager.AddTitle((ushort)pathRewardEntry.CharacterTitleId);


### PR DESCRIPTION
Additional tidying & bug fixes. 
- Only 1 reward was being granted when there were multiple rewards for leveling up. This should be resolved now.
- Spell effect added to indicate level up has occurred.