### PR TITLE
Social/Emotes: Fix invisible units, animations and targeting

### DIFF
--- a/Source/NexusForever.Shared/GameTable/GameTableManager.cs
+++ b/Source/NexusForever.Shared/GameTable/GameTableManager.cs
@@ -550,7 +550,10 @@ namespace NexusForever.Shared.GameTable
         [GameData]
         public GameTable<Spell4ValidTargetsEntry> Spell4ValidTargets { get; private set; }
 
+        [GameData]
         public GameTable<Spell4VisualEntry> Spell4Visual { get; private set; }
+
+        [GameData]
         public GameTable<Spell4VisualGroupEntry> Spell4VisualGroup { get; private set; }
 
         [GameData]
@@ -621,7 +624,10 @@ namespace NexusForever.Shared.GameTable
 
         public GameTable<VeteranTierEntry> VeteranTier { get; private set; }
         public GameTable<VirtualItemEntry> VirtualItem { get; private set; }
+
+        [GameData]
         public GameTable<VisualEffectEntry> VisualEffect { get; private set; }
+
         public GameTable<VitalEntry> Vital { get; private set; }
         public GameTable<WaterSurfaceEffectEntry> WaterSurfaceEffect { get; private set; }
 

--- a/Source/NexusForever.Shared/GameTable/Model/Spell4VisualGroupEntry.cs
+++ b/Source/NexusForever.Shared/GameTable/Model/Spell4VisualGroupEntry.cs
@@ -3,42 +3,8 @@ namespace NexusForever.Shared.GameTable.Model
     public class Spell4VisualGroupEntry
     {
         public uint Id;
-        public uint Spell4VisualIdVisual00;
-        public uint Spell4VisualIdVisual01;
-        public uint Spell4VisualIdVisual02;
-        public uint Spell4VisualIdVisual03;
-        public uint Spell4VisualIdVisual04;
-        public uint Spell4VisualIdVisual05;
-        public uint Spell4VisualIdVisual06;
-        public uint Spell4VisualIdVisual07;
-        public uint Spell4VisualIdVisual08;
-        public uint Spell4VisualIdVisual09;
-        public uint Spell4VisualIdVisual10;
-        public uint Spell4VisualIdVisual11;
-        public uint Spell4VisualIdVisual12;
-        public uint Spell4VisualIdVisual13;
-        public uint Spell4VisualIdVisual14;
-        public uint Spell4VisualIdVisual15;
-        public uint Spell4VisualIdVisual16;
-        public uint Spell4VisualIdVisual17;
-        public uint Spell4VisualIdVisual18;
-        public uint Spell4VisualIdVisual19;
-        public uint Spell4VisualIdVisual20;
-        public uint Spell4VisualIdVisual21;
-        public uint Spell4VisualIdVisual22;
-        public uint Spell4VisualIdVisual23;
-        public uint Spell4VisualIdVisual24;
-        public uint Spell4VisualIdVisual25;
-        public uint Spell4VisualIdVisual26;
-        public uint Spell4VisualIdVisual27;
-        public uint Spell4VisualIdVisual28;
-        public uint Spell4VisualIdVisual29;
-        public uint Spell4VisualIdVisual30;
-        public uint Spell4VisualIdVisual31;
-        public uint Spell4VisualIdVisual32;
-        public uint Spell4VisualIdVisual33;
-        public uint Spell4VisualIdVisual34;
-        public uint Spell4VisualIdVisual35;
+        [GameTableFieldArray(36u)]
+        public uint[] Spell4VisualIdVisuals;
         public uint VisualEffectIdPrimaryCaster;
     }
 }

--- a/Source/NexusForever.Shared/Network/Message/GameMessageOpcode.cs
+++ b/Source/NexusForever.Shared/Network/Message/GameMessageOpcode.cs
@@ -127,6 +127,7 @@ namespace NexusForever.Shared.Network.Message
         ClientPacked                    = 0x025C, // the same as ClientEncrypted except the contents isn't encrypted?
         ServerPlayerCreate              = 0x025E,
         ServerEntityCreate              = 0x0262,
+        ServerEntityVisualEffect        = 0x0263,
         ClientCharacterDelete           = 0x0352,
         ServerEntityDestroy             = 0x0355,
         Server0357                      = 0x0357,
@@ -141,6 +142,7 @@ namespace NexusForever.Shared.Network.Message
         ClientQuestRetry                = 0x0365,
         ServerForceKick                 = 0x036A,
         ClientEmote                     = 0x037E,
+        ServerEntityEmote               = 0x037F,
         ClientCostumeItemForget         = 0x038B,
         ClientPackedWorld               = 0x038C,
         Server03AA                      = 0x03AA, // friendship account related

--- a/Source/NexusForever.WorldServer/Game/Entity/Player.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/Player.cs
@@ -134,8 +134,31 @@ namespace NexusForever.WorldServer.Game.Entity
         public bool IsSitting => currentChairGuid != null;
         private uint? currentChairGuid;
 
-        public bool SignatureEnabled = false; // TODO: Make configurable.
+        /// <summary>
+        /// Whether or not this <see cref="Player"/> is currently in a state after using an emote. Setting this to false will let all nearby entities know that the state has been reset.
+        /// </summary>
+        public bool IsEmoting 
+        {
+            get => isEmoting;
+            set
+            {
+                if (isEmoting && value == false)
+                {
+                    isEmoting = false;
+                    EnqueueToVisible(new ServerEntityEmote
+                    {
+                        EmotesId = 0,
+                        SourceUnitId = Guid
+                    });
+                    return;
+                }
 
+                isEmoting = value;
+            }
+        }
+        private bool isEmoting;
+
+        public bool SignatureEnabled = false; // TODO: Make configurable.
         public WorldSession Session { get; }
         public bool IsLoading { get; set; } = true;
 

--- a/Source/NexusForever.WorldServer/Game/Spell/SpellInfo.cs
+++ b/Source/NexusForever.WorldServer/Game/Spell/SpellInfo.cs
@@ -21,9 +21,11 @@ namespace NexusForever.WorldServer.Game.Spell
         public PrerequisiteEntry CasterPersistencePrerequisites { get; }
         public PrerequisiteEntry TargetPersistencePrerequisites { get; }
         public List<PrerequisiteEntry> PrerequisiteRunners { get; } = new List<PrerequisiteEntry>();
+        public Spell4VisualGroupEntry VisualGroup { get; }
 
         public List<TelegraphDamageEntry> Telegraphs { get; }
         public List<Spell4EffectsEntry> Effects { get; }
+        public List<Spell4VisualEntry> Visuals { get; } = new List<Spell4VisualEntry>();
 
         public SpellInfo(SpellBaseInfo spellBaseBaseInfo, Spell4Entry spell4Entry)
         {
@@ -40,12 +42,21 @@ namespace NexusForever.WorldServer.Game.Spell
             TargetCastPrerequisites        = GameTableManager.Instance.Prerequisite.GetEntry(spell4Entry.PrerequisiteIdTargetCast);
             CasterPersistencePrerequisites = GameTableManager.Instance.Prerequisite.GetEntry(spell4Entry.PrerequisiteIdCasterPersistence);
             TargetPersistencePrerequisites = GameTableManager.Instance.Prerequisite.GetEntry(spell4Entry.PrerequisiteIdTargetPersistence);
+            VisualGroup                    = GameTableManager.Instance.Spell4VisualGroup.GetEntry(spell4Entry.Spell4VisualGroupId);
 
             Telegraphs = GlobalSpellManager.Instance.GetTelegraphDamageEntries(spell4Entry.Id).ToList();
             Effects = GlobalSpellManager.Instance.GetSpell4EffectEntries(spell4Entry.Id).ToList();
 
             foreach (uint runnerId in spell4Entry.PrerequisiteIdRunners.Where(r => r != 0))
                 PrerequisiteRunners.Add(GameTableManager.Instance.Prerequisite.GetEntry(runnerId));
+
+            if (VisualGroup != null)
+                foreach (uint visual in VisualGroup.Spell4VisualIdVisuals.Where(i => i != 0).ToList())
+                {
+                    Spell4VisualEntry visualEntry = GameTableManager.Instance.Spell4Visual.GetEntry(visual);
+                    if (visualEntry != null)
+                        Visuals.Add(visualEntry);
+                }
         }
     }
 }

--- a/Source/NexusForever.WorldServer/Network/Message/Handler/EntityHandler.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Handler/EntityHandler.cs
@@ -24,6 +24,9 @@ namespace NexusForever.WorldServer.Network.Message.Handler
             if (session.Player.ControlGuid != session.Player.Guid)
                 mover = session.Player.GetVisible<WorldEntity>(session.Player.ControlGuid);
 
+            if (session.Player.IsEmoting)
+                session.Player.IsEmoting = false;
+
             foreach ((EntityCommand id, IEntityCommandModel command) in entityCommand.Commands)
             {
                 switch (command)

--- a/Source/NexusForever.WorldServer/Network/Message/Model/ServerEntityEmote.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Model/ServerEntityEmote.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+using NexusForever.Shared.Network;
+using NexusForever.Shared.Network.Message;
+using NexusForever.WorldServer.Network.Message.Model.Shared;
+using NexusForever.WorldServer.Game.Entity.Static;
+
+namespace NexusForever.WorldServer.Network.Message.Model
+{
+    [Message(GameMessageOpcode.ServerEntityEmote)]
+    public class ServerEntityEmote : IWritable
+    {
+        public ushort EmotesId { get; set; } // 14u
+        public uint Seed { get; set; }
+        public uint SourceUnitId { get; set; }
+        public uint TargetUnitId { get; set; }
+        public bool Targeted { get; set; }
+        public bool Silent { get; set; }
+
+        public void Write(GamePacketWriter writer)
+        {
+            writer.Write(EmotesId, 14u);
+            writer.Write(Seed);
+            writer.Write(SourceUnitId);
+            writer.Write(TargetUnitId);
+            writer.Write(Targeted);
+            writer.Write(Silent);
+        }
+    }
+}

--- a/Source/NexusForever.WorldServer/Network/Message/Model/ServerEntityVisualEffect.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Model/ServerEntityVisualEffect.cs
@@ -1,0 +1,30 @@
+﻿using NexusForever.Shared.Network;
+using NexusForever.Shared.Network.Message;
+using NexusForever.WorldServer.Game.Entity;
+
+namespace NexusForever.WorldServer.Network.Message.Model
+{
+
+    [Message(GameMessageOpcode.ServerEntityVisualEffect)]
+    public class ServerEntityVisualEffect : IWritable
+    {
+        public uint ServerUniqueId { get; set; }
+        public uint SourceUnitId { get; set; }
+        public uint VisualEffectId { get; set; } // 17u
+        public uint TimeElapsed { get; set; } // 17u
+        public uint Unknown0 { get; set; } // 17u
+        public uint Unknown1 { get; set; }
+        public Position SourceLocation { get; set; } = new Position();
+
+        public void Write(GamePacketWriter writer)
+        {
+            writer.Write(ServerUniqueId);
+            writer.Write(SourceUnitId);
+            writer.Write(VisualEffectId, 17u);
+            writer.Write(TimeElapsed, 17u);
+            writer.Write(Unknown0, 17u);
+            writer.Write(Unknown1);
+            SourceLocation.Write(writer);
+        }
+    }
+}


### PR DESCRIPTION
This fixes some of the bugs reported by community members around emotes. Namely: 
- no "targeting" support - where it would say "Soandso points at you." / "Soandso points at Thingy.".
- no animations played to other Players.
- certain emotes (usually ones without animation) would make the Player who used it invisible to other players until they did an emote that made them visible (usually one with an animation).

This also adds basic model animation support to spells. I have a feeling that this is probably not the full picture, but it works as a first step into having the entity animations on/during spells. Most of them already work, but there are some where the entity is crying or cheering, for example, that wasn't visible to other Players before now.