### PR TITLE
Map/Zones: Zone Change Client packet

### DIFF
--- a/Source/NexusForever.Shared/Network/Message/GameMessageOpcode.cs
+++ b/Source/NexusForever.Shared/Network/Message/GameMessageOpcode.cs
@@ -175,6 +175,7 @@ namespace NexusForever.Shared.Network.Message
         ClientEntityCommand             = 0x0637, // bidirectional? packet has both read and write handlers 
         ServerEntityCommand             = 0x0638, // bidirectional? packet has both read and write handlers
         Server0639                      = 0x0639, // mount up or something
+        ClientZoneChange                = 0x063A,
         ClientPlayerMovementSpeedUpdate = 0x063B,
         ServerAuthDenied                = 0x063D,
         ServerOwnedCommodityOrders      = 0x064C,

--- a/Source/NexusForever.WorldServer/Network/Message/Handler/MiscHandler.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Handler/MiscHandler.cs
@@ -78,5 +78,10 @@ namespace NexusForever.WorldServer.Network.Message.Handler
                 RandomRollResult = new Random().Next((int)randomRoll.MinRandom, (int)randomRoll.MaxRandom)
             });
         }
+
+        [MessageHandler(GameMessageOpcode.ClientZoneChange)]
+        public static void HandleClientZoneChange(WorldSession session, ClientZoneChange zoneChange)
+        {
+        }
     }
 }

--- a/Source/NexusForever.WorldServer/Network/Message/Model/ClientZoneChange.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Model/ClientZoneChange.cs
@@ -1,0 +1,18 @@
+using NexusForever.Shared.Network;
+using NexusForever.Shared.Network.Message;
+
+namespace NexusForever.WorldServer.Network.Message.Model
+{
+    [Message(GameMessageOpcode.ClientZoneChange)]
+    public class ClientZoneChange : IReadable
+    {
+        public ushort PreviousZoneId { get; private set; }
+        public ushort NewZoneId { get; private set; }
+
+        public void Read(GamePacketReader reader)
+        {
+            PreviousZoneId = reader.ReadUShort(15u);
+            NewZoneId = reader.ReadUShort(15u);
+        }
+    }
+}


### PR DESCRIPTION
I was tired of seeing `063A` pop up constantly and with no clue what it meant 😛 Now this makes sense. I haven't hooked any functionality up to it, but would be a good indicator when we want to apply scripts when a Player is in a certain area, like the gravity effect modifier for The Loftite Cliffs. Or, trigger a Challenge, for example.