### PR TITLE
Entity/Costumes: Fix unused Costume Slots hiding worn items

### DIFF
--- a/Source/NexusForever.WorldServer/Game/Entity/Inventory.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/Inventory.cs
@@ -143,7 +143,7 @@ namespace NexusForever.WorldServer.Game.Entity
             return new ItemVisual
             {
                 Slot      = itemSlot,
-                DisplayId = Item.GetDisplayId(costumeItem != null ? costumeItem.Entry : item?.Entry),
+                DisplayId = Item.GetDisplayId(costumeItem?.Entry != null ? costumeItem.Entry : item?.Entry),
                 DyeData   = costumeItem?.DyeData ?? 0
             };
         }


### PR DESCRIPTION
This resolves the issue where a costume's empty slot removes the Worn Item's appearance.