### PR TITLE
Fix for math error in CurrencyManager.cs. Fixes #190 .

### DIFF
--- a/Source/NexusForever.WorldServer/Game/Entity/CurrencyManager.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/CurrencyManager.cs
@@ -75,7 +75,7 @@ namespace NexusForever.WorldServer.Game.Entity
 
             amount += currency.Amount;
             if (currency.Entry.CapAmount > 0)
-                amount = Math.Min(amount + currency.Amount, currency.Entry.CapAmount);
+                amount = Math.Min(amount, currency.Entry.CapAmount);
 
             CurrencyAmountUpdate(currency, amount, isLoot);
         }


### PR DESCRIPTION
Fix for #190, in which CurrencyAddAmount added the player's
existing currency twice to the new amount when a currency
cap was in place.