### PR TITLE
Spells/ActionSet: Fixed Save Issues, Added Macro support

### DIFF
--- a/Source/NexusForever.Database.Character/CharacterContext.cs
+++ b/Source/NexusForever.Database.Character/CharacterContext.cs
@@ -243,7 +243,8 @@ namespace NexusForever.Database.Character
                 entity.Property(e => e.SpecIndex)
                     .HasColumnName("specIndex")
                     .HasColumnType("tinyint(3) unsigned")
-                    .HasDefaultValue(0);
+                    .HasDefaultValue(0)
+                    .ValueGeneratedNever();
 
                 entity.Property(e => e.AmpId)
                     .HasColumnName("ampId")
@@ -271,12 +272,14 @@ namespace NexusForever.Database.Character
                 entity.Property(e => e.SpecIndex)
                     .HasColumnName("specIndex")
                     .HasColumnType("tinyint(3) unsigned")
-                    .HasDefaultValue(0);
+                    .HasDefaultValue(0)
+                    .ValueGeneratedNever();
 
                 entity.Property(e => e.Location)
                     .HasColumnName("location")
                     .HasColumnType("smallint(5) unsigned")
-                    .HasDefaultValue(0);
+                    .HasDefaultValue(0)
+                    .ValueGeneratedNever();
 
                 entity.Property(e => e.ObjectId)
                     .HasColumnName("objectId")

--- a/Source/NexusForever.WorldServer/Game/Entity/Player.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/Player.cs
@@ -168,6 +168,9 @@ namespace NexusForever.WorldServer.Game.Entity
             TimePlayedTotal = model.TimePlayedTotal;
             TimePlayedLevel = model.TimePlayedLevel;
 
+            foreach (CharacterStatModel statModel in model.Stat)
+                stats.Add((Stat)statModel.Stat, new StatValue(statModel));
+
             // managers
             CostumeManager          = new CostumeManager(this, session.Account, model);
             Inventory               = new Inventory(this, model);
@@ -212,8 +215,6 @@ namespace NexusForever.WorldServer.Game.Entity
             foreach (CharacterBoneModel bone in model.Bone.OrderBy(bone => bone.BoneIndex))
                 Bones.Add(bone.Bone);
 
-            foreach (CharacterStatModel statModel in model.Stat)
-                stats.Add((Stat)statModel.Stat, new StatValue(statModel));
 
             SetStat(Stat.Sheathed, 1u);
 

--- a/Source/NexusForever.WorldServer/Game/Spell/ActionSet.cs
+++ b/Source/NexusForever.WorldServer/Game/Spell/ActionSet.cs
@@ -63,7 +63,7 @@ namespace NexusForever.WorldServer.Game.Spell
 
             if ((saveMask & ActionSetSaveMask.ActionSetAmps) != 0)
             {
-                foreach ((ushort id, ActionSetAmp amp) in amps.ToList())
+                foreach ((ushort id, ActionSetAmp amp) in amps.OrderBy(i => i.Value.PendingDelete == true).ToList())
                 {
                     if (amp.PendingDelete)
                         amps.Remove(id);
@@ -74,7 +74,7 @@ namespace NexusForever.WorldServer.Game.Spell
 
             if ((saveMask & ActionSetSaveMask.ActionSetActions) != 0)
             {
-                foreach ((UILocation location, ActionSetShortcut shortcut) in actions.ToList())
+                foreach ((UILocation location, ActionSetShortcut shortcut) in actions.OrderBy(i => i.Value.PendingDelete == true).ToList())
                 {
                     if (shortcut.PendingDelete)
                         actions.Remove(location);

--- a/Source/NexusForever.WorldServer/Game/Spell/Static/ShortcutType.cs
+++ b/Source/NexusForever.WorldServer/Game/Spell/Static/ShortcutType.cs
@@ -5,7 +5,7 @@
     {
         None      = 0,
         Item      = 1,
-        Unknown2  = 2,
+        Macro     = 2,
         Unknown3  = 3,
         Spell     = 4,
         Unknown6  = 6,

--- a/Source/NexusForever.WorldServer/Network/Message/Handler/SpellHandler.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Handler/SpellHandler.cs
@@ -148,6 +148,12 @@ namespace NexusForever.WorldServer.Network.Message.Handler
                 }
                 case ShortcutType.Spell:
                     throw new InvalidPacketValueException();
+                case ShortcutType.None:
+                    // Removing Shortcut. Intentionally leaving blank.
+                    break;
+                case ShortcutType.Macro:
+                    // Allowed. Macros seem to be stored client side only.
+                    break;
                 default:
                     throw new NotImplementedException();
             }


### PR DESCRIPTION
Updated April 13th, 2020.
- Fixed Saving of Shortcuts and AMPs. Should also fix load issues related to AMPs
- Fixed removal of shortcuts from the non-LAS hotbars.
- Added Macro support. Macros are not stored server side at this time, but Macro shortcuts should be stored between sessions.

---

Main problem previously was that Amps and Shortcuts that were looking to be created could've tried to be created earlier than the existing one was being deleted. This forces the deleted shortcuts and amps to execute first "freeing up" the entry's keys to be used by the newly created entry.