### PR TITLE
Core: Custom GameTable structures proof of concept - WIP

### DIFF
--- a/Source/NexusForever.Shared/GameTable/GameTableManager.cs
+++ b/Source/NexusForever.Shared/GameTable/GameTableManager.cs
@@ -804,5 +804,20 @@ namespace NexusForever.Shared.GameTable
                     throw new ArgumentOutOfRangeException();
             }
         }
+
+        public static ICustomGameTableStructure GetSpellEffectData(uint effectType)
+        {
+            switch (effectType)
+            {
+                case 8:
+                    return new SpellEffectDataDamage();
+                case 11:
+                    return new SpellEffectDataUnitPropertyModifier();
+                case 26:
+                    return new SpellEffectDataProxy();
+                default:
+                    return new SpellEffectDataDefault();
+            }
+        }
     }
 }

--- a/Source/NexusForever.Shared/GameTable/Model/Spell4EffectsEntry.cs
+++ b/Source/NexusForever.Shared/GameTable/Model/Spell4EffectsEntry.cs
@@ -1,3 +1,5 @@
+using NexusForever.Shared.GameTable.Static;
+
 namespace NexusForever.Shared.GameTable.Model
 {
     public class Spell4EffectsEntry
@@ -11,16 +13,8 @@ namespace NexusForever.Shared.GameTable.Model
         public uint TickTime;
         public uint DurationTime;
         public uint Flags;
-        public uint DataBits00;
-        public uint DataBits01;
-        public uint DataBits02;
-        public uint DataBits03;
-        public uint DataBits04;
-        public uint DataBits05;
-        public uint DataBits06;
-        public uint DataBits07;
-        public uint DataBits08;
-        public uint DataBits09;
+        [GameTableFieldArray(10)]
+        public ICustomGameTableStructure DataBits;
         public uint InnateCostPerTickType0;
         public uint InnateCostPerTickType1;
         public uint InnateCostPerTick0;

--- a/Source/NexusForever.Shared/GameTable/Model/SpellEffectDataDamage.cs
+++ b/Source/NexusForever.Shared/GameTable/Model/SpellEffectDataDamage.cs
@@ -1,0 +1,21 @@
+﻿using NexusForever.Shared.GameTable.Static;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NexusForever.Shared.GameTable.Model
+{
+    public class SpellEffectDataDamage : ICustomGameTableStructure
+    {
+        public float Amount;
+        public uint DataBits01;
+        public uint DataBits02;
+        public uint DataBits03;
+        public uint DataBits04;
+        public uint DataBits05;
+        public uint DataBits06;
+        public uint DataBits07;
+        public uint DataBits08;
+        public uint DataBits09;
+    }
+}

--- a/Source/NexusForever.Shared/GameTable/Model/SpellEffectDataDefault.cs
+++ b/Source/NexusForever.Shared/GameTable/Model/SpellEffectDataDefault.cs
@@ -1,0 +1,21 @@
+﻿using NexusForever.Shared.GameTable.Static;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NexusForever.Shared.GameTable.Model
+{
+    public class SpellEffectDataDefault : ICustomGameTableStructure
+    {
+        public uint DataBits00;
+        public uint DataBits01;
+        public uint DataBits02;
+        public uint DataBits03;
+        public uint DataBits04;
+        public uint DataBits05;
+        public uint DataBits06;
+        public uint DataBits07;
+        public uint DataBits08;
+        public uint DataBits09;
+    }
+}

--- a/Source/NexusForever.Shared/GameTable/Model/SpellEffectDataProxy.cs
+++ b/Source/NexusForever.Shared/GameTable/Model/SpellEffectDataProxy.cs
@@ -1,0 +1,21 @@
+﻿using NexusForever.Shared.GameTable.Static;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NexusForever.Shared.GameTable.Model
+{
+    public class SpellEffectDataProxy : ICustomGameTableStructure
+    {
+        public uint Spell4Id;
+        public uint DataBits01;
+        public uint DataBits02;
+        public float DataBits03;
+        public uint DataBits04;
+        public uint DataBits05;
+        public uint DataBits06;
+        public uint DataBits07;
+        public uint DataBits08;
+        public uint DataBits09;
+    }
+}

--- a/Source/NexusForever.Shared/GameTable/Model/SpellEffectDataUnitPropertyModifier.cs
+++ b/Source/NexusForever.Shared/GameTable/Model/SpellEffectDataUnitPropertyModifier.cs
@@ -1,0 +1,21 @@
+﻿using NexusForever.Shared.GameTable.Static;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NexusForever.Shared.GameTable.Model
+{
+    public class SpellEffectDataUnitPropertyModifier : ICustomGameTableStructure
+    {
+        public uint Property;
+        public uint Method;
+        public float BaseValue;
+        public float Modifier;
+        public uint DataBits04;
+        public uint DataBits05;
+        public uint DataBits06;
+        public uint DataBits07;
+        public uint DataBits08;
+        public uint DataBits09;
+    }
+}

--- a/Source/NexusForever.Shared/GameTable/Static/ICustomGameTableStructure.cs
+++ b/Source/NexusForever.Shared/GameTable/Static/ICustomGameTableStructure.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NexusForever.Shared.GameTable.Static
+{
+    public interface ICustomGameTableStructure
+    {
+    }
+}

--- a/Source/NexusForever.WorldServer/Game/Entity/UnitEntity.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/UnitEntity.cs
@@ -41,7 +41,8 @@ namespace NexusForever.WorldServer.Game.Entity
 
             Spell4Entry spell4Entry = GameTableManager.Spell4.GetEntry(spell4Id);
             if (spell4Entry == null)
-                throw new ArgumentOutOfRangeException();
+                return;
+                //throw new ArgumentOutOfRangeException("spell4Id", $"{spell4Id} not found in Spell4 Entries.");
 
             CastSpell(spell4Entry.Spell4BaseIdBaseSpell, (byte)spell4Entry.TierIndex, parameters);
         }

--- a/Source/NexusForever.WorldServer/Game/Spell/SpellEffectHandler.cs
+++ b/Source/NexusForever.WorldServer/Game/Spell/SpellEffectHandler.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Numerics;
 using NexusForever.Shared;
@@ -18,36 +19,74 @@ namespace NexusForever.WorldServer.Game.Spell
         private void HandleEffectDamage(UnitEntity target, SpellTargetInfo.SpellTargetEffectInfo info)
         {
             // TODO: calculate damage
-            info.AddDamage((DamageType)info.Entry.DamageType, 1337);
+            if(!(info.Entry.DataBits is SpellEffectDataDamage dataDamage))
+                throw new ArgumentException("info.Entry.DataBits is not of type SpellEffectDataDamage as expected");
+
+            log.Info($"Damage called: {dataDamage.Amount}");
+
+            info.AddDamage((DamageType)info.Entry.DamageType, (uint)Math.Round(info.Entry.ParameterValue01 * caster.Level));
         }
 
         [SpellEffectHandler(SpellEffectType.Proxy)]
         private void HandleEffectProxy(UnitEntity target, SpellTargetInfo.SpellTargetEffectInfo info)
         {
-            target.CastSpell(info.Entry.DataBits00, new SpellParameters
+            if (!(info.Entry.DataBits is SpellEffectDataProxy data))
+                throw new ArgumentException("info.Entry.DataBits is not of type SpellEffectDataProxy as expected");
+
+            log.Info($"[Proxy] Spell4Id: {data.Spell4Id}, DataBits03: {data.DataBits03}");
+
+            target.CastSpell(data.Spell4Id, new SpellParameters
             {
-                ParentSpellInfo        = parameters.SpellInfo,
-                RootSpellInfo          = parameters.RootSpellInfo,
+                ParentSpellInfo = parameters.SpellInfo,
+                RootSpellInfo = parameters.RootSpellInfo,
                 UserInitiatedSpellCast = false
             });
         }
 
-        [SpellEffectHandler(SpellEffectType.Disguise)]
-        private void HandleEffectDisguise(UnitEntity target, SpellTargetInfo.SpellTargetEffectInfo info)
+        [SpellEffectHandler(SpellEffectType.UnitPropertyModifier)]
+        private void HandleEffectPropertyModifier(UnitEntity target, SpellTargetInfo.SpellTargetEffectInfo info)
         {
             if (!(target is Player player))
                 return;
 
-            Creature2Entry creature2 = GameTableManager.Creature2.GetEntry(info.Entry.DataBits02);
-            if (creature2 == null)
-                return;
+            if (!(info.Entry.DataBits is SpellEffectDataUnitPropertyModifier data))
+                throw new ArgumentException("info.Entry.DataBits is not of type SpellEffectDataUnitPropertyModifier as expected");
 
-            Creature2DisplayGroupEntryEntry displayGroupEntry = GameTableManager.Creature2DisplayGroupEntry.Entries.FirstOrDefault(d => d.Creature2DisplayGroupId == creature2.Creature2DisplayGroupId);
-            if (displayGroupEntry == null)
-                return;
+            if (data.Method == 1) // Adjust value by percent
+                log.Info($"[UnitPropertyModifier] {(Property)data.Property} modification method {data.Method}. Modifying by {data.BaseValue * data.Modifier}");
 
-            player.SetDisplayInfo(displayGroupEntry.Creature2DisplayInfoId);
+            if (data.Method == 2) // Override current value (mainly used by debuffs, and NPC buffs)
+                log.Info($"[UnitPropertyModifier] {(Property)data.Property} modification method {data.Method}. Modifying to {data.BaseValue}");
+
+            if (data.Method == 3) // Adjust current value
+            {
+                if (data.Modifier > 0u)
+                    log.Info($"[UnitPropertyModifier] {(Property)data.Property} modification method {data.Method}. Modifying by {data.BaseValue * data.Modifier}");
+                else
+                    log.Info($"[UnitPropertyModifier] {(Property)data.Property} modification method {data.Method}. Modifying to {data.BaseValue}");
+            }
+
+            if (data.Method == 4) // Adjust current value per stack
+                log.Info($"[UnitPropertyModifier] {(Property)data.Property} modification method {data.Method}. Modifying by {data.BaseValue + data.Modifier}");
+
         }
+
+        //[SpellEffectHandler(SpellEffectType.Disguise)]
+        //private void HandleEffectDisguise(UnitEntity target, SpellTargetInfo.SpellTargetEffectInfo info)
+        //{
+        //    if (!(target is Player player))
+        //        return;
+
+        //    Creature2Entry creature2 = GameTableManager.Creature2.GetEntry(info.Entry.DataBits02);
+        //    if (creature2 == null)
+        //        return;
+
+        //    Creature2DisplayGroupEntryEntry displayGroupEntry = GameTableManager.Creature2DisplayGroupEntry.Entries.FirstOrDefault(d => d.Creature2DisplayGroupId == creature2.Creature2DisplayGroupId);
+        //    if (displayGroupEntry == null)
+        //        return;
+
+        //    player.SetDisplayInfo(displayGroupEntry.Creature2DisplayInfoId);
+        //}
 
         [SpellEffectHandler(SpellEffectType.SummonMount)]
         private void HandleEffectSummonMount(UnitEntity target, SpellTargetInfo.SpellTargetEffectInfo info)
@@ -59,7 +98,10 @@ namespace NexusForever.WorldServer.Game.Spell
             if (player.VehicleGuid != 0u)
                 return;
 
-            var mount = new Mount(player, parameters.SpellInfo.Entry.Id, info.Entry.DataBits00, info.Entry.DataBits01, info.Entry.DataBits04);
+            if (!(info.Entry.DataBits is SpellEffectDataDefault data))
+                throw new ArgumentException("info.Entry.DataBits is not of type SpellEffectDataDefault as expected");
+
+            var mount = new Mount(player, parameters.SpellInfo.Entry.Id, data.DataBits00, data.DataBits01, data.DataBits04);
             mount.EnqueuePassengerAdd(player, VehicleSeatType.Pilot, 0);
 
             // usually for hover boards
@@ -78,105 +120,105 @@ namespace NexusForever.WorldServer.Game.Spell
             // FIXME: also cast 80530,Mount Sprint  - Tier 2,36122
         }
 
-        [SpellEffectHandler(SpellEffectType.Teleport)]
-        private void HandleEffectTeleport(UnitEntity target, SpellTargetInfo.SpellTargetEffectInfo info)
-        {
-            WorldLocation2Entry locationEntry = GameTableManager.WorldLocation2.GetEntry(info.Entry.DataBits00);
-            if (locationEntry == null)
-                return;
+        //[SpellEffectHandler(SpellEffectType.Teleport)]
+        //private void HandleEffectTeleport(UnitEntity target, SpellTargetInfo.SpellTargetEffectInfo info)
+        //{
+        //    WorldLocation2Entry locationEntry = GameTableManager.WorldLocation2.GetEntry((uint)info.Entry.DataBits00);
+        //    if (locationEntry == null)
+        //        return;
 
-            if (target is Player player)
-                player.TeleportTo((ushort)locationEntry.WorldId, locationEntry.Position0, locationEntry.Position1, locationEntry.Position2);
-        }
+        //    if (target is Player player)
+        //        player.TeleportTo((ushort)locationEntry.WorldId, locationEntry.Position0, locationEntry.Position1, locationEntry.Position2);
+        //}
 
-        [SpellEffectHandler(SpellEffectType.FullScreenEffect)]
-        private void HandleFullScreenEffect(UnitEntity target, SpellTargetInfo.SpellTargetEffectInfo info)
-        {
-        }
+        //[SpellEffectHandler(SpellEffectType.FullScreenEffect)]
+        //private void HandleFullScreenEffect(UnitEntity target, SpellTargetInfo.SpellTargetEffectInfo info)
+        //{
+        //}
 
-        [SpellEffectHandler(SpellEffectType.RapidTransport)]
-        private void HandleEffectRapidTransport(UnitEntity target, SpellTargetInfo.SpellTargetEffectInfo info)
-        {
-            TaxiNodeEntry taxiNode = GameTableManager.TaxiNode.GetEntry(parameters.TaxiNode);
-            if (taxiNode == null)
-                return;
+        //[SpellEffectHandler(SpellEffectType.RapidTransport)]
+        //private void HandleEffectRapidTransport(UnitEntity target, SpellTargetInfo.SpellTargetEffectInfo info)
+        //{
+        //    TaxiNodeEntry taxiNode = GameTableManager.TaxiNode.GetEntry(parameters.TaxiNode);
+        //    if (taxiNode == null)
+        //        return;
 
-            WorldLocation2Entry worldLocation = GameTableManager.WorldLocation2.GetEntry(taxiNode.WorldLocation2Id);
-            if (worldLocation == null)
-                return;
+        //    WorldLocation2Entry worldLocation = GameTableManager.WorldLocation2.GetEntry(taxiNode.WorldLocation2Id);
+        //    if (worldLocation == null)
+        //        return;
 
-            if (!(target is Player player))
-                return;
+        //    if (!(target is Player player))
+        //        return;
 
-            var rotation = new Quaternion(worldLocation.Facing0, worldLocation.Facing0, worldLocation.Facing2, worldLocation.Facing3);
-            player.Rotation = rotation.ToEulerDegrees();
-            player.TeleportTo((ushort)worldLocation.WorldId, worldLocation.Position0, worldLocation.Position1, worldLocation.Position2);
-        }
+        //    var rotation = new Quaternion(worldLocation.Facing0, worldLocation.Facing0, worldLocation.Facing2, worldLocation.Facing3);
+        //    player.Rotation = rotation.ToEulerDegrees();
+        //    player.TeleportTo((ushort)worldLocation.WorldId, worldLocation.Position0, worldLocation.Position1, worldLocation.Position2);
+        //}
 
-        [SpellEffectHandler(SpellEffectType.LearnDyeColor)]
-        private void HandleEffectLearnDyeColor(UnitEntity target, SpellTargetInfo.SpellTargetEffectInfo info)
-        {
-            if (!(target is Player player))
-                return;
+        //[SpellEffectHandler(SpellEffectType.LearnDyeColor)]
+        //private void HandleEffectLearnDyeColor(UnitEntity target, SpellTargetInfo.SpellTargetEffectInfo info)
+        //{
+        //    if (!(target is Player player))
+        //        return;
 
-            player.Session.GenericUnlockManager.Unlock((ushort)info.Entry.DataBits00);
-        }
+        //    player.Session.GenericUnlockManager.Unlock((ushort)info.Entry.DataBits00);
+        //}
 
-        [SpellEffectHandler(SpellEffectType.UnlockMount)]
-        private void HandleEffectUnlockMount(UnitEntity target, SpellTargetInfo.SpellTargetEffectInfo info)
-        {
-            if (!(target is Player player))
-                return;
+        //[SpellEffectHandler(SpellEffectType.UnlockMount)]
+        //private void HandleEffectUnlockMount(UnitEntity target, SpellTargetInfo.SpellTargetEffectInfo info)
+        //{
+        //    if (!(target is Player player))
+        //        return;
 
-            Spell4Entry spell4Entry = GameTableManager.Spell4.GetEntry(info.Entry.DataBits00);
-            player.SpellManager.AddSpell(spell4Entry.Spell4BaseIdBaseSpell);
+        //    Spell4Entry spell4Entry = GameTableManager.Spell4.GetEntry((uint)info.Entry.DataBits00);
+        //    player.SpellManager.AddSpell(spell4Entry.Spell4BaseIdBaseSpell);
 
-            player.Session.EnqueueMessageEncrypted(new ServerUnlockMount
-            {
-                Spell4Id = info.Entry.DataBits00
-            });
-        }
+        //    player.Session.EnqueueMessageEncrypted(new ServerUnlockMount
+        //    {
+        //        Spell4Id = (uint)info.Entry.DataBits00
+        //    });
+        //}
 
-        [SpellEffectHandler(SpellEffectType.UnlockPetFlair)]
-        private void HandleEffectUnlockPetFlair(UnitEntity target, SpellTargetInfo.SpellTargetEffectInfo info)
-        {
-            if (!(target is Player player))
-                return;
+        //[SpellEffectHandler(SpellEffectType.UnlockPetFlair)]
+        //private void HandleEffectUnlockPetFlair(UnitEntity target, SpellTargetInfo.SpellTargetEffectInfo info)
+        //{
+        //    if (!(target is Player player))
+        //        return;
 
-            player.PetCustomisationManager.UnlockFlair((ushort)info.Entry.DataBits00);
-        }
+        //    player.PetCustomisationManager.UnlockFlair((ushort)info.Entry.DataBits00);
+        //}
 
-        [SpellEffectHandler(SpellEffectType.UnlockVanityPet)]
-        private void HandleEffectUnlockVanityPet(UnitEntity target, SpellTargetInfo.SpellTargetEffectInfo info)
-        {
-            if (!(target is Player player))
-                return;
+        //[SpellEffectHandler(SpellEffectType.UnlockVanityPet)]
+        //private void HandleEffectUnlockVanityPet(UnitEntity target, SpellTargetInfo.SpellTargetEffectInfo info)
+        //{
+        //    if (!(target is Player player))
+        //        return;
 
-            Spell4Entry spell4Entry = GameTableManager.Spell4.GetEntry(info.Entry.DataBits00);
-            player.SpellManager.AddSpell(spell4Entry.Spell4BaseIdBaseSpell);
+        //    Spell4Entry spell4Entry = GameTableManager.Spell4.GetEntry((uint)info.Entry.DataBits00);
+        //    player.SpellManager.AddSpell(spell4Entry.Spell4BaseIdBaseSpell);
 
-            player.Session.EnqueueMessageEncrypted(new ServerUnlockMount
-            {
-                Spell4Id = info.Entry.DataBits00
-            });
-        }
+        //    player.Session.EnqueueMessageEncrypted(new ServerUnlockMount
+        //    {
+        //        Spell4Id = (uint)info.Entry.DataBits00
+        //    });
+        //}
 
-        [SpellEffectHandler(SpellEffectType.SummonVanityPet)]
-        private void HandleEffectSummonVanityPet(UnitEntity target, SpellTargetInfo.SpellTargetEffectInfo info)
-        {
-            if (!(target is Player player))
-                return;
+        //[SpellEffectHandler(SpellEffectType.SummonVanityPet)]
+        //private void HandleEffectSummonVanityPet(UnitEntity target, SpellTargetInfo.SpellTargetEffectInfo info)
+        //{
+        //    if (!(target is Player player))
+        //        return;
 
-            // enqueue removal of existing vanity pet if summoned
-            if (player.VanityPetGuid != null)
-            {
-                VanityPet oldVanityPet = player.GetVisible<VanityPet>(player.VanityPetGuid.Value);
-                oldVanityPet?.RemoveFromMap();
-                player.VanityPetGuid = 0u;
-            }
+        //    // enqueue removal of existing vanity pet if summoned
+        //    if (player.VanityPetGuid != null)
+        //    {
+        //        VanityPet oldVanityPet = player.GetVisible<VanityPet>(player.VanityPetGuid.Value);
+        //        oldVanityPet?.RemoveFromMap();
+        //        player.VanityPetGuid = 0u;
+        //    }
 
-            var vanityPet = new VanityPet(player, info.Entry.DataBits00);
-            player.Map.EnqueueAdd(vanityPet, player.Position);
-        }
+        //    var vanityPet = new VanityPet(player, (uint)info.Entry.DataBits00);
+        //    player.Map.EnqueueAdd(vanityPet, player.Position);
+        //}
     }
 }


### PR DESCRIPTION
This proof of concept allows the server to store entries with data that is specific to the entry type. In this example, I used the Spell Effects entries to demonstrate how you could store the same data in different ways depending on the spell effect type. I'm sure there's further ways to clean it up, but didn't want to go too far without approval.