### PR TITLE
Entity/RewardProperties: Account Tier based Reward Properties. Retail-like.

### DIFF
--- a/Source/NexusForever.Database.Auth/AuthContext.cs
+++ b/Source/NexusForever.Database.Auth/AuthContext.cs
@@ -849,6 +849,11 @@ namespace NexusForever.Database.Auth
                     {
                         Id   = 10000,
                         Name = "Other: InstantLogout"
+                    },
+                    new PermissionModel
+                    {
+                        Id   = 10001,
+                        Name = "Other: Signature"
                     });
             });
 

--- a/Source/NexusForever.Database.Auth/Migrations/20201119110054_RBACSignature.Designer.cs
+++ b/Source/NexusForever.Database.Auth/Migrations/20201119110054_RBACSignature.Designer.cs
@@ -2,15 +2,17 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NexusForever.Database.Auth;
 
 namespace NexusForever.Database.Auth.Migrations
 {
     [DbContext(typeof(AuthContext))]
-    partial class AuthContextModelSnapshot : ModelSnapshot
+    [Migration("20201119110054_RBACSignature")]
+    partial class RBACSignature
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Source/NexusForever.Database.Auth/Migrations/20201119110054_RBACSignature.cs
+++ b/Source/NexusForever.Database.Auth/Migrations/20201119110054_RBACSignature.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace NexusForever.Database.Auth.Migrations
+{
+    public partial class RBACSignature : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.InsertData(
+                table: "permission",
+                columns: new[] { "id", "name" },
+                values: new object[] { 10001u, "Other: Signature" });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 10001u);
+        }
+    }
+}

--- a/Source/NexusForever.Shared/GameTable/GameTableManager.cs
+++ b/Source/NexusForever.Shared/GameTable/GameTableManager.cs
@@ -458,7 +458,10 @@ namespace NexusForever.Shared.GameTable
         public GameTable<ResourceConversionEntry> ResourceConversion { get; private set; }
         public GameTable<ResourceConversionGroupEntry> ResourceConversionGroup { get; private set; }
         public GameTable<RewardPropertyEntry> RewardProperty { get; private set; }
+
+        [GameData]
         public GameTable<RewardPropertyPremiumModifierEntry> RewardPropertyPremiumModifier { get; private set; }
+
         public GameTable<RewardRotationContentEntry> RewardRotationContent { get; private set; }
         public GameTable<RewardRotationEssenceEntry> RewardRotationEssence { get; private set; }
         public GameTable<RewardRotationItemEntry> RewardRotationItem { get; private set; }

--- a/Source/NexusForever.Shared/GameTable/GameTableManager.cs
+++ b/Source/NexusForever.Shared/GameTable/GameTableManager.cs
@@ -457,6 +457,8 @@ namespace NexusForever.Shared.GameTable
         public GameTable<ReplaceableMaterialInfoEntry> ReplaceableMaterialInfo { get; private set; }
         public GameTable<ResourceConversionEntry> ResourceConversion { get; private set; }
         public GameTable<ResourceConversionGroupEntry> ResourceConversionGroup { get; private set; }
+
+        [GameData]
         public GameTable<RewardPropertyEntry> RewardProperty { get; private set; }
 
         [GameData]

--- a/Source/NexusForever.Shared/Network/Message/GameMessageOpcode.cs
+++ b/Source/NexusForever.Shared/Network/Message/GameMessageOpcode.cs
@@ -289,6 +289,7 @@ namespace NexusForever.Shared.Network.Message
         ServerAccountItemCooldownSet    = 0x0974,
         ServerAccountItemAdd            = 0x0975,
         ServerAccountItemsPending       = 0x0979,
+        ServerAccountTier               = 0x097F,
         ServerGenericUnlockList         = 0x0981,
         ServerGenericUnlock             = 0x0982,
         ServerGenericUnlockResult       = 0x0985,

--- a/Source/NexusForever.Shared/Network/Message/IBuildable.cs
+++ b/Source/NexusForever.Shared/Network/Message/IBuildable.cs
@@ -1,6 +1,6 @@
 ﻿namespace NexusForever.Shared.Network.Message
 {
-    public interface IBuildable<out T> where T : IWritable
+    public interface IBuildable<out T>
     {
         T Build();
     }

--- a/Source/NexusForever.WorldServer/Game/Entity/Player.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/Player.cs
@@ -183,7 +183,7 @@ namespace NexusForever.WorldServer.Game.Entity
             TimePlayedTotal = model.TimePlayedTotal;
             TimePlayedLevel = model.TimePlayedLevel;
 
-            Session.EntitlementManager.OnNewCharacter(model);
+            Session.EntitlementManager.Initialise(model);
 
             foreach (CharacterStatModel statModel in model.Stat)
                 stats.Add((Stat)statModel.Stat, new StatValue(statModel));
@@ -485,12 +485,6 @@ namespace NexusForever.WorldServer.Game.Entity
             Session.EnqueueMessageEncrypted(new ServerHousingNeighbors());
             Session.EnqueueMessageEncrypted(new Server00F1());
             SetControl(this);
-
-            // TODO: Move to Unlocks/Rewards Handler. A lot of these are tied to Entitlements which display in the character sheet, but don't actually unlock anything without this packet.
-            Session.EnqueueMessageEncrypted(new ServerRewardPropertySet
-            {
-                Variables = Session.EntitlementManager.GetRewardPropertiesNetworkMessage()
-            });
 
             CostumeManager.SendInitialPackets();
             

--- a/Source/NexusForever.WorldServer/Game/Entity/Player.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/Player.cs
@@ -183,6 +183,8 @@ namespace NexusForever.WorldServer.Game.Entity
             TimePlayedTotal = model.TimePlayedTotal;
             TimePlayedLevel = model.TimePlayedLevel;
 
+            Session.EntitlementManager.OnNewCharacter(model);
+
             foreach (CharacterStatModel statModel in model.Stat)
                 stats.Add((Stat)statModel.Stat, new StatValue(statModel));
 
@@ -203,8 +205,6 @@ namespace NexusForever.WorldServer.Game.Entity
             SupplySatchelManager    = new SupplySatchelManager(this, model);
             XpManager               = new XpManager(this, model);
             ReputationManager       = new ReputationManager(this, model);
-
-            Session.EntitlementManager.OnNewCharacter(model);
 
             // temp
             Properties.Add(Property.BaseHealth, new PropertyValue(Property.BaseHealth, 200f, 800f));
@@ -489,39 +489,7 @@ namespace NexusForever.WorldServer.Game.Entity
             // TODO: Move to Unlocks/Rewards Handler. A lot of these are tied to Entitlements which display in the character sheet, but don't actually unlock anything without this packet.
             Session.EnqueueMessageEncrypted(new ServerRewardPropertySet
             {
-                Variables = new List<ServerRewardPropertySet.RewardProperty>
-                {
-                    new ServerRewardPropertySet.RewardProperty
-                    {
-                        Id    = RewardProperty.CostumeSlots,
-                        Type  = 1,
-                        Value = CostumeManager.CostumeCap
-                    },
-                    new ServerRewardPropertySet.RewardProperty
-                    {
-                        Id    = RewardProperty.ExtraDecorSlots,
-                        Type  = 1,
-                        Value = 2000
-                    },
-                    new ServerRewardPropertySet.RewardProperty
-                    {
-                        Id    = RewardProperty.Trading,
-                        Type  = 1,
-                        Value = 1
-                    },
-                    new ServerRewardPropertySet.RewardProperty
-                    {
-                        Id    = RewardProperty.TradeskillMatStackLimit,
-                        Type  = 1,
-                        Value = 100
-                    },
-                    new ServerRewardPropertySet.RewardProperty
-                    {
-                        Id    = RewardProperty.TradeskillMatTrading,
-                        Type  = 1,
-                        Value = 1
-                    }
-                }
+                Variables = Session.EntitlementManager.GetRewardPropertiesNetworkMessage()
             });
 
             CostumeManager.SendInitialPackets();

--- a/Source/NexusForever.WorldServer/Game/Entity/RewardProperty.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/RewardProperty.cs
@@ -1,0 +1,104 @@
+﻿using NexusForever.Shared.GameTable.Model;
+using NexusForever.Shared.Network.Message;
+using NexusForever.WorldServer.Game.Entity.Static;
+using NexusForever.WorldServer.Network;
+using NexusForever.WorldServer.Network.Message.Model;
+using System;
+using System.Collections.Generic;
+
+namespace NexusForever.WorldServer.Game.Entity
+{
+    public class RewardProperty : IBuildable<ServerRewardPropertySet.RewardProperty>
+    {
+        public RewardPropertyType Type { get; }
+        public uint Data { get; }
+        public float Value { get; private set; }
+
+        private byte dataType;
+
+        /// <summary>
+        /// Create a <see cref="RewardProperty"/> with the provided <see cref="RewardPropertyPremiumModifierEntry"/>
+        /// </summary>
+        public RewardProperty(RewardPropertyPremiumModifierEntry entry)
+        {
+            Type = (RewardPropertyType)entry.RewardPropertyId;
+            Data = entry.RewardPropertyData;
+            dataType = (byte)(entry.RewardPropertyData > 0 ? 0 : 1);
+        }
+
+        /// <summary>
+        /// Adds data from the provided <see cref="RewardPropertyPremiumModifierEntry"/> to this <see cref="RewardProperty"/>. Should only be used when loading in to world.
+        /// </summary>
+        public void AddValue(RewardPropertyPremiumModifierEntry entry, EntitlementManager manager)
+        {
+            if (entry.ModifierValueInt > 0)
+                Value += entry.ModifierValueInt;
+
+            if (entry.ModifierValueFloat > 0 && entry.EntitlementIdModifierCount == 0)
+            {
+                Value += entry.ModifierValueFloat;
+
+                if (dataType != 0u)
+                    dataType = 2;
+            }
+
+            if (entry.EntitlementIdModifierCount > 0)
+            {
+                Value += manager.GetAccountEntitlement((EntitlementType)entry.EntitlementIdModifierCount)?.Amount ?? 0u;
+                Value += manager.GetCharacterEntitlement((EntitlementType)entry.EntitlementIdModifierCount)?.Amount ?? 0u;
+
+                // TODO: If the RewardProperty value is higher on Load that the Entitlement. Should we set the Entitlement to match? This is only necessary for things like Bank Slots (4 for Signature, 2 for Basic), Auction Slots, and Commodity Slots. Do we know if you subscribed, then unsubscribed, that you would keep those Bank Slots? Did they get greyed out and unusable?
+            }
+        }
+
+        /// <summary>
+        /// Adds to the current Value of this <see cref="RewardProperty"/>. If the <see cref="Player"/> is in World, it will also update them with the changes.
+        /// </summary>
+        public void AddValue(float value, Player player)
+        {
+            Value += value;
+
+            if (player.IsLoading)
+                return;
+
+            SendUpdate(player.Session);
+        }
+
+        /// <summary>
+        /// Sets the Value of this <see cref="RewardProperty"/>. This will overwrite all existing values.
+        /// </summary>
+        /// <remarks>Good for setting weekly Omnibit Caps with configuration.</remarks>
+        public void SetValue(float amount)
+        {
+            Value = amount;
+        }
+
+        /// <summary>
+        /// Returns a <see cref="ServerRewardPropertySet.RewardProperty"/> with the data from this <see cref="RewardProperty"/>.
+        /// </summary>
+        public ServerRewardPropertySet.RewardProperty Build()
+        {
+            return new ServerRewardPropertySet.RewardProperty
+            {
+                Id = Type,
+                Data = Data,
+                Type = dataType,
+                Value = Value,
+            };
+        }
+
+        /// <summary>
+        /// Sends <see cref="ServerRewardPropertySet"/> to the <see cref="WorldSession"/> with data from this <see cref="RewardProperty"/>.
+        /// </summary>
+        private void SendUpdate(WorldSession session)
+        {
+            session.EnqueueMessageEncrypted(new ServerRewardPropertySet
+            {
+                Variables = new List<ServerRewardPropertySet.RewardProperty>
+                {
+                    Build()
+                }
+            });
+        }
+    }
+}

--- a/Source/NexusForever.WorldServer/Game/Entity/RewardProperty.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/RewardProperty.cs
@@ -1,103 +1,70 @@
-﻿using NexusForever.Shared.GameTable.Model;
+﻿using System.Collections.Generic;
+using System.Linq;
+using NexusForever.Shared.GameTable.Model;
 using NexusForever.Shared.Network.Message;
 using NexusForever.WorldServer.Game.Entity.Static;
-using NexusForever.WorldServer.Network;
 using NexusForever.WorldServer.Network.Message.Model;
-using System;
-using System.Collections.Generic;
 
 namespace NexusForever.WorldServer.Game.Entity
 {
-    public class RewardProperty : IBuildable<ServerRewardPropertySet.RewardProperty>
+    public class RewardProperty : IBuildable<IEnumerable<ServerRewardPropertySet.RewardProperty>>
     {
-        public RewardPropertyType Type { get; }
-        public uint Data { get; }
-        public float Value { get; private set; }
+        public RewardPropertyEntry Entry { get; }
 
-        private byte dataType;
+        private readonly Dictionary<uint, float> values = new Dictionary<uint, float>();
 
         /// <summary>
-        /// Create a <see cref="RewardProperty"/> with the provided <see cref="RewardPropertyPremiumModifierEntry"/>
+        /// Create a new <see cref="RewardProperty"/> with the supplied <see cref="RewardPropertyEntry"/>.
         /// </summary>
-        public RewardProperty(RewardPropertyPremiumModifierEntry entry)
+        public RewardProperty(RewardPropertyEntry entry)
         {
-            Type = (RewardPropertyType)entry.RewardPropertyId;
-            Data = entry.RewardPropertyData;
-            dataType = (byte)(entry.RewardPropertyData > 0 ? 0 : 1);
+            Entry = entry;
         }
 
         /// <summary>
-        /// Adds data from the provided <see cref="RewardPropertyPremiumModifierEntry"/> to this <see cref="RewardProperty"/>. Should only be used when loading in to world.
+        /// Update the value of the supplied data value.
         /// </summary>
-        public void AddValue(RewardPropertyPremiumModifierEntry entry, EntitlementManager manager)
+        /// <remarks>
+        /// A positive value will increment and a negative value will decrement the value.
+        /// </remarks>
+        public void UpdateValue(uint data, float value)
         {
-            if (entry.ModifierValueInt > 0)
-                Value += entry.ModifierValueInt;
+            if (!values.ContainsKey(data))
+                values.Add(data, value);
+            else
+                values[data] += value;
+        }
 
-            if (entry.ModifierValueFloat > 0 && entry.EntitlementIdModifierCount == 0)
+        /// <summary>
+        /// Set the value of the supplied data value.
+        /// </summary>
+        public void SetValue(uint data, float value)
+        {
+            if (!values.ContainsKey(data))
+                values.Add(data, value);
+            else
+                values[data] = value;
+        }
+
+        /// <summary>
+        /// Get the value of the supplied data value.
+        /// </summary>
+        public float? GetValue(uint data)
+        {
+            return values.TryGetValue(data, out float value) ? value : (float?)null;
+        }
+
+        /// <summary>
+        /// Build the network model <see cref="ServerRewardPropertySet.RewardProperty"/> for this <see cref="RewardProperty"/>.
+        /// </summary>
+        public IEnumerable<ServerRewardPropertySet.RewardProperty> Build()
+        {
+            return values.Select(p => new ServerRewardPropertySet.RewardProperty
             {
-                Value += entry.ModifierValueFloat;
-
-                if (dataType != 0u)
-                    dataType = 2;
-            }
-
-            if (entry.EntitlementIdModifierCount > 0)
-            {
-                Value += manager.GetAccountEntitlement((EntitlementType)entry.EntitlementIdModifierCount)?.Amount ?? 0u;
-                Value += manager.GetCharacterEntitlement((EntitlementType)entry.EntitlementIdModifierCount)?.Amount ?? 0u;
-
-                // TODO: If the RewardProperty value is higher on Load that the Entitlement. Should we set the Entitlement to match? This is only necessary for things like Bank Slots (4 for Signature, 2 for Basic), Auction Slots, and Commodity Slots. Do we know if you subscribed, then unsubscribed, that you would keep those Bank Slots? Did they get greyed out and unusable?
-            }
-        }
-
-        /// <summary>
-        /// Adds to the current Value of this <see cref="RewardProperty"/>. If the <see cref="Player"/> is in World, it will also update them with the changes.
-        /// </summary>
-        public void AddValue(float value, Player player)
-        {
-            Value += value;
-
-            if (player.IsLoading)
-                return;
-
-            SendUpdate(player.Session);
-        }
-
-        /// <summary>
-        /// Sets the Value of this <see cref="RewardProperty"/>. This will overwrite all existing values.
-        /// </summary>
-        /// <remarks>Good for setting weekly Omnibit Caps with configuration.</remarks>
-        public void SetValue(float amount)
-        {
-            Value = amount;
-        }
-
-        /// <summary>
-        /// Returns a <see cref="ServerRewardPropertySet.RewardProperty"/> with the data from this <see cref="RewardProperty"/>.
-        /// </summary>
-        public ServerRewardPropertySet.RewardProperty Build()
-        {
-            return new ServerRewardPropertySet.RewardProperty
-            {
-                Id = Type,
-                Data = Data,
-                Type = dataType,
-                Value = Value,
-            };
-        }
-
-        /// <summary>
-        /// Sends <see cref="ServerRewardPropertySet"/> to the <see cref="WorldSession"/> with data from this <see cref="RewardProperty"/>.
-        /// </summary>
-        private void SendUpdate(WorldSession session)
-        {
-            session.EnqueueMessageEncrypted(new ServerRewardPropertySet
-            {
-                Variables = new List<ServerRewardPropertySet.RewardProperty>
-                {
-                    Build()
-                }
+                Id    = (RewardPropertyType)Entry.Id,
+                Type  = (RewardPropertyModifierValueType)Entry.RewardModifierValueTypeEnum,
+                Data  = p.Key,
+                Value = p.Value
             });
         }
     }

--- a/Source/NexusForever.WorldServer/Game/Entity/Static/RewardPropertyModifierValueType.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/Static/RewardPropertyModifierValueType.cs
@@ -1,0 +1,9 @@
+﻿namespace NexusForever.WorldServer.Game.Entity.Static
+{
+    public enum RewardPropertyModifierValueType
+    {
+        AdditiveScalar,
+        Discrete,
+        MultiplicativeScalar
+    }
+}

--- a/Source/NexusForever.WorldServer/Game/Entity/Static/RewardPropertyPremiumModiferFlags.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/Static/RewardPropertyPremiumModiferFlags.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace NexusForever.WorldServer.Game.Entity.Static
+{
+    [Flags]
+    public enum RewardPropertyPremiumModiferFlags
+    {
+        None        = 0x0,
+        // this determines if a modifier entry falls through to the next tier
+        // if this is set for tier 0 it will be included for tier 1 as well
+        FallThrough = 0x1
+    }
+}

--- a/Source/NexusForever.WorldServer/Game/Entity/Static/RewardPropertyType.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/Static/RewardPropertyType.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// Replication of the CodeEnumRewardProperty enum from the client. Gaps for missing numbers.
     /// </summary>
-    public enum RewardProperty
+    public enum RewardPropertyType
     {
         XP                          = 1,
         CurrencyType                = 2,

--- a/Source/NexusForever.WorldServer/Game/Entity/SupplySatchelManager.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/SupplySatchelManager.cs
@@ -6,6 +6,7 @@ using NexusForever.Database.Character;
 using NexusForever.Database.Character.Model;
 using NexusForever.Shared.GameTable;
 using NexusForever.Shared.GameTable.Model;
+using NexusForever.WorldServer.Game.Entity.Static;
 using NexusForever.WorldServer.Network.Message.Model;
 
 namespace NexusForever.WorldServer.Game.Entity
@@ -19,9 +20,7 @@ namespace NexusForever.WorldServer.Game.Entity
         public SupplySatchelManager(Player owner, CharacterModel model)
         {
             player = owner;
-
-            // TODO: Make this configurable and powered by the same entry that would power the RewardProperty
-            maximumStackAmount = (uint)owner.Session.EntitlementManager.GetRewardProperty(Static.RewardPropertyType.TradeskillMatStackLimit, 0)?.Value;
+            maximumStackAmount = (uint)(owner.Session.EntitlementManager.GetRewardProperty(RewardPropertyType.TradeskillMatStackLimit)?.GetValue(0u) ?? 0f);
 
             foreach (CharacterTradeskillMaterialModel tradeskillMaterial in model.TradeskillMaterials)
                 tradeskillMaterials.Add(tradeskillMaterial.MaterialId, new TradeskillMaterial(tradeskillMaterial));

--- a/Source/NexusForever.WorldServer/Game/Entity/SupplySatchelManager.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/SupplySatchelManager.cs
@@ -13,7 +13,7 @@ namespace NexusForever.WorldServer.Game.Entity
     public class SupplySatchelManager: IEnumerable<TradeskillMaterial>, ISaveCharacter
     {
         private readonly Player player;
-        private readonly uint maximumStackAmount;
+        private readonly uint maximumStackAmount = 100;
         private readonly Dictionary</* materialId */ushort, TradeskillMaterial> tradeskillMaterials = new Dictionary<ushort, TradeskillMaterial>();
 
         public SupplySatchelManager(Player owner, CharacterModel model)
@@ -21,7 +21,7 @@ namespace NexusForever.WorldServer.Game.Entity
             player = owner;
 
             // TODO: Make this configurable and powered by the same entry that would power the RewardProperty
-            maximumStackAmount = 100u;
+            maximumStackAmount = (uint)owner.Session.EntitlementManager.GetRewardProperty(Static.RewardPropertyType.TradeskillMatStackLimit, 0)?.Value;
 
             foreach (CharacterTradeskillMaterialModel tradeskillMaterial in model.TradeskillMaterials)
                 tradeskillMaterials.Add(tradeskillMaterial.MaterialId, new TradeskillMaterial(tradeskillMaterial));

--- a/Source/NexusForever.WorldServer/Game/RBAC/Static/Permission.cs
+++ b/Source/NexusForever.WorldServer/Game/RBAC/Static/Permission.cs
@@ -159,6 +159,7 @@
         ReputationUpdate            = 99,
 
         // non command permissions
-        InstantLogout               = 10000
+        InstantLogout               = 10000,
+        Signature                   = 10001
     }
 }

--- a/Source/NexusForever.WorldServer/Game/Static/AccountTier.cs
+++ b/Source/NexusForever.WorldServer/Game/Static/AccountTier.cs
@@ -1,0 +1,8 @@
+﻿namespace NexusForever.WorldServer.Game.Static
+{
+    public enum AccountTier
+    {
+        Basic,
+        Signature
+    }
+}

--- a/Source/NexusForever.WorldServer/Game/Static/PremiumSystem.cs
+++ b/Source/NexusForever.WorldServer/Game/Static/PremiumSystem.cs
@@ -1,0 +1,9 @@
+﻿namespace NexusForever.WorldServer.Game.Static
+{
+    public enum PremiumSystem
+    {
+        None,
+        Hybrid,
+        VIP
+    }
+}

--- a/Source/NexusForever.WorldServer/Network/Message/Handler/CharacterHandler.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Handler/CharacterHandler.cs
@@ -137,6 +137,10 @@ namespace NexusForever.WorldServer.Network.Message.Handler
                         })
                         .ToList()
                 });
+                session.EnqueueMessageEncrypted(new ServerAccountTier
+                {
+                    Tier = session.AccountTier
+                });
 
                 var serverCharacterList = new ServerCharacterList
                 {

--- a/Source/NexusForever.WorldServer/Network/Message/Model/ServerAccountTier.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Model/ServerAccountTier.cs
@@ -1,0 +1,17 @@
+using NexusForever.Shared.Network;
+using NexusForever.Shared.Network.Message;
+using NexusForever.WorldServer.Game.Static;
+
+namespace NexusForever.WorldServer.Network.Message.Model
+{
+    [Message(GameMessageOpcode.ServerAccountTier)]
+    public class ServerAccountTier : IWritable
+    {
+        public AccountTier Tier { get; set; } // 5
+
+        public void Write(GamePacketWriter writer)
+        {
+            writer.Write(Tier, 5u);
+        }
+    }
+}

--- a/Source/NexusForever.WorldServer/Network/Message/Model/ServerRewardPropertySet.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Model/ServerRewardPropertySet.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using NexusForever.Shared.Network;
 using NexusForever.Shared.Network.Message;
-using RewardPropertyEnum = NexusForever.WorldServer.Game.Entity.Static.RewardPropertyType;
+using NexusForever.WorldServer.Game.Entity.Static;
 
 namespace NexusForever.WorldServer.Network.Message.Model
 {
@@ -36,9 +36,9 @@ namespace NexusForever.WorldServer.Network.Message.Model
                 }
             }
 
-            public RewardPropertyEnum Id { get; set; }
+            public RewardPropertyType Id { get; set; }
             public uint Data { get; set; }
-            public byte Type { get; set; }
+            public RewardPropertyModifierValueType Type { get; set; }
             public float Value { get; set; }
             public List<UnknownStruct> UnknownStructs { get; set; } = new List<UnknownStruct>();
 
@@ -50,11 +50,11 @@ namespace NexusForever.WorldServer.Network.Message.Model
 
                 switch (Type)
                 {
-                    case 0:
-                    case 2:
+                    case RewardPropertyModifierValueType.AdditiveScalar:
+                    case RewardPropertyModifierValueType.MultiplicativeScalar:
                         writer.Write(Value);
                         break;
-                    case 1:
+                    case RewardPropertyModifierValueType.Discrete:
                         writer.Write((uint)Value);
                         break;
                 }
@@ -64,12 +64,12 @@ namespace NexusForever.WorldServer.Network.Message.Model
             }
         }
 
-        public List<RewardProperty> Variables { get; set; } = new List<RewardProperty>();
+        public List<RewardProperty> Properties { get; set; } = new List<RewardProperty>();
 
         public void Write(GamePacketWriter writer)
         {
-            writer.Write((byte)Variables.Count);
-            Variables.ForEach(u => u.Write(writer));
+            writer.Write((byte)Properties.Count);
+            Properties.ForEach(u => u.Write(writer));
         }
     }
 }

--- a/Source/NexusForever.WorldServer/Network/Message/Model/ServerRewardPropertySet.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Model/ServerRewardPropertySet.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using NexusForever.Shared.Network;
 using NexusForever.Shared.Network.Message;
-using RewardPropertyEnum = NexusForever.WorldServer.Game.Entity.Static.RewardProperty;
+using RewardPropertyEnum = NexusForever.WorldServer.Game.Entity.Static.RewardPropertyType;
 
 namespace NexusForever.WorldServer.Network.Message.Model
 {
@@ -10,14 +10,42 @@ namespace NexusForever.WorldServer.Network.Message.Model
     {
         public class RewardProperty : IWritable
         {
+            public class UnknownStruct : IWritable
+            {
+                public byte Unknown0 { get; set; } // 4
+                public uint Unknown1 { get; set; }
+                public byte Type { get; set; }
+                public float Value { get; set; }
+
+                public void Write(GamePacketWriter writer)
+                {
+                    writer.Write(Unknown0, 4u);
+                    writer.Write(Unknown1);
+                    writer.Write(Type, 2u);
+
+                    switch (Type)
+                    {
+                        case 0:
+                        case 2:
+                            writer.Write(Value);
+                            break;
+                        case 1:
+                            writer.Write((uint)Value);
+                            break;
+                    }
+                }
+            }
+
             public RewardPropertyEnum Id { get; set; }
+            public uint Data { get; set; }
             public byte Type { get; set; }
             public float Value { get; set; }
+            public List<UnknownStruct> UnknownStructs { get; set; } = new List<UnknownStruct>();
 
             public void Write(GamePacketWriter writer)
             {
                 writer.Write(Id, 6u);
-                writer.Write(0u);
+                writer.Write(Data);
                 writer.Write(Type, 2u);
 
                 switch (Type)
@@ -31,7 +59,8 @@ namespace NexusForever.WorldServer.Network.Message.Model
                         break;
                 }
 
-                writer.Write((byte)0);
+                writer.Write(UnknownStructs.Count, 8u);
+                UnknownStructs.ForEach(u => u.Write(writer));
             }
         }
 

--- a/Source/NexusForever.WorldServer/Network/WorldSession.cs
+++ b/Source/NexusForever.WorldServer/Network/WorldSession.cs
@@ -12,6 +12,7 @@ using NexusForever.Shared.Network.Packet;
 using NexusForever.WorldServer.Game.RBAC;
 using NexusForever.WorldServer.Game.Account;
 using NexusForever.WorldServer.Game.Entity;
+using NexusForever.WorldServer.Game.RBAC.Static;
 using NexusForever.WorldServer.Game.Static;
 using NexusForever.WorldServer.Network.Message.Model;
 
@@ -29,8 +30,7 @@ namespace NexusForever.WorldServer.Network
         public AccountCurrencyManager AccountCurrencyManager { get; private set; }
         public EntitlementManager EntitlementManager { get; private set; }
 
-        // TODO: Add Account Tiers to the Database?
-        public AccountTier AccountTier = (AccountTier)ConfigurationManager<WorldServerConfiguration>.Instance.Config.DefaultAccountTier;
+        public AccountTier AccountTier => AccountRbacManager.HasPermission(Permission.Signature) ? AccountTier.Signature : AccountTier.Basic;
 
         public override void OnAccept(Socket newSocket)
         {

--- a/Source/NexusForever.WorldServer/Network/WorldSession.cs
+++ b/Source/NexusForever.WorldServer/Network/WorldSession.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net.Sockets;
 using NexusForever.Database.Auth.Model;
 using NexusForever.Database.Character.Model;
+using NexusForever.Shared.Configuration;
 using NexusForever.Shared.Cryptography;
 using NexusForever.Shared.Network;
 using NexusForever.Shared.Network.Message;
@@ -11,6 +12,7 @@ using NexusForever.Shared.Network.Packet;
 using NexusForever.WorldServer.Game.RBAC;
 using NexusForever.WorldServer.Game.Account;
 using NexusForever.WorldServer.Game.Entity;
+using NexusForever.WorldServer.Game.Static;
 using NexusForever.WorldServer.Network.Message.Model;
 
 namespace NexusForever.WorldServer.Network
@@ -26,6 +28,9 @@ namespace NexusForever.WorldServer.Network
         public GenericUnlockManager GenericUnlockManager { get; private set; }
         public AccountCurrencyManager AccountCurrencyManager { get; private set; }
         public EntitlementManager EntitlementManager { get; private set; }
+
+        // TODO: Add Account Tiers to the Database?
+        public AccountTier AccountTier = (AccountTier)ConfigurationManager<WorldServerConfiguration>.Instance.Config.DefaultAccountTier;
 
         public override void OnAccept(Socket newSocket)
         {

--- a/Source/NexusForever.WorldServer/WorldServer.example.json
+++ b/Source/NexusForever.WorldServer/WorldServer.example.json
@@ -35,6 +35,5 @@
     "RealmId": 1,
     "MessageOfTheDay": "Welcome to this NexusForever server!",
     "LengthOfInGameDay": 12600,
-    "CrossFactionChat": true,
-    "DefaultAccountTier":  0
+    "CrossFactionChat": true
 }

--- a/Source/NexusForever.WorldServer/WorldServer.example.json
+++ b/Source/NexusForever.WorldServer/WorldServer.example.json
@@ -35,5 +35,6 @@
     "RealmId": 1,
     "MessageOfTheDay": "Welcome to this NexusForever server!",
     "LengthOfInGameDay": 12600,
-    "CrossFactionChat":  true
+    "CrossFactionChat": true,
+    "DefaultAccountTier":  0
 }

--- a/Source/NexusForever.WorldServer/WorldServerConfiguration.cs
+++ b/Source/NexusForever.WorldServer/WorldServerConfiguration.cs
@@ -23,6 +23,5 @@ namespace NexusForever.WorldServer
         public string MessageOfTheDay { get; set; }
         public uint LengthOfInGameDay { get; set; }
         public bool CrossFactionChat { get; set; } = true;
-        public byte DefaultAccountTier { get; set; }
     }
 }

--- a/Source/NexusForever.WorldServer/WorldServerConfiguration.cs
+++ b/Source/NexusForever.WorldServer/WorldServerConfiguration.cs
@@ -23,5 +23,6 @@ namespace NexusForever.WorldServer
         public string MessageOfTheDay { get; set; }
         public uint LengthOfInGameDay { get; set; }
         public bool CrossFactionChat { get; set; } = true;
+        public byte DefaultAccountTier { get; set; }
     }
 }


### PR DESCRIPTION
This provides the necessary functionality to send unlocks to the client based on their Account Tier. The Account Tier itself is unimportant for the purpose of this feature. My goal was to make sure that we were sending things like Guild/Circle functionality, Bag Slots, Bank Slots, Auction and Commodity Counts appropriately. The Game Tables have this data available in it, so I am using them to generate the necessary properties.
In addition, the EntitlementManager can now be used to update the Client immediately. When I "purchase" a Costume slot, it is immediately reflected in my Character Pane without relog/zone. 

This was necessary work to get Store Purchasing working. This PR, #272, #273, and #275, are all necessary for Store Purchases to work. Outside of the added functionality, with the Store Purchasing, the majority of "Account features" should be complete.