### PR TITLE
Core/Packets: Client Entered World and Communicators

### DIFF
--- a/Source/NexusForever.Shared/Network/Message/GameMessageOpcode.cs
+++ b/Source/NexusForever.Shared/Network/Message/GameMessageOpcode.cs
@@ -34,6 +34,7 @@ namespace NexusForever.Shared.Network.Message
         ServerDatacubeVolumeUpdate      = 0x00E2,
         ServerCharacterDeleteResult     = 0x00E6,
         Server00F1                      = 0x00F1, // handler sends 0x00D5 and ClientPlayerMovementSpeedUpdate
+        ClientEnteredWorld              = 0x00F2,
         ServerCharacterFlagsUpdated     = 0x00FE,
         Server0104                      = 0x0104, // Galactic Archive
         ServerGenericError              = 0x0106,
@@ -206,6 +207,7 @@ namespace NexusForever.Shared.Network.Message
         ClientRandomRollRequest         = 0x071B,
         ServerRandomRollResponse        = 0x071C,
         ServerEntityInteractiveUpdate   = 0x0755,
+        ServerCommunicatorMessage       = 0x0757,
         ServerRealmFirstAchievement     = 0x075F,
         ServerRealmList                 = 0x0761, // bidirectional? packet has both read and write handlers
         ServerRealmMessages             = 0x0763,

--- a/Source/NexusForever.WorldServer/Game/Entity/Player.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/Player.cs
@@ -756,32 +756,6 @@ namespace NexusForever.WorldServer.Game.Entity
             });
         }
 
-        /// <summary>
-        /// Send a communicator message to this client, displaying the <see cref="CommunicatorMessagesEntry"/> text at the top of the screen. This is to be used by scripts to trigger quest dialog.
-        /// </summary>
-        public void SendCommunicatorMessage(uint communicatorId)
-        {
-            // TODO: Communicator messages should be queueable, so that the client can 
-
-            CommunicatorMessagesEntry entry = GameTableManager.Instance.CommunicatorMessages.GetEntry(communicatorId);
-            if (entry == null)
-                throw new InvalidOperationException($"CommunicatorMessagesEntry with ID {communicatorId} does not exist.");
-
-            if (entry.FactionId > 0 && entry.FactionId != (uint)Faction1)
-                throw new InvalidOperationException($"Invalid faction for Communicator Message");
-
-            if (entry.RaceId > 0 && entry.RaceId != (uint)Race)
-                throw new InvalidOperationException($"Invalid Race for Communicator Message");
-
-            if (entry.ClassId > 0 && entry.ClassId != (uint)Class)
-                throw new InvalidOperationException($"Invalid Class for Communicator Message");
-
-            Session.EnqueueMessageEncrypted(new ServerCommunicatorMessage
-            {
-                CommunicatorId = (ushort)entry.Id
-            });
-        }
-
         public void Save(AuthContext context)
         {
             Session.GenericUnlockManager.Save(context);

--- a/Source/NexusForever.WorldServer/Game/Entity/Player.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/Player.cs
@@ -756,6 +756,32 @@ namespace NexusForever.WorldServer.Game.Entity
             });
         }
 
+        /// <summary>
+        /// Send a communicator message to this client, displaying the <see cref="CommunicatorMessagesEntry"/> text at the top of the screen. This is to be used by scripts to trigger quest dialog.
+        /// </summary>
+        public void SendCommunicatorMessage(uint communicatorId)
+        {
+            // TODO: Communicator messages should be queueable, so that the client can 
+
+            CommunicatorMessagesEntry entry = GameTableManager.Instance.CommunicatorMessages.GetEntry(communicatorId);
+            if (entry == null)
+                throw new InvalidOperationException($"CommunicatorMessagesEntry with ID {communicatorId} does not exist.");
+
+            if (entry.FactionId > 0 && entry.FactionId != (uint)Faction1)
+                throw new InvalidOperationException($"Invalid faction for Communicator Message");
+
+            if (entry.RaceId > 0 && entry.RaceId != (uint)Race)
+                throw new InvalidOperationException($"Invalid Race for Communicator Message");
+
+            if (entry.ClassId > 0 && entry.ClassId != (uint)Class)
+                throw new InvalidOperationException($"Invalid Class for Communicator Message");
+
+            Session.EnqueueMessageEncrypted(new ServerCommunicatorMessage
+            {
+                CommunicatorId = (ushort)entry.Id
+            });
+        }
+
         public void Save(AuthContext context)
         {
             Session.GenericUnlockManager.Save(context);

--- a/Source/NexusForever.WorldServer/Game/Quest/CommunicatorMessage.cs
+++ b/Source/NexusForever.WorldServer/Game/Quest/CommunicatorMessage.cs
@@ -3,12 +3,14 @@ using NexusForever.WorldServer.Game.Entity;
 using NexusForever.WorldServer.Game.Entity.Static;
 using NexusForever.WorldServer.Game.Prerequisite;
 using NexusForever.WorldServer.Game.Quest.Static;
+using NexusForever.WorldServer.Network;
+using NexusForever.WorldServer.Network.Message.Model;
 
 namespace NexusForever.WorldServer.Game.Quest
 {
     public class CommunicatorMessage
     {
-        public ushort Id => (ushort)entry.QuestIdDelivered;
+        public ushort QuestId => (ushort)entry.QuestIdDelivered;
 
         private readonly CommunicatorMessagesEntry entry;
 
@@ -59,6 +61,17 @@ namespace NexusForever.WorldServer.Game.Quest
                 return false;
 
             return true;
+        }
+
+        /// <summary>
+        /// Send communicator message to <see cref="WorldSession"/>.
+        /// </summary>
+        public void Send(WorldSession session)
+        {
+            session.EnqueueMessageEncrypted(new ServerCommunicatorMessage
+            {
+                CommunicatorId = (ushort)entry.Id
+            });
         }
     }
 }

--- a/Source/NexusForever.WorldServer/Game/Quest/GlobalQuestManager.cs
+++ b/Source/NexusForever.WorldServer/Game/Quest/GlobalQuestManager.cs
@@ -102,11 +102,11 @@ namespace NexusForever.WorldServer.Game.Quest
             foreach (CommunicatorMessagesEntry entry in GameTableManager.Instance.CommunicatorMessages.Entries
                 .Where(e => e.QuestIdDelivered != 0u))
             {
-                var quest = new CommunicatorMessage(entry);
-                if (!builder.ContainsKey(quest.Id))
-                    builder.Add(quest.Id, new List<CommunicatorMessage>());
+                var communicator = new CommunicatorMessage(entry);
+                if (!builder.ContainsKey(communicator.QuestId))
+                    builder.Add(communicator.QuestId, new List<CommunicatorMessage>());
 
-                builder[quest.Id].Add(quest);
+                builder[communicator.QuestId].Add(communicator);
             }
 
             communicatorQuestStore = builder.ToImmutableDictionary(e => e.Key, e => e.Value.ToImmutableList());

--- a/Source/NexusForever.WorldServer/Network/Message/Handler/MiscHandler.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Handler/MiscHandler.cs
@@ -83,5 +83,13 @@ namespace NexusForever.WorldServer.Network.Message.Handler
         public static void HandleClientZoneChange(WorldSession session, ClientZoneChange zoneChange)
         {
         }
+
+        /// <summary>
+        /// The client sends this after every teleport, when it has entered the world.
+        /// </summary>
+        [MessageHandler(GameMessageOpcode.ClientEnteredWorld)]
+        public static void HandleClientEnteredWorld(WorldSession session, ClientEnteredWorld enteredWorld)
+        {
+        }
     }
 }

--- a/Source/NexusForever.WorldServer/Network/Message/Model/ClientEnteredWorld.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Model/ClientEnteredWorld.cs
@@ -1,0 +1,16 @@
+using NexusForever.Shared.Network;
+using NexusForever.Shared.Network.Message;
+
+namespace NexusForever.WorldServer.Network.Message.Model
+{
+    [Message(GameMessageOpcode.ClientEnteredWorld)]
+    public class ClientEnteredWorld : IReadable
+    {
+        public ushort WorldZoneId { get; private set; } // 15
+
+        public void Read(GamePacketReader reader)
+        {
+            WorldZoneId = reader.ReadUShort(15u);
+        }
+    }
+}

--- a/Source/NexusForever.WorldServer/Network/Message/Model/ServerCommunicatorMessage.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Model/ServerCommunicatorMessage.cs
@@ -1,6 +1,5 @@
 ﻿using NexusForever.Shared.Network;
 using NexusForever.Shared.Network.Message;
-using NexusForever.WorldServer.Game.Static;
 
 namespace NexusForever.WorldServer.Network.Message.Model
 {

--- a/Source/NexusForever.WorldServer/Network/Message/Model/ServerCommunicatorMessage.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Model/ServerCommunicatorMessage.cs
@@ -1,0 +1,19 @@
+﻿using NexusForever.Shared.Network;
+using NexusForever.Shared.Network.Message;
+using NexusForever.WorldServer.Game.Static;
+
+namespace NexusForever.WorldServer.Network.Message.Model
+{
+    [Message(GameMessageOpcode.ServerCommunicatorMessage)]
+    public class ServerCommunicatorMessage : IWritable
+    {
+        public ushort CommunicatorId { get; set; }
+        public bool Unknown0 { get; set; }
+
+        public void Write(GamePacketWriter writer)
+        {
+            writer.Write(CommunicatorId, 15u);
+            writer.Write(Unknown0);
+        }
+    }
+}


### PR DESCRIPTION
The ClientEnteredWorld packet is sent after every teleport/loading screen.
Includes basic Communicator message support. This is used in story telling settings, i.e. quests, dungeons, etc.