### PR TITLE
ServerManager/Fix: Display status properly

### DIFF
--- a/Source/NexusForever.WorldServer/Network/Message/Handler/CharacterHandler.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Handler/CharacterHandler.cs
@@ -42,12 +42,16 @@ namespace NexusForever.WorldServer.Network.Message.Handler
 
             foreach (ServerInfo server in ServerManager.Instance.Servers)
             {
+                RealmStatus status = RealmStatus.Up;
+                if (!server.IsOnline && server.Model.Id != WorldServer.RealmId)
+                    status = RealmStatus.Down;
+
                 serverRealmList.Realms.Add(new ServerRealmList.RealmInfo
                 {
                     RealmId          = server.Model.Id,
                     RealmName        = server.Model.Name,
                     Type             = (RealmType)server.Model.Type,
-                    Status           = server.IsOnline ? RealmStatus.Up : RealmStatus.Down,
+                    Status           = status,
                     Population       = RealmPopulation.Low,
                     Unknown8         = new byte[16],
                     AccountRealmInfo = new ServerRealmList.RealmInfo.AccountRealmData


### PR DESCRIPTION
This was missed during testing following the refactor, sorry about that. This just fixes the display of the current server's status. Trying to connect to the server still worked if it was actually online.