### PR TITLE
Housing/Core: Update client when deleting Decor from Crate

### DIFF
--- a/Source/NexusForever.WorldServer/Game/Map/ResidenceMap.cs
+++ b/Source/NexusForever.WorldServer/Game/Map/ResidenceMap.cs
@@ -421,6 +421,16 @@ namespace NexusForever.WorldServer.Game.Map
             residence.DecorDelete(decor);
 
             // TODO: send packet to remove from decor list
+            var residenceDecor = new ServerHousingResidenceDecor();
+            residenceDecor.DecorData.Add(new ServerHousingResidenceDecor.Decor
+            {
+                RealmId = WorldServer.RealmId,
+                ResidenceId = residence.Id,
+                DecorId = decor.DecorId,
+                DecorInfoId = 0
+            });
+
+            EnqueueToAll(residenceDecor);
         }
 
         /// <summary>


### PR DESCRIPTION
Dug through a bunch of sniffs and couldn't find any where a Player deleted something from the crate. I reversed the `ServerHousingResidenceDecor` handler and was able to determine the Client will "drop" the decor if the `DecorInfoId` is 0.
Tested this in game and was able to delete 1 or multiple items and it would update the Client appropriately.