### PR TITLE
Gameplayer/Features: Transmat Support & Client Interaction - WIP

### DIFF
--- a/Source/NexusForever.Database.Character/CharacterContext.cs
+++ b/Source/NexusForever.Database.Character/CharacterContext.cs
@@ -84,6 +84,11 @@ namespace NexusForever.Database.Character
                     .HasColumnType("tinyint(3) unsigned")
                     .HasDefaultValue(0);
 
+                entity.Property(e => e.BindPoint)
+                    .HasColumnName("bindPoint")
+                    .HasColumnType("smallint(5) unsigned")
+                    .HasDefaultValueSql("'0'");
+
                 entity.Property(e => e.Class)
                     .HasColumnName("class")
                     .HasColumnType("tinyint(3) unsigned")

--- a/Source/NexusForever.Database.Character/Migrations/20200416021649_Bindpoints.Designer.cs
+++ b/Source/NexusForever.Database.Character/Migrations/20200416021649_Bindpoints.Designer.cs
@@ -2,19 +2,21 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NexusForever.Database.Character;
 
 namespace NexusForever.Database.Character.Migrations
 {
     [DbContext(typeof(CharacterContext))]
-    partial class CharacterContextModelSnapshot : ModelSnapshot
+    [Migration("20200416021649_Bindpoints")]
+    partial class Bindpoints
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "3.1.5")
+                .HasAnnotation("ProductVersion", "3.1.2")
                 .HasAnnotation("Relational:MaxIdentifierLength", 64);
 
             modelBuilder.Entity("NexusForever.Database.Character.Model.CharacterAchievementModel", b =>
@@ -62,6 +64,7 @@ namespace NexusForever.Database.Character.Migrations
                         .HasDefaultValue(0ul);
 
                     b.Property<byte>("SpecIndex")
+                        .ValueGeneratedOnAdd()
                         .HasColumnName("specIndex")
                         .HasColumnType("tinyint(3) unsigned")
                         .HasDefaultValue((byte)0);
@@ -86,11 +89,13 @@ namespace NexusForever.Database.Character.Migrations
                         .HasDefaultValue(0ul);
 
                     b.Property<byte>("SpecIndex")
+                        .ValueGeneratedOnAdd()
                         .HasColumnName("specIndex")
                         .HasColumnType("tinyint(3) unsigned")
                         .HasDefaultValue((byte)0);
 
                     b.Property<ushort>("Location")
+                        .ValueGeneratedOnAdd()
                         .HasColumnName("location")
                         .HasColumnType("smallint(5) unsigned")
                         .HasDefaultValue((ushort)0);
@@ -918,31 +923,6 @@ namespace NexusForever.Database.Character.Migrations
                     b.ToTable("character_quest_objective");
                 });
 
-            modelBuilder.Entity("NexusForever.Database.Character.Model.CharacterReputation", b =>
-                {
-                    b.Property<ulong>("Id")
-                        .HasColumnName("id")
-                        .HasColumnType("bigint(20) unsigned")
-                        .HasDefaultValue(0ul);
-
-                    b.Property<uint>("FactionId")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnName("factionId")
-                        .HasColumnType("int(10) unsigned")
-                        .HasDefaultValue(0u);
-
-                    b.Property<float>("Amount")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnName("amount")
-                        .HasColumnType("float")
-                        .HasDefaultValue(0f);
-
-                    b.HasKey("Id", "FactionId")
-                        .HasName("PRIMARY");
-
-                    b.ToTable("character_reputation");
-                });
-
             modelBuilder.Entity("NexusForever.Database.Character.Model.CharacterSpellModel", b =>
                 {
                     b.Property<ulong>("Id")
@@ -1570,16 +1550,6 @@ namespace NexusForever.Database.Character.Migrations
                         .WithMany("QuestObjective")
                         .HasForeignKey("Id", "QuestId")
                         .HasConstraintName("FK__character_quest_objective_id__character_id")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-                });
-
-            modelBuilder.Entity("NexusForever.Database.Character.Model.CharacterReputation", b =>
-                {
-                    b.HasOne("NexusForever.Database.Character.Model.CharacterModel", "Character")
-                        .WithMany("Reputation")
-                        .HasForeignKey("Id")
-                        .HasConstraintName("FK__character_reputation_id__character_id")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });

--- a/Source/NexusForever.Database.Character/Migrations/20200416021649_Bindpoints.cs
+++ b/Source/NexusForever.Database.Character/Migrations/20200416021649_Bindpoints.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace NexusForever.Database.Character.Migrations
+{
+    public partial class Bindpoints : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<ushort>(
+                name: "bindPoint",
+                table: "character",
+                type: "smallint(5) unsigned",
+                nullable: false,
+                defaultValueSql: "'0'");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "bindPoint",
+                table: "character");
+        }
+    }
+}

--- a/Source/NexusForever.Database.Character/Model/CharacterModel.cs
+++ b/Source/NexusForever.Database.Character/Model/CharacterModel.cs
@@ -33,6 +33,7 @@ namespace NexusForever.Database.Character.Model
         public string OriginalName { get; set; }
         public uint TotalXp { get; set; }
         public uint RestBonusXp { get; set; }
+        public ushort BindPoint { get; set; }
 
         public ResidenceModel Residence { get; set; }
         public ICollection<CharacterAchievementModel> Achievement { get; set; } = new HashSet<CharacterAchievementModel>();

--- a/Source/NexusForever.Database.World/WorldDatabase.cs
+++ b/Source/NexusForever.Database.World/WorldDatabase.cs
@@ -47,6 +47,12 @@ namespace NexusForever.Database.World
                 .ToImmutableList();
         }
 
+        public EntityModel GetEntity(uint creatureId)
+        {
+            using var context = new WorldContext(config);
+            return context.Entity.FirstOrDefault(e => e.Creature == creatureId);
+        }
+
         public ImmutableList<EntityModel> GetEntitiesWithoutArea()
         {
             using var context = new WorldContext(config);

--- a/Source/NexusForever.Shared/GameTable/GameTableManager.cs
+++ b/Source/NexusForever.Shared/GameTable/GameTableManager.cs
@@ -54,7 +54,10 @@ namespace NexusForever.Shared.GameTable
         public GameTable<ArchiveLinkEntry> ArchiveLink { get; private set; }
         public GameTable<AttributeMilestoneGroupEntry> AttributeMilestoneGroup { get; private set; }
         public GameTable<AttributeMiniMilestoneGroupEntry> AttributeMiniMilestoneGroup { get; private set; }
+
+        [GameData]
         public GameTable<BindPointEntry> BindPoint { get; private set; }
+        
         public GameTable<BinkMovieEntry> BinkMovie { get; private set; }
         public GameTable<BinkMovieSubtitleEntry> BinkMovieSubtitle { get; private set; }
         public GameTable<BugCategoryEntry> BugCategory { get; private set; }

--- a/Source/NexusForever.Shared/GameTable/Model/ClientSideInteractionEntry.cs
+++ b/Source/NexusForever.Shared/GameTable/Model/ClientSideInteractionEntry.cs
@@ -12,20 +12,12 @@ namespace NexusForever.Shared.GameTable.Model
         public uint Flags;
         public uint TapTime0;
         public uint TapTime1;
-        public uint VisualEffectId0;
-        public uint VisualEffectId1;
-        public uint VisualEffectId2;
-        public uint VisualEffectId3;
-        public uint VisualEffectIdTarget00;
-        public uint VisualEffectIdTarget01;
-        public uint VisualEffectIdTarget02;
-        public uint VisualEffectIdTarget03;
-        public uint VisualEffectIdTarget04;
-        public uint VisualEffectIdCaster00;
-        public uint VisualEffectIdCaster01;
-        public uint VisualEffectIdCaster02;
-        public uint VisualEffectIdCaster03;
-        public uint VisualEffectIdCaster04;
+        [GameTableFieldArray(4u)]
+        public uint[] VisualEffectIds;
+        [GameTableFieldArray(5u)]
+        public uint[] VisualEffectIdsTarget;
+        [GameTableFieldArray(5u)]
+        public uint[] VisualEffectIdsCaster;
         public uint LocalizedTextIdContext;
     }
 }

--- a/Source/NexusForever.Shared/GameTable/Model/Creature2Entry.cs
+++ b/Source/NexusForever.Shared/GameTable/Model/Creature2Entry.cs
@@ -16,14 +16,10 @@ namespace NexusForever.Shared.GameTable.Model
         public uint Creature2OutfitGroupId;
         public uint PrerequisiteIdVisibility;
         public float ModelScale;
-        public uint Spell4IdActivate00;
-        public uint Spell4IdActivate01;
-        public uint Spell4IdActivate02;
-        public uint Spell4IdActivate03;
-        public uint PrerequisiteIdActivateSpell00;
-        public uint PrerequisiteIdActivateSpell01;
-        public uint PrerequisiteIdActivateSpell02;
-        public uint PrerequisiteIdActivateSpell03;
+        [GameTableFieldArray(4u)]
+        public uint[] Spell4IdActivate;
+        [GameTableFieldArray(4u)]
+        public uint[] PrerequisiteIdActivateSpells;
         public uint ActivateSpellCastTime;
         public float ActivateSpellMinRange;
         public float ActivateSpellMaxRange;

--- a/Source/NexusForever.Shared/Network/Message/GameMessageOpcode.cs
+++ b/Source/NexusForever.Shared/Network/Message/GameMessageOpcode.cs
@@ -10,6 +10,7 @@ namespace NexusForever.Shared.Network.Message
         ServerAuthEncrypted             = 0x0076,
         ServerLogoutUpdate              = 0x0092,
         ClientActivateUnitCast          = 0x0097, // not sure about the name - almost the same as 0x00B3, but also initiates 0x07FD
+        ClientActivateUnitInteraction   = 0x0098,
         ClientCastSpell                 = 0x009A,
         ServerChangeWorld               = 0x00AD,
         ServerAchievementInit           = 0x00AE,
@@ -65,6 +66,7 @@ namespace NexusForever.Shared.Network.Message
         ServerAbilityPoints             = 0x0169,
         ClientNonSpellActionSetChanges  = 0x016A,
         ServerShowActionBar             = 0x016C,
+        ServerCharacterBindpoint        = 0x016D,
         ClientInnateChange              = 0x016F,
         ClientChangeActiveActionSet     = 0x0174,
         ServerChangeActiveActionSet     = 0x0175,
@@ -236,12 +238,13 @@ namespace NexusForever.Shared.Network.Message
         Server07FA                      = 0x07FA, // spell related
         Server07FB                      = 0x07FB, // spell miss info?
         ServerSpellCastResult           = 0x07FC,
-        Server07FD                      = 0x07FD, // spell related
+        ServerSpellStartClientInteraction = 0x07FD, // spell related
         ServerSpellFinish               = 0x07FE,
         ServerSpellStart                = 0x07FF,
         ClientSpellStopCast             = 0x0801,
         ClientCancelEffect              = 0x0802,
         ServerCooldown                  = 0x0804,
+        ClientInteractionResult         = 0x0805,
         Server0811                      = 0x0811, // spell related: broadcast parts of 0x07FF?
         ServerSpellBuffRemove           = 0x0813,
         Server0814                      = 0x0814, // spell related

--- a/Source/NexusForever.WorldServer/Game/CSI/ClientSideInteraction.cs
+++ b/Source/NexusForever.WorldServer/Game/CSI/ClientSideInteraction.cs
@@ -1,0 +1,65 @@
+﻿using NexusForever.Shared.GameTable;
+using NexusForever.Shared.GameTable.Model;
+using NexusForever.WorldServer.Game.CSI.Static;
+using NexusForever.WorldServer.Game.Entity;
+using NexusForever.WorldServer.Game.Spell;
+using NexusForever.WorldServer.Network.Message.Model;
+using NLog;
+using System;
+using System.Linq;
+
+namespace NexusForever.WorldServer.Game.CSI
+{
+    public class ClientSideInteraction
+    {
+        private static readonly ILogger log = LogManager.GetCurrentClassLogger();
+
+        public uint ClientUniqueId { get; private set; } = 0;
+        public WorldEntity ActivateUnit { get; private set; } = null;
+        public CSIType CsiType { get; private set; } = CSIType.Interaction;
+        public ClientSideInteractionEntry Entry { get; private set; }
+
+        private Player Owner { get; set; } = null;
+
+        public ClientSideInteraction(Player owner, WorldEntity activateUnit, uint clientUniqueId)
+        {
+            Owner = owner;
+            ActivateUnit = activateUnit;
+            ClientUniqueId = clientUniqueId;
+        }
+
+        public void TriggerReady()
+        {
+            // This should be used for things like responding after a timer, or ensuring an event happens during an interaction's cast time.
+        }
+
+        public void TriggerFail()
+        {
+            ActivateUnit.OnActivateFail(Owner);
+        }
+
+        public void TriggerSuccess()
+        {
+            ActivateUnit.OnActivateSuccess(Owner);
+        }
+
+        public void SetClientSideInteractionEntry(ClientSideInteractionEntry clientSideInteractionEntry)
+        {
+            if (clientSideInteractionEntry == null)
+            {
+                CsiType = CSIType.Interaction;
+                return;
+            }
+
+            Entry = clientSideInteractionEntry;
+            CsiType = (CSIType)Entry.InteractionType;
+        }
+
+        public void HandleSuccess(SpellParameters spellCast)
+        {
+            // Placeholder Method in case we need to do things prior to triggering
+
+            TriggerSuccess();
+        }
+    }
+}

--- a/Source/NexusForever.WorldServer/Game/CSI/Static/CSIType.cs
+++ b/Source/NexusForever.WorldServer/Game/CSI/Static/CSIType.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NexusForever.WorldServer.Game.CSI.Static
+{
+    public enum CSIType
+    {
+        Interaction         = -1,
+        PressAndHold        = 0,
+        RapidTapping        = 1,
+        PrecisionTapping    = 2,
+        Metronome           = 3,
+        YesNo               = 4,
+        Memory              = 5,
+        Keypad              = 6,
+        RapidTappingInverse = 7,
+    }
+}

--- a/Source/NexusForever.WorldServer/Game/Entity/BindPoint.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/BindPoint.cs
@@ -1,0 +1,99 @@
+using NexusForever.Shared.GameTable;
+using NexusForever.Shared.GameTable.Model;
+using NexusForever.WorldServer.Game.CSI;
+using NexusForever.WorldServer.Game.Entity.Network;
+using NexusForever.WorldServer.Game.Entity.Network.Model;
+using NexusForever.WorldServer.Game.Entity.Static;
+using NexusForever.WorldServer.Game.Spell;
+using NexusForever.WorldServer.Network.Message.Model;
+using NLog;
+using System.Linq;
+using NexusForever.Database.World.Model;
+
+namespace NexusForever.WorldServer.Game.Entity
+{
+    [DatabaseEntity(EntityType.BindPoint)]
+    public class BindPoint : UnitEntity
+    {
+        private static readonly Logger log = LogManager.GetCurrentClassLogger();
+
+        public Creature2Entry Entry { get; private set; } = null;
+        public BindPointEntry BindPointEntry { get; private set; } = null;
+
+        public BindPoint()
+            : base(EntityType.BindPoint)
+        {
+        }
+
+        public override void Initialise(EntityModel model)
+        {
+            base.Initialise(model);
+            CreatureId          = model.Creature;
+            Entry               = GameTableManager.Instance.Creature2.GetEntry(CreatureId);
+            if (Entry.BindPointId != 0u)
+                BindPointEntry      = GameTableManager.Instance.BindPoint.GetEntry(Entry.BindPointId);
+        }
+
+        protected override IEntityModel BuildEntityModel()
+        {
+            return new BindpointEntityModel
+            {
+                CreatureId      = CreatureId
+            };
+        }
+
+        public override ServerEntityCreate BuildCreatePacket()
+        {
+            ServerEntityCreate bindPointEntity = base.BuildCreatePacket();
+
+            return bindPointEntity;
+        }
+
+        public override void OnActivateFail(Player activator)
+        {
+            base.OnActivateFail(activator);
+        }
+
+        public override void OnActivateSuccess(Player activator)
+        {
+            if (BindPointEntry == null)
+                log.Error($"BindPoint not found: {Entry.BindPointId}");
+            else
+            {
+                // Set bindpoint
+                activator.BindPoint = (ushort)BindPointEntry.Id;
+
+                // Send ServerCharacterBindpoint
+                activator.Session.EnqueueMessageEncrypted(new ServerCharacterBindpoint
+                {
+                    BindpointId = (ushort)Entry.BindPointId
+                });
+
+                // Grant Recall spell: "8568, Teleporting to Eldan Stone - Recall Shard - Hearthstone - Global - Tier 1"
+                if (activator.SpellManager.GetSpell(7575) == null)
+                    activator.SpellManager.AddSpell(7575);
+            }
+
+            base.OnActivateSuccess(activator);
+        }
+
+        public override void OnActivateCast(Player activator, uint interactionId)
+        {
+            if (BindPointEntry == null)
+                log.Error($"BindPoint not found: {Entry.BindPointId}");
+            else
+            {
+                // TODO: Confirm that this bindpoint can be used by the Player's faction
+
+                // TODO: cast "8566, Bind to Transmatter Terminal (Previously Eldan Stone) - DO NOT DELETE - SYSTEM SPELL - Tier 1" by 0x07FD
+                // This might also be GameFormula Entry #472?
+                SpellParameters parameters = new SpellParameters
+                {
+                    PrimaryTargetId = Guid,
+                    ClientSideInteraction = new ClientSideInteraction(activator, this, interactionId)
+                };
+                activator.CastSpell(8566, parameters);
+            }
+        }
+    }
+}

--- a/Source/NexusForever.WorldServer/Game/Entity/CollectibleUnit.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/CollectibleUnit.cs
@@ -1,0 +1,49 @@
+using NexusForever.Database.World.Model;
+using NexusForever.Shared.GameTable;
+using NexusForever.Shared.GameTable.Model;
+using NexusForever.WorldServer.Game.CSI;
+using NexusForever.WorldServer.Game.Entity.Network;
+using NexusForever.WorldServer.Game.Entity.Network.Model;
+using NexusForever.WorldServer.Game.Entity.Static;
+using NexusForever.WorldServer.Game.Quest.Static;
+using NexusForever.WorldServer.Game.Spell;
+
+namespace NexusForever.WorldServer.Game.Entity
+{
+    [DatabaseEntity(EntityType.CollectableUnit)]
+    public class CollectableUnit : UnitEntity
+    {
+        public byte QuestChecklistIdx { get; private set; }
+
+        public CollectableUnit()
+            : base(EntityType.CollectableUnit)
+        {
+        }
+
+        public override void Initialise(EntityModel model)
+        {
+            base.Initialise(model);
+            QuestChecklistIdx = model.QuestChecklistIdx;
+        }
+
+        protected override IEntityModel BuildEntityModel()
+        {
+            return new SimpleEntityModel
+            {
+                CreatureId        = CreatureId,
+                QuestChecklistIdx = QuestChecklistIdx
+            };
+        }
+
+        public override void OnInteract(Player activator)
+        {
+
+        }
+
+        public override void OnActivateSuccess(Player activator)
+        {
+            activator.QuestManager.ObjectiveUpdate(QuestObjectiveType.ActivateEntity, CreatureId, 1u);
+            activator.QuestManager.ObjectiveUpdate(QuestObjectiveType.SucceedCSI, CreatureId, 1u);
+        }
+    }
+}

--- a/Source/NexusForever.WorldServer/Game/Entity/Location.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/Location.cs
@@ -1,0 +1,22 @@
+﻿using NexusForever.Shared.GameTable.Model;
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using System.Text;
+
+namespace NexusForever.WorldServer.Game.Entity
+{
+    public class Location
+    {
+        public WorldEntry World { get; private set; }
+        public Vector3 Position { get; private set; }
+        public Vector3 Rotation { get; private set; }
+
+        public Location(WorldEntry world, Vector3 position, Vector3 rotation)
+        {
+            World = world;
+            Position = position;
+            Rotation = rotation;
+        }
+    }
+}

--- a/Source/NexusForever.WorldServer/Game/Entity/Mailbox.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/Mailbox.cs
@@ -25,6 +25,7 @@ namespace NexusForever.WorldServer.Game.Entity
         {
             ServerEntityCreate entityCreate = base.BuildCreatePacket();
             entityCreate.CreateFlags = 0;
+
             return entityCreate;
         }
     }

--- a/Source/NexusForever.WorldServer/Game/Entity/NonPlayer.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/NonPlayer.cs
@@ -1,9 +1,12 @@
 ﻿using NexusForever.Database.World.Model;
 using NexusForever.Shared.GameTable;
 using NexusForever.Shared.GameTable.Model;
+using NexusForever.WorldServer.Game.CSI;
 using NexusForever.WorldServer.Game.Entity.Network;
 using NexusForever.WorldServer.Game.Entity.Network.Model;
 using NexusForever.WorldServer.Game.Entity.Static;
+using NexusForever.WorldServer.Game.Quest.Static;
+using NexusForever.WorldServer.Game.Spell;
 
 namespace NexusForever.WorldServer.Game.Entity
 {
@@ -37,6 +40,12 @@ namespace NexusForever.WorldServer.Game.Entity
                 CreatureId = CreatureId,
                 QuestChecklistIdx = 0
             };
+        }
+
+        public override void OnActivateSuccess(Player activator)
+        {
+            activator.QuestManager.ObjectiveUpdate(QuestObjectiveType.ActivateEntity, CreatureId, 1u);
+            activator.QuestManager.ObjectiveUpdate(QuestObjectiveType.SucceedCSI, CreatureId, 1u);
         }
 
         private void CalculateProperties()

--- a/Source/NexusForever.WorldServer/Game/Entity/Player.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/Player.cs
@@ -92,6 +92,17 @@ namespace NexusForever.WorldServer.Game.Entity
             }
         }
         private byte innateIndex;
+        
+        public ushort BindPoint
+        {
+            get => bindPoint;
+            set
+            {
+                bindPoint = value;
+                saveMask |= PlayerSaveMask.BindPoint;
+            }
+        }
+        private ushort bindPoint;
 
         public DateTime CreateTime { get; }
         public double TimePlayedTotal { get; private set; }
@@ -178,6 +189,7 @@ namespace NexusForever.WorldServer.Game.Entity
             Faction1        = (Faction)model.FactionId;
             Faction2        = (Faction)model.FactionId;
             innateIndex     = model.InnateIndex;
+            BindPoint       = model.BindPoint;
 
             CreateTime      = model.CreateTime;
             TimePlayedTotal = model.TimePlayedTotal;
@@ -362,6 +374,12 @@ namespace NexusForever.WorldServer.Game.Entity
                     entity.Property(p => p.InnateIndex).IsModified = true;
                 }
 
+                if ((saveMask & PlayerSaveMask.BindPoint) != 0)
+                {
+                    model.BindPoint = BindPoint;
+                    entity.Property(p => p.BindPoint).IsModified = true;
+                }
+
                 saveMask = PlayerSaveMask.None;
             }
 
@@ -540,6 +558,7 @@ namespace NexusForever.WorldServer.Game.Entity
                         })
                         .ToList()
                 },
+                BindPoint             = BindPoint,
                 ActiveCostumeIndex    = CostumeIndex,
                 InputKeySet           = (uint)InputKeySet,
                 CharacterEntitlements = Session.EntitlementManager.GetCharacterEntitlements()

--- a/Source/NexusForever.WorldServer/Game/Entity/Simple.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/Simple.cs
@@ -1,9 +1,12 @@
 using NexusForever.Database.World.Model;
 using NexusForever.Shared.GameTable;
 using NexusForever.Shared.GameTable.Model;
+using NexusForever.WorldServer.Game.CSI;
 using NexusForever.WorldServer.Game.Entity.Network;
 using NexusForever.WorldServer.Game.Entity.Network.Model;
 using NexusForever.WorldServer.Game.Entity.Static;
+using NexusForever.WorldServer.Game.Quest.Static;
+using NexusForever.WorldServer.Game.Spell;
 
 namespace NexusForever.WorldServer.Game.Entity
 {
@@ -32,14 +35,14 @@ namespace NexusForever.WorldServer.Game.Entity
             };
         }
 
-        public override void OnActivate(Player activator)
+        public override void OnInteract(Player activator)
         {
             Creature2Entry entry = GameTableManager.Instance.Creature2.GetEntry(CreatureId);
             if (entry.DatacubeId != 0u)
                 activator.DatacubeManager.AddDatacube((ushort)entry.DatacubeId, int.MaxValue);
         }
 
-        public override void OnActivateCast(Player activator)
+        public override void OnActivateSuccess(Player activator)
         {
             uint progress = (uint)(1 << QuestChecklistIdx);
 
@@ -68,7 +71,8 @@ namespace NexusForever.WorldServer.Game.Entity
                 }
             }
 
-            //TODO: cast "116,Generic Quest Spell - Activating - Activate - Tier 1" by 0x07FD
+            activator.QuestManager.ObjectiveUpdate(QuestObjectiveType.ActivateEntity, CreatureId, 1u);
+            activator.QuestManager.ObjectiveUpdate(QuestObjectiveType.SucceedCSI, CreatureId, 1u);
         }
     }
 }

--- a/Source/NexusForever.WorldServer/Game/Entity/Static/PlayerSaveMask.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/Static/PlayerSaveMask.cs
@@ -14,6 +14,7 @@ namespace NexusForever.WorldServer.Game.Entity.Static
         Costume     = 0x0004,
         InputKeySet = 0x0008,
         Xp          = 0x0010,
-        Innate      = 0x0080
+        Innate      = 0x0080,
+        BindPoint   = 0x0200
     }
 }

--- a/Source/NexusForever.WorldServer/Game/Entity/UnitEntity.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/UnitEntity.cs
@@ -58,6 +58,9 @@ namespace NexusForever.WorldServer.Game.Entity
             if (spellBaseInfo == null)
                 throw new ArgumentOutOfRangeException();
 
+            if (parameters.ClientSideInteraction != null)
+                parameters.ClientSideInteraction.SetClientSideInteractionEntry(GameTableManager.Instance.ClientSideInteraction.GetEntry(spellBaseInfo.Entry.ClientSideInteractionId));
+
             SpellInfo spellInfo = spellBaseInfo.GetSpellInfo(tier);
             if (spellInfo == null)
                 throw new ArgumentOutOfRangeException();
@@ -117,6 +120,16 @@ namespace NexusForever.WorldServer.Game.Entity
         {
             Spell.Spell spell = pendingSpells.SingleOrDefault(s => s.CastingId == castingId);
             spell?.CancelCast(CastResult.SpellCancelled);
+        }
+
+        /// <summary>
+        /// Returns a pending <see cref="Spell.Spell"/> based on its casting id
+        /// </summary>
+        /// <param name="castingId">Casting ID of the spell to return</param>
+        public Spell.Spell GetPendingSpell(uint castingId)
+        {
+            Spell.Spell spell = pendingSpells.SingleOrDefault(s => s.CastingId == castingId);
+            return spell ?? null;
         }
     }
 }

--- a/Source/NexusForever.WorldServer/Game/Entity/WorldEntity.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/WorldEntity.cs
@@ -3,13 +3,18 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 using NexusForever.Database.World.Model;
+using NexusForever.Shared.GameTable;
+using NexusForever.Shared.GameTable.Model;
 using NexusForever.Shared.Network.Message;
+using NexusForever.WorldServer.Game.CSI;
 using NexusForever.WorldServer.Game.Entity.Movement;
 using NexusForever.WorldServer.Game.Entity.Network;
 using NexusForever.WorldServer.Game.Entity.Static;
 using NexusForever.WorldServer.Game.Map;
+using NexusForever.WorldServer.Game.Prerequisite;
 using NexusForever.WorldServer.Game.Reputation;
 using NexusForever.WorldServer.Game.Reputation.Static;
+using NexusForever.WorldServer.Game.Spell;
 using NexusForever.WorldServer.Network.Message.Model;
 using NexusForever.WorldServer.Network.Message.Model.Shared;
 
@@ -163,7 +168,7 @@ namespace NexusForever.WorldServer.Game.Entity
         /// <summary>
         /// Invoked when <see cref="WorldEntity"/> is activated.
         /// </summary>
-        public virtual void OnActivate(Player activator)
+        public virtual void OnInteract(Player activator)
         {
             // deliberately empty
         }
@@ -171,7 +176,47 @@ namespace NexusForever.WorldServer.Game.Entity
         /// <summary>
         /// Invoked when <see cref="WorldEntity"/> is cast activated.
         /// </summary>
-        public virtual void OnActivateCast(Player activator)
+        public virtual void OnActivateCast(Player activator, uint interactionId)
+        {
+            Creature2Entry entry = GameTableManager.Instance.Creature2.GetEntry(CreatureId);
+
+            uint spell4Id = 0;
+            for (int i = 0; i < entry.Spell4IdActivate.Length; i++)
+            {
+                if (spell4Id > 0u || i == entry.Spell4IdActivate.Length)
+                    break;
+
+                if (entry.PrerequisiteIdActivateSpells[i] > 0 && PrerequisiteManager.Instance.Meets(activator, entry.PrerequisiteIdActivateSpells[i]))
+                        spell4Id = entry.Spell4IdActivate[i];
+
+                if (spell4Id == 0u && entry.Spell4IdActivate[i] == 0u && i > 0)
+                    spell4Id = entry.Spell4IdActivate[i - 1];
+            }
+
+            if (spell4Id == 0)
+                throw new InvalidOperationException($"Spell4Id should not be 0. Unhandled Creature ActivateCast {CreatureId}");
+
+            SpellParameters parameters = new SpellParameters
+            {
+                PrimaryTargetId       = Guid,
+                ClientSideInteraction = new ClientSideInteraction(activator, this, interactionId),
+                CastTimeOverride      = (int)entry.ActivateSpellCastTime,
+            };
+            activator.CastSpell(spell4Id, parameters);
+        }
+
+        /// <summary>
+        /// Invoked when <see cref="WorldEntity"/>'s activate succeeds.
+        /// </summary>
+        public virtual void OnActivateSuccess(Player activator)
+        {
+            // deliberately empty
+        }
+
+        /// <summary>
+        /// Invoked when <see cref="WorldEntity"/>'s activation fails.
+        /// </summary>
+        public virtual void OnActivateFail(Player activator)
         {
             // deliberately empty
         }

--- a/Source/NexusForever.WorldServer/Game/Spell/SpellEffectHandler.cs
+++ b/Source/NexusForever.WorldServer/Game/Spell/SpellEffectHandler.cs
@@ -1,8 +1,10 @@
 using System.Linq;
 using System.Numerics;
 using NexusForever.Shared;
+using NexusForever.Shared.Game.Events;
 using NexusForever.Shared.GameTable;
 using NexusForever.Shared.GameTable.Model;
+using NexusForever.Shared.Network;
 using NexusForever.WorldServer.Game.Entity;
 using NexusForever.WorldServer.Game.Entity.Static;
 using NexusForever.WorldServer.Game.Spell.Static;
@@ -24,11 +26,12 @@ namespace NexusForever.WorldServer.Game.Spell
         [SpellEffectHandler(SpellEffectType.Proxy)]
         private void HandleEffectProxy(UnitEntity target, SpellTargetInfo.SpellTargetEffectInfo info)
         {
-            target.CastSpell(info.Entry.DataBits00, new SpellParameters
+            caster.CastSpell(info.Entry.DataBits00, new SpellParameters
             {
                 ParentSpellInfo        = parameters.SpellInfo,
                 RootSpellInfo          = parameters.RootSpellInfo,
-                UserInitiatedSpellCast = false
+                UserInitiatedSpellCast = false,
+                PrimaryTargetId        = target.Guid
             });
         }
 
@@ -81,13 +84,35 @@ namespace NexusForever.WorldServer.Game.Spell
         [SpellEffectHandler(SpellEffectType.Teleport)]
         private void HandleEffectTeleport(UnitEntity target, SpellTargetInfo.SpellTargetEffectInfo info)
         {
+            // Handle NPC teleporting?
+
+            if (!(target is Player player))
+                return;
+
+            // Assuming that this is Recall to Transmat
+            if (info.Entry.DataBits00 == 0)
+            {
+                if (player.BindPoint == 0) // Must have bindpoint set
+                    return;
+
+                Location bindPointLocation = AssetManager.Instance.GetBindPoint(player.BindPoint);
+                Vector3 offset = new Vector3(2f, 1.5f, 2f); // TODO: Should use new Vector3(0f, 1.5f, 0f); when map props are being used
+
+                if (player.CanTeleport()) {
+                    player.Rotation = bindPointLocation.Rotation;
+                    player.TeleportTo(bindPointLocation.World, Vector3.Add(bindPointLocation.Position, offset));
+                }
+                return;
+            }
+
             WorldLocation2Entry locationEntry = GameTableManager.Instance.WorldLocation2.GetEntry(info.Entry.DataBits00);
             if (locationEntry == null)
                 return;
 
-            if (target is Player player)
-                if (player.CanTeleport())
-                    player.TeleportTo((ushort)locationEntry.WorldId, locationEntry.Position0, locationEntry.Position1, locationEntry.Position2);
+            if (player.CanTeleport()) {
+                player.Rotation = new Quaternion(locationEntry.Facing0, locationEntry.Facing1, locationEntry.Facing2, locationEntry.Facing3).ToEulerDegrees();
+                player.TeleportTo((ushort)locationEntry.WorldId, locationEntry.Position0, locationEntry.Position1, locationEntry.Position2);
+            }
         }
 
         [SpellEffectHandler(SpellEffectType.FullScreenEffect)]
@@ -192,6 +217,12 @@ namespace NexusForever.WorldServer.Game.Spell
                 return;
 
             player.TitleManager.AddTitle((ushort)info.Entry.DataBits00);
+        }
+
+        [SpellEffectHandler(SpellEffectType.Activate)]
+        private void HandleEffectActivate(UnitEntity target, SpellTargetInfo.SpellTargetEffectInfo info)
+        {
+            parameters.ClientSideInteraction?.HandleSuccess(parameters);
         }
     }
 }

--- a/Source/NexusForever.WorldServer/Game/Spell/SpellParameters.cs
+++ b/Source/NexusForever.WorldServer/Game/Spell/SpellParameters.cs
@@ -1,4 +1,6 @@
-﻿using NexusForever.WorldServer.Game.Entity;
+﻿using NexusForever.WorldServer.Game.CSI;
+using NexusForever.WorldServer.Game.Entity;
+using System;
 
 namespace NexusForever.WorldServer.Game.Spell
 {
@@ -12,5 +14,8 @@ namespace NexusForever.WorldServer.Game.Spell
         public uint PrimaryTargetId { get; set; }
         public Position Position { get; set; }
         public ushort TaxiNode { get; set; }
+        public ClientSideInteraction ClientSideInteraction { get; set; }
+        public Action<SpellParameters> CompleteAction { get; set; }
+        public int CastTimeOverride { get; set; } = -1;
     }
 }

--- a/Source/NexusForever.WorldServer/Game/Spell/Static/CastMethod.cs
+++ b/Source/NexusForever.WorldServer/Game/Spell/Static/CastMethod.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NexusForever.WorldServer.Game.Spell.Static
+{
+    public enum CastMethod
+    {
+        Normal                  = 0,
+        Channeled               = 1,
+        PressHold               = 2,
+        ChanneledField          = 3,
+        UNUSED04                = 4,
+        ClientSideInteraction   = 5,
+        RapidTap                = 6,
+        ChargeRelease           = 7,
+        Multiphase              = 8,
+        Transactional           = 9,
+        Aura                    = 10
+    }
+}

--- a/Source/NexusForever.WorldServer/Game/Spell/Static/SpellEffectTargetFlags.cs
+++ b/Source/NexusForever.WorldServer/Game/Spell/Static/SpellEffectTargetFlags.cs
@@ -7,7 +7,7 @@ namespace NexusForever.WorldServer.Game.Spell.Static
     {
         None      = 0x00,
         Caster    = 0x01,
-        Unknown02 = 0x02,
+        Target    = 0x02,
         Telegraph = 0x04,
         Unknown08 = 0x08
     }

--- a/Source/NexusForever.WorldServer/Network/Message/Handler/EntityHandler.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Handler/EntityHandler.cs
@@ -4,12 +4,14 @@ using NexusForever.Shared.Network.Message;
 using NexusForever.WorldServer.Game.Entity;
 using NexusForever.WorldServer.Game.Entity.Network;
 using NexusForever.WorldServer.Game.Entity.Network.Command;
+using NexusForever.WorldServer.Game.Spell;
 using NexusForever.WorldServer.Network.Message.Model;
 using NexusForever.Shared.GameTable;
 using NexusForever.Shared.GameTable.Model;
 using NexusForever.WorldServer.Game.Quest.Static;
 using NexusForever.WorldServer.Game;
 using NLog;
+using System;
 
 namespace NexusForever.WorldServer.Network.Message.Handler
 {
@@ -60,7 +62,7 @@ namespace NexusForever.WorldServer.Network.Message.Handler
 
             // TODO: sanity check for range etc.
 
-            entity.OnActivate(session.Player);
+            entity.OnInteract(session.Player);
         }
 
         [MessageHandler(GameMessageOpcode.ClientActivateUnitCast)]
@@ -76,7 +78,7 @@ namespace NexusForever.WorldServer.Network.Message.Handler
             foreach (uint targetGroupId in AssetManager.Instance.GetTargetGroupsForCreatureId(entity.CreatureId) ?? Enumerable.Empty<uint>())
                 session.Player.QuestManager.ObjectiveUpdate(QuestObjectiveType.ActivateTargetGroup, targetGroupId, 1u); // Updates the objective, but seems to disable all the other targets. TODO: Investigate
             
-            entity.OnActivateCast(session.Player);
+            entity.OnActivateCast(session.Player, unit.ClientUniqueId);
         }
 
         [MessageHandler(GameMessageOpcode.ClientEntityInteract)]
@@ -152,6 +154,41 @@ namespace NexusForever.WorldServer.Network.Message.Handler
                 throw new InvalidPacketValueException();
 
             session.Player.Sit(chair);
+        }
+        
+        [MessageHandler(GameMessageOpcode.ClientActivateUnitInteraction)]
+        public static void HandleActivateUnitDeferred(WorldSession session, ClientActivateUnitInteraction request)
+        {
+            WorldEntity entity = session.Player.GetVisible<WorldEntity>(request.ActivateUnitId);
+            if (entity == null)
+                throw new InvalidPacketValueException();
+
+            entity.OnActivateCast(session.Player, request.ClientUniqueId);
+        }
+
+        [MessageHandler(GameMessageOpcode.ClientInteractionResult)]
+        public static void HandleSpellDeferredResult(WorldSession session, ClientSpellInteractionResult result)
+        {
+            log.Info($"{result.CastingId}, {result.Result}, {result.Validation}");
+            Spell spell = session.Player.GetPendingSpell(result.CastingId);
+            if (spell == null)
+                throw new ArgumentNullException($"Spell cast {result.CastingId} not found.");
+
+            if (!spell.IsClientSideInteraction)
+                throw new ArgumentNullException($"Spell missing a ClientSideInteraction.");
+
+            switch (result.Result)
+            {
+                case 0:
+                    spell.FailClientInteraction();
+                    break;
+                case 1:
+                    spell.SucceedClientInteraction();
+                    break;
+                case 2:
+                    spell.CancelCast(Game.Spell.Static.CastResult.ClientSideInteractionFail);
+                    break;
+            }
         }
     }
 }

--- a/Source/NexusForever.WorldServer/Network/Message/Model/ClientActivateUnitInteraction.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Model/ClientActivateUnitInteraction.cs
@@ -1,0 +1,18 @@
+using NexusForever.Shared.Network;
+using NexusForever.Shared.Network.Message;
+
+namespace NexusForever.WorldServer.Network.Message.Model
+{
+    [Message(GameMessageOpcode.ClientActivateUnitInteraction)]
+    public class ClientActivateUnitInteraction : IReadable
+    {
+        public uint ClientUniqueId { get; private set; } // first value of 0x7FD response, probably global increment
+        public uint ActivateUnitId { get; private set; }
+
+        public void Read(GamePacketReader reader)
+        {
+            ClientUniqueId  = reader.ReadUInt();
+            ActivateUnitId  = reader.ReadUInt();
+        }
+    }
+}

--- a/Source/NexusForever.WorldServer/Network/Message/Model/ClientSpellInteractionResult.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Model/ClientSpellInteractionResult.cs
@@ -1,0 +1,22 @@
+﻿using NexusForever.Shared.Network;
+using NexusForever.Shared.Network.Message;
+using NexusForever.WorldServer.Game.Social;
+
+
+namespace NexusForever.WorldServer.Network.Message.Model
+{
+    [Message(GameMessageOpcode.ClientInteractionResult)]
+    public class ClientSpellInteractionResult : IReadable
+    {
+        public uint CastingId { get; private set; }
+        public byte Result { get; private set; } // 3u
+        public uint Validation { get; private set; }
+
+        public void Read(GamePacketReader reader)
+        {
+            CastingId = reader.ReadUInt();
+            Result = reader.ReadByte(3u);
+            Validation = reader.ReadUInt();
+        }
+    }
+}

--- a/Source/NexusForever.WorldServer/Network/Message/Model/ServerCharacterBindpoint.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Model/ServerCharacterBindpoint.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using NexusForever.Shared.Network;
+using NexusForever.Shared.Network.Message;
+using NexusForever.WorldServer.Game.Entity.Static;
+
+namespace NexusForever.WorldServer.Network.Message.Model
+{
+    [Message(GameMessageOpcode.ServerCharacterBindpoint)]
+    public class ServerCharacterBindpoint : IWritable
+    {
+        public ushort BindpointId { get; set; }
+
+        public void Write(GamePacketWriter writer)
+        {
+            writer.Write(BindpointId);
+        }
+    }
+}

--- a/Source/NexusForever.WorldServer/Network/Message/Model/ServerPlayerCreate.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Model/ServerPlayerCreate.cs
@@ -77,7 +77,7 @@ namespace NexusForever.WorldServer.Network.Message.Model
         public Faction FactionData { get; set; }
         public List<Pet> Pets { get; } = new List<Pet>();
         public uint InputKeySet { get; set; }
-        public ushort UnknownBC { get; set; }
+        public ushort BindPoint { get; set; }
         public int ActiveCostumeIndex { get; set; }
         public uint UnknownC4 { get; set; }
         public uint UnknownC8 { get; set; }
@@ -111,7 +111,7 @@ namespace NexusForever.WorldServer.Network.Message.Model
             Pets.ForEach(p => p.Write(writer));
 
             writer.Write(InputKeySet);
-            writer.Write(UnknownBC);
+            writer.Write(BindPoint);
             writer.Write(ActiveCostumeIndex);
             writer.Write(UnknownC4);
             writer.Write(UnknownC8);

--- a/Source/NexusForever.WorldServer/Network/Message/Model/ServerSpellStartClientInteraction.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Model/ServerSpellStartClientInteraction.cs
@@ -6,25 +6,26 @@ using NexusForever.WorldServer.Network.Message.Model.Shared;
 
 namespace NexusForever.WorldServer.Network.Message.Model
 {
-    [Message(GameMessageOpcode.Server07FD)]
-    public class Server07FD : IWritable
+    // Used by CastMethod: 5
+    [Message(GameMessageOpcode.ServerSpellStartClientInteraction)]
+    public class ServerSpellStartClientInteraction : IWritable
     {
-        public uint Time { get; set; }
+        public uint ClientUniqueId { get; set; }
         public uint CastingId { get; set; }
         public uint CasterId { get; set; }
         public Position Position { get; set; } = new Position();
-        public uint Unknown16 { get; set; }
+        public uint Yaw { get; set; }
 
         public List<InitialPosition> InitialPositionData { get; set; } = new List<InitialPosition>();
         public List<TelegraphPosition> TelegraphPositionData { get; set; } = new List<TelegraphPosition>();
 
         public void Write(GamePacketWriter writer)
         {
-            writer.Write(Time);
+            writer.Write(ClientUniqueId);
             writer.Write(CastingId);
             writer.Write(CasterId);
             Position.Write(writer);
-            writer.Write(Unknown16);
+            writer.Write(Yaw);
 
             writer.Write(InitialPositionData.Count, 8u);
             InitialPositionData.ForEach(u => u.Write(writer));


### PR DESCRIPTION
Contributes towards #306 

**Features**
- Binds players to any Transmat location
- Teaches the necessary Recall spell on bind, if the player does not know it
- Bind locations are saved to the database per player
- Client Interaction Events have basic support, allowing for things like the Minigames where you match colours, or the "tap quickly/slowly or at specific times", to be supported.
   - Validation of these events is currently not implemented. We rely on the Client as the source of truth which is not ideal.
- Journal / Key cast times have been implemented. In fact, any Simple entity that has an interaction event that requires a cast time of some sort should fire the spell cast now.
   - Note: This does not mean every interaction "works", just that it will cast the associated spell.

**Findings**
- "Activate" spell effect is probably how Carbine tied spells to scripts on the server. Whenever I see Activate, there's never any data associated with it in the table, suggesting that the server stored this piece.
- "ActorPropId" entity property forces that entity to assume the map prop's location & model, and toggles the model's state/effects when the entity is told to do something.
   - For a proof of concept, go to Tremor Ridge, Algoroc and check the Transmat there. This is setup exactly as Live was (based on the sniffed data I have) and you can see, between the `BindPoint.cs` and in-game visuals, how things work.