### PR TITLE
Misc/Fix: Deleted character kick the client out

### DIFF
--- a/Source/NexusForever.WorldServer/Network/Message/Handler/MiscHandler.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Handler/MiscHandler.cs
@@ -26,7 +26,7 @@ namespace NexusForever.WorldServer.Network.Message.Handler
         {
             ICharacter character = CharacterManager.Instance.GetCharacterInfo(request.Identity.CharacterId);
             if (character == null)
-                throw new InvalidPacketValueException();
+                return;
 
             session.EnqueueMessageEncrypted(new ServerPlayerInfoFullResponse
             {


### PR DESCRIPTION
Throwing the exception causes the client to be disconnected. This makes the client show this other player as "Unknown" in the Mail "from" field, friends' lists, guild lists', etc. 

This fix is mainly for Mail, as a player should be removed as a friend, removed from guild, removed from communities, and neighbours list, on deletion.