### PR TITLE
[Commands/fix] Remove rouge empty command name from Save Handler

### DIFF
--- a/Source/NexusForever.WorldServer/Command/Handler/SaveCommandHandler.cs
+++ b/Source/NexusForever.WorldServer/Command/Handler/SaveCommandHandler.cs
@@ -8,7 +8,7 @@ namespace NexusForever.WorldServer.Command.Handler
     public class SaveCommandHandler : NamedCommand
     {
         public SaveCommandHandler()
-            : base(false, "save", "")
+            : base(false, "save")
         {
         }
 


### PR DESCRIPTION
Remove a rouge command name that would crash the world server if the command began with a space