### PR TITLE
Core/RealmList: Reload servers and handle offline

### DIFF
--- a/Source/NexusForever.AuthServer/Network/AuthSession.cs
+++ b/Source/NexusForever.AuthServer/Network/AuthSession.cs
@@ -16,7 +16,7 @@ namespace NexusForever.AuthServer.Network
             {
                 AuthVersion = 16042,
                 AuthMessage = 0x97998A0,
-                Unknown1C   = 3
+                ConnectionType = 3
             });
         }
 

--- a/Source/NexusForever.AuthServer/Network/AuthSession.cs
+++ b/Source/NexusForever.AuthServer/Network/AuthSession.cs
@@ -14,8 +14,8 @@ namespace NexusForever.AuthServer.Network
 
             EnqueueMessage(new ServerHello
             {
-                AuthVersion = 16042,
-                AuthMessage = 0x97998A0,
+                AuthVersion    = 16042,
+                AuthMessage    = 0x97998A0,
                 ConnectionType = 3
             });
         }

--- a/Source/NexusForever.Shared/Game/ServerInfo.cs
+++ b/Source/NexusForever.Shared/Game/ServerInfo.cs
@@ -14,7 +14,7 @@ namespace NexusForever.Shared.Game
 
         public Server Model { get; }
         public uint Address { get; }
-        public bool IsOnline { get; private set; } = false;
+        public bool IsOnline { get; private set; }
 
         public ServerInfo(Server model)
         {
@@ -38,20 +38,17 @@ namespace NexusForever.Shared.Game
             }
         }
 
-        public async Task PingHost(string hostIP, int port)
+        /// <summary>
+        /// Attempt to connect to the remote world server asynchronously.
+        /// </summary>
+        public async Task PingHostAsync()
         {
-            using (var client = new TcpClient())
+            using var client = new TcpClient();
+            await client.ConnectAsync(Model.Host, Model.Port).ContinueWith(task =>
             {
-                await client.ConnectAsync(hostIP, port).ContinueWith(task =>
-                {
-                    if (task.IsFaulted)
-                        IsOnline = false;
-                    else
-                        IsOnline = true;
-
-                    return Task.CompletedTask;
-                });
-            }
+                IsOnline = !task.IsFaulted;
+                return task;
+            });
         }
     }
 }

--- a/Source/NexusForever.Shared/Game/ServerInfo.cs
+++ b/Source/NexusForever.Shared/Game/ServerInfo.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
+using System.Threading.Tasks;
 using NexusForever.Shared.Database.Auth.Model;
 using NLog;
 
@@ -13,6 +14,7 @@ namespace NexusForever.Shared.Game
 
         public Server Model { get; }
         public uint Address { get; }
+        public bool IsOnline { get; private set; } = false;
 
         public ServerInfo(Server model)
         {
@@ -33,6 +35,22 @@ namespace NexusForever.Shared.Game
             {
                 log.Fatal(e, $"Failed to load server entry id: {model.Id}, host: {model.Host} from the database!");
                 throw;
+            }
+        }
+
+        public async Task PingHost(string hostIP, int port)
+        {
+            using (var client = new TcpClient())
+            {
+                await client.ConnectAsync(hostIP, port).ContinueWith(task =>
+                {
+                    if (task.IsFaulted)
+                        IsOnline = false;
+                    else
+                        IsOnline = true;
+
+                    return Task.CompletedTask;
+                });
             }
         }
     }

--- a/Source/NexusForever.Shared/Game/ServerManager.cs
+++ b/Source/NexusForever.Shared/Game/ServerManager.cs
@@ -1,5 +1,10 @@
-﻿using System.Collections.Immutable;
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using NexusForever.Shared.Database.Auth;
 
 namespace NexusForever.Shared.Game
@@ -9,6 +14,11 @@ namespace NexusForever.Shared.Game
         public ImmutableList<ServerInfo> Servers { get; private set; }
         public ImmutableList<ServerMessageInfo> ServerMessages { get; private set; }
 
+        private readonly UpdateTimer checkTimer = new UpdateTimer(60d);
+        private readonly UpdateTimer pingCheckTimer = new UpdateTimer(15d);
+
+        private volatile bool shutdownRequested;
+
         private ServerManager()
         {
         }
@@ -17,6 +27,24 @@ namespace NexusForever.Shared.Game
         {
             InitialiseServers();
             InitialiseServerMessages();
+
+            var serverManagerThread = new Thread(() =>
+            {
+                var stopwatch = new Stopwatch();
+                double lastTick = 0d;
+
+                while (!shutdownRequested)
+                {
+                    stopwatch.Restart();
+
+                    Update(lastTick);
+
+                    Thread.Sleep(1000);
+                    lastTick = (double)stopwatch.ElapsedTicks / Stopwatch.Frequency;
+                }
+            });
+
+            serverManagerThread.Start();
         }
 
         private void InitialiseServers()
@@ -32,6 +60,35 @@ namespace NexusForever.Shared.Game
                 .GroupBy(m => m.Index)
                 .Select(g => new ServerMessageInfo(g))
                 .ToImmutableList();
+        }
+
+        public void Update(double lastTick)
+        {
+            checkTimer.Update(lastTick);
+            if (checkTimer.HasElapsed)
+            {
+                InitialiseServers();
+                InitialiseServerMessages();
+
+                checkTimer.Reset();
+            }
+
+            pingCheckTimer.Update(lastTick);
+            if (pingCheckTimer.HasElapsed)
+            {
+                var tasks = new List<Task>();
+                foreach (ServerInfo server in Servers)
+                    tasks.Add(server.PingHost(server.Model.Host, server.Model.Port));
+
+                Task.WaitAll(tasks.ToArray());
+
+                pingCheckTimer.Reset();
+            }
+        }
+
+        public void Shutdown()
+        {
+            shutdownRequested = true;
         }
     }
 }

--- a/Source/NexusForever.Shared/Game/UpdateTimer.cs
+++ b/Source/NexusForever.Shared/Game/UpdateTimer.cs
@@ -1,6 +1,4 @@
-﻿using NexusForever.Shared;
-
-namespace NexusForever.Shared.Game
+﻿namespace NexusForever.Shared.Game
 {
     public class UpdateTimer : IUpdate
     {

--- a/Source/NexusForever.Shared/Game/UpdateTimer.cs
+++ b/Source/NexusForever.Shared/Game/UpdateTimer.cs
@@ -1,6 +1,6 @@
 ﻿using NexusForever.Shared;
 
-namespace NexusForever.WorldServer.Game
+namespace NexusForever.Shared.Game
 {
     public class UpdateTimer : IUpdate
     {

--- a/Source/NexusForever.Shared/Network/Message/GameMessageOpcode.cs
+++ b/Source/NexusForever.Shared/Network/Message/GameMessageOpcode.cs
@@ -117,6 +117,7 @@ namespace NexusForever.Shared.Network.Message
         ServerQuestObjectiveUpdate      = 0x0361,
         ClientQuestSetTracked           = 0x0364,
         ClientQuestRetry                = 0x0365,
+        ServerForceKick                 = 0x036A,
         ClientEmote                     = 0x037E,
         ClientCostumeItemForget         = 0x038B,
         ClientPackedWorld               = 0x038C,

--- a/Source/NexusForever.Shared/Network/Message/Model/ServerHello.cs
+++ b/Source/NexusForever.Shared/Network/Message/Model/ServerHello.cs
@@ -5,28 +5,28 @@
     {
         public uint AuthVersion { get; set; }
         public uint RealmId { get; set; }
-        public uint Unknown8 { get; set; }
-        public uint UnknownC { get; set; }
-        public ulong Unknown10 { get; set; }
-        public ushort Unknown18 { get; set; }
-        public byte Unknown1C { get; set; }
+        public uint RealmGroupId { get; set; }
+        public uint RealmGroupEnum { get; set; }
+        public ulong StartupTime { get; set; }
+        public ushort ListenPort { get; set; }
+        public byte ConnectionType { get; set; }
         public uint AuthMessage { get; set; }
-        public uint Unknown24 { get; set; }
-        public ulong Unknown28 { get; set; }
+        public uint ProcessId { get; set; }
+        public ulong ProcessCreationTime { get; set; }
         public uint Unknown30 { get; set; }
 
         public void Write(GamePacketWriter writer)
         {
             writer.Write(AuthVersion);
             writer.Write(RealmId);
-            writer.Write(Unknown8);
-            writer.Write(UnknownC);
-            writer.Write(Unknown10);
-            writer.Write(Unknown18);
-            writer.Write(Unknown1C, 5);
+            writer.Write(RealmGroupId);
+            writer.Write(RealmGroupEnum);
+            writer.Write(StartupTime);
+            writer.Write(ListenPort);
+            writer.Write(ConnectionType, 5);
             writer.Write(AuthMessage);
-            writer.Write(Unknown24);
-            writer.Write(Unknown28);
+            writer.Write(ProcessId);
+            writer.Write(ProcessCreationTime);
             writer.Write(Unknown30);
         }
     }

--- a/Source/NexusForever.WorldServer/Game/Entity/MailManager.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/MailManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 using NexusForever.Shared;
+using NexusForever.Shared.Game;
 using NexusForever.Shared.Game.Events;
 using NexusForever.Shared.GameTable;
 using NexusForever.Shared.GameTable.Model;

--- a/Source/NexusForever.WorldServer/Game/Entity/Movement/MovementManager.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/Movement/MovementManager.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 using NexusForever.Shared;
+using NexusForever.Shared.Game;
 using NexusForever.Shared.GameTable;
 using NexusForever.Shared.GameTable.Model;
 using NexusForever.WorldServer.Game.Entity.Movement.Generator;

--- a/Source/NexusForever.WorldServer/Game/Entity/Player.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/Player.cs
@@ -7,6 +7,7 @@ using NexusForever.Shared.Configuration;
 using NexusForever.Shared.Database;
 using NexusForever.Shared.Database.Auth;
 using NexusForever.Shared.Database.Auth.Model;
+using NexusForever.Shared.Game;
 using NexusForever.Shared.Game.Events;
 using NexusForever.Shared.GameTable;
 using NexusForever.Shared.GameTable.Model;

--- a/Source/NexusForever.WorldServer/Game/Entity/VanityPet.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/VanityPet.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using System.Numerics;
 using NexusForever.Shared;
+using NexusForever.Shared.Game;
 using NexusForever.Shared.GameTable;
 using NexusForever.Shared.GameTable.Model;
 using NexusForever.WorldServer.Game.Entity.Network;

--- a/Source/NexusForever.WorldServer/Game/Map/MapGrid.cs
+++ b/Source/NexusForever.WorldServer/Game/Map/MapGrid.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Numerics;
 using NexusForever.Shared;
 using NexusForever.Shared.Configuration;
+using NexusForever.Shared.Game;
 using NexusForever.Shared.Game.Map;
 using NexusForever.WorldServer.Game.Entity;
 using NexusForever.WorldServer.Game.Map.Search;

--- a/Source/NexusForever.WorldServer/Game/Quest/Quest.cs
+++ b/Source/NexusForever.WorldServer/Game/Quest/Quest.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using NexusForever.Shared;
+using NexusForever.Shared.Game;
 using NexusForever.WorldServer.Database;
 using NexusForever.WorldServer.Database.Character.Model;
 using NexusForever.WorldServer.Game.Entity;

--- a/Source/NexusForever.WorldServer/Game/Static/ForceKickReason.cs
+++ b/Source/NexusForever.WorldServer/Game/Static/ForceKickReason.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NexusForever.WorldServer.Game.Static
+{
+    public enum ForceKickReason
+    {
+        GMKick          = 0x0006,
+        Inactivity      = 0x0007,
+        AuthDisconnect  = 0x0008,
+        StsDisconnect   = 0x000C,
+        WorldDisconnect = 0x000F,
+        GameTimeExpired = 0x0010,
+        AccountDisconnect = 0x0013,
+        TransactionFail = 0x0014
+    }
+}

--- a/Source/NexusForever.WorldServer/Game/Static/ForceKickReason.cs
+++ b/Source/NexusForever.WorldServer/Game/Static/ForceKickReason.cs
@@ -1,18 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace NexusForever.WorldServer.Game.Static
+﻿namespace NexusForever.WorldServer.Game.Static
 {
     public enum ForceKickReason
     {
-        GMKick          = 0x0006,
-        Inactivity      = 0x0007,
-        AuthDisconnect  = 0x0008,
-        StsDisconnect   = 0x000C,
-        WorldDisconnect = 0x000F,
-        GameTimeExpired = 0x0010,
+        GMKick            = 0x0006,
+        Inactivity        = 0x0007,
+        AuthDisconnect    = 0x0008,
+        StsDisconnect     = 0x000C,
+        WorldDisconnect   = 0x000F,
+        GameTimeExpired   = 0x0010,
         AccountDisconnect = 0x0013,
-        TransactionFail = 0x0014
+        TransactionFail   = 0x0014
     }
 }

--- a/Source/NexusForever.WorldServer/Network/Message/Handler/CharacterHandler.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Handler/CharacterHandler.cs
@@ -30,7 +30,6 @@ using CostumeEntity = NexusForever.WorldServer.Game.Entity.Costume;
 using Item = NexusForever.WorldServer.Game.Entity.Item;
 using Residence = NexusForever.WorldServer.Game.Housing.Residence;
 using NetworkMessage = NexusForever.Shared.Network.Message.Model.Shared.Message;
-using System.Net.Sockets;
 
 namespace NexusForever.WorldServer.Network.Message.Handler
 {
@@ -45,12 +44,12 @@ namespace NexusForever.WorldServer.Network.Message.Handler
             {
                 serverRealmList.Realms.Add(new ServerRealmList.RealmInfo
                 {
-                    RealmId = server.Model.Id,
-                    RealmName = server.Model.Name,
-                    Type = (RealmType)server.Model.Type,
-                    Status = server.IsOnline ? RealmStatus.Up : RealmStatus.Down,
-                    Population = RealmPopulation.Low,
-                    Unknown8 = new byte[16],
+                    RealmId          = server.Model.Id,
+                    RealmName        = server.Model.Name,
+                    Type             = (RealmType)server.Model.Type,
+                    Status           = server.IsOnline ? RealmStatus.Up : RealmStatus.Down,
+                    Population       = RealmPopulation.Low,
+                    Unknown8         = new byte[16],
                     AccountRealmInfo = new ServerRealmList.RealmInfo.AccountRealmData
                     {
                         RealmId = server.Model.Id
@@ -59,12 +58,12 @@ namespace NexusForever.WorldServer.Network.Message.Handler
             }
 
             serverRealmList.Messages = ServerManager.Instance.ServerMessages
-                    .Select(m => new NetworkMessage
-                    {
-                        Index = m.Index,
-                        Messages = m.Messages
-                    })
-                    .ToList();
+                .Select(m => new NetworkMessage
+                {
+                    Index    = m.Index,
+                    Messages = m.Messages
+                })
+                .ToList();
 
             session.EnqueueMessageEncrypted(serverRealmList);
         }
@@ -93,14 +92,14 @@ namespace NexusForever.WorldServer.Network.Message.Handler
             {
                 session.EnqueueMessageEncrypted(new ServerNewRealm
                 {
-                    SessionKey = sessionKey,
+                    SessionKey  = sessionKey,
                     GatewayData = new ServerNewRealm.Gateway
                     {
                         Address = server.Address,
-                        Port = server.Model.Port
+                        Port    = server.Model.Port
                     },
                     RealmName = server.Model.Name,
-                    Type = (RealmType)server.Model.Type
+                    Type      = (RealmType)server.Model.Type
                 });
             }));
         }

--- a/Source/NexusForever.WorldServer/Network/Message/Handler/CharacterHandler.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Handler/CharacterHandler.cs
@@ -30,6 +30,7 @@ using CostumeEntity = NexusForever.WorldServer.Game.Entity.Costume;
 using Item = NexusForever.WorldServer.Game.Entity.Item;
 using Residence = NexusForever.WorldServer.Game.Housing.Residence;
 using NetworkMessage = NexusForever.Shared.Network.Message.Model.Shared.Message;
+using System.Net.Sockets;
 
 namespace NexusForever.WorldServer.Network.Message.Handler
 {
@@ -38,33 +39,32 @@ namespace NexusForever.WorldServer.Network.Message.Handler
         [MessageHandler(GameMessageOpcode.ClientRealmList)]
         public static void HandleRealmList(WorldSession session, ClientRealmList realmList)
         {
-            var serverRealmList = new ServerRealmList
-            {
-                Messages = ServerManager.Instance.ServerMessages
-                    .Select(m => new NetworkMessage
-                    {
-                        Index    = m.Index,
-                        Messages = m.Messages
-                    })
-                    .ToList()
-            };
+            var serverRealmList = new ServerRealmList();
 
             foreach (ServerInfo server in ServerManager.Instance.Servers)
             {
                 serverRealmList.Realms.Add(new ServerRealmList.RealmInfo
                 {
-                    RealmId    = server.Model.Id,
-                    RealmName  = server.Model.Name,
-                    Type       = (RealmType)server.Model.Type,
-                    Status     = RealmStatus.Up,
+                    RealmId = server.Model.Id,
+                    RealmName = server.Model.Name,
+                    Type = (RealmType)server.Model.Type,
+                    Status = server.IsOnline ? RealmStatus.Up : RealmStatus.Down,
                     Population = RealmPopulation.Low,
-                    Unknown8   = new byte[16],
+                    Unknown8 = new byte[16],
                     AccountRealmInfo = new ServerRealmList.RealmInfo.AccountRealmData
                     {
                         RealmId = server.Model.Id
                     }
                 });
             }
+
+            serverRealmList.Messages = ServerManager.Instance.ServerMessages
+                    .Select(m => new NetworkMessage
+                    {
+                        Index = m.Index,
+                        Messages = m.Messages
+                    })
+                    .ToList();
 
             session.EnqueueMessageEncrypted(serverRealmList);
         }
@@ -80,20 +80,27 @@ namespace NexusForever.WorldServer.Network.Message.Handler
             if (server.Model.Id == WorldServer.RealmId)
                 return;
 
+            // TODO: Return proper error packet if server is not online
+            if (!server.IsOnline)
+            {
+                session.EnqueueMessageEncrypted(new ServerForceKick());
+                return;
+            }
+
             byte[] sessionKey = RandomProvider.GetBytes(16u);
             session.EnqueueEvent(new TaskEvent(AuthDatabase.UpdateAccountSessionKey(session.Account, sessionKey),
                 () =>
             {
                 session.EnqueueMessageEncrypted(new ServerNewRealm
                 {
-                    SessionKey  = sessionKey,
+                    SessionKey = sessionKey,
                     GatewayData = new ServerNewRealm.Gateway
                     {
                         Address = server.Address,
-                        Port    = server.Model.Port
+                        Port = server.Model.Port
                     },
-                    RealmName   = server.Model.Name,
-                    Type        = (RealmType)server.Model.Type
+                    RealmName = server.Model.Name,
+                    Type = (RealmType)server.Model.Type
                 });
             }));
         }

--- a/Source/NexusForever.WorldServer/Network/Message/Model/ServerForceKick.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Model/ServerForceKick.cs
@@ -1,0 +1,17 @@
+﻿using NexusForever.Shared.Network;
+using NexusForever.Shared.Network.Message;
+using NexusForever.WorldServer.Game.Static;
+
+namespace NexusForever.WorldServer.Network.Message.Model
+{
+    [Message(GameMessageOpcode.ServerForceKick)]
+    public class ServerForceKick : IWritable
+    {
+        public ForceKickReason Reason { get; set; } = ForceKickReason.WorldDisconnect;
+
+        public void Write(GamePacketWriter writer)
+        {
+            writer.Write(Reason, 5u);
+        }
+    }
+}

--- a/Source/NexusForever.WorldServer/Network/WorldSession.cs
+++ b/Source/NexusForever.WorldServer/Network/WorldSession.cs
@@ -31,11 +31,11 @@ namespace NexusForever.WorldServer.Network
 
             EnqueueMessageEncrypted(new ServerHello
             {
-                AuthVersion     = 16042,
-                RealmId         = WorldServer.RealmId,
-                RealmGroupId    = 21,
-                AuthMessage     = 0x97998A0,
-                ConnectionType  = 11
+                AuthVersion    = 16042,
+                RealmId        = WorldServer.RealmId,
+                RealmGroupId   = 21,
+                AuthMessage    = 0x97998A0,
+                ConnectionType = 11
             });
         }
 

--- a/Source/NexusForever.WorldServer/Network/WorldSession.cs
+++ b/Source/NexusForever.WorldServer/Network/WorldSession.cs
@@ -31,11 +31,11 @@ namespace NexusForever.WorldServer.Network
 
             EnqueueMessageEncrypted(new ServerHello
             {
-                AuthVersion = 16042,
-                RealmId     = WorldServer.RealmId,
-                Unknown8    = 21,
-                AuthMessage = 0x97998A0,
-                Unknown1C   = 11
+                AuthVersion     = 16042,
+                RealmId         = WorldServer.RealmId,
+                RealmGroupId    = 21,
+                AuthMessage     = 0x97998A0,
+                ConnectionType  = 11
             });
         }
 

--- a/Source/NexusForever.WorldServer/WorldServer.cs
+++ b/Source/NexusForever.WorldServer/WorldServer.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using NLog;
 using NexusForever.Shared;
@@ -65,7 +64,6 @@ namespace NexusForever.WorldServer
             PrerequisiteManager.Instance.Initialise();
             GlobalSpellManager.Instance.Initialise();
             GlobalQuestManager.Instance.Initialise();
-            ServerManager.Instance.Initialise();
 
             CharacterManager.Instance.Initialise();
             ResidenceManager.Instance.Initialise();
@@ -73,10 +71,8 @@ namespace NexusForever.WorldServer
 
             GlobalAchievementManager.Instance.Initialise();
 
-            // make sure the assigned realm id in the configuration file exists in the database
             RealmId = ConfigurationManager<WorldServerConfiguration>.Instance.Config.RealmId;
-            if (ServerManager.Instance.Servers.All(s => s.Model.Id != RealmId))
-                throw new ConfigurationException($"Realm id {RealmId} in configuration file doesn't exist in the database!");
+            ServerManager.Instance.Initialise(RealmId); 
 
             MessageManager.Instance.Initialise();
             SocialManager.Instance.Initialise();


### PR DESCRIPTION
Refreshes servers from database if the server list is deemed dirty
This will kick the user back to login if they try to join a server that is marked as offline. It's not elegant at this time, but it works.

Note: This was written so that Admins could add/remove extra realms from their Auth table without having to bump any existing World Servers.