### PR TITLE
Prerequisite/Checks: Checks Update - April 2020

### DIFF
--- a/Source/NexusForever.WorldServer/Game/AssetManager.cs
+++ b/Source/NexusForever.WorldServer/Game/AssetManager.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Reflection;
 using NexusForever.Database.World.Model;
 using NexusForever.Shared;
@@ -139,6 +140,15 @@ namespace NexusForever.WorldServer.Game
 
         private void CacheCreatureTargetGroups()
         {
+            List<TargetGroupType> acceptedTypes = new List<TargetGroupType>
+            {
+                TargetGroupType.OtherTargetGroup,
+                TargetGroupType.OtherTargetGroup2,
+            };
+            List<TargetGroupEntry> tgEntries = GameTableManager.Instance.TargetGroup.Entries
+                        .Where(x => acceptedTypes.Contains((TargetGroupType)x.Type))
+                        .ToList();
+
             var entries = ImmutableDictionary.CreateBuilder<uint, List<uint>>();
             foreach (TargetGroupEntry entry in GameTableManager.Instance.TargetGroup.Entries)
             {
@@ -153,6 +163,17 @@ namespace NexusForever.WorldServer.Game
                     entries[creatureId].Add(entry.Id);
                 }
             }
+
+            // Add TargetGroup Ids which target the Creature's TargetGroup Ids
+            foreach ((uint creatureId, List<uint> targetGroups) in entries.ToList())
+                foreach (uint targetGroupId in targetGroups.ToList())
+                    foreach (TargetGroupEntry tgEntry in tgEntries)
+                    {
+                        if (!tgEntry.DataEntries.Contains(targetGroupId))
+                            continue;
+
+                        entries[creatureId].Add(tgEntry.Id);
+                    }
 
             creatureAssociatedTargetGroups = entries.ToImmutableDictionary(e => e.Key, e => e.Value.ToImmutableList());
         }

--- a/Source/NexusForever.WorldServer/Game/Entity/QuestManager.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/QuestManager.cs
@@ -247,10 +247,14 @@ namespace NexusForever.WorldServer.Game.Entity
             if (player.Level < info.Entry.PrerequisiteLevel)
                 return false;
 
+            bool prequestCheckPassed = true;
             // ReSharper disable once PossibleInvalidCastExceptionInForeachLoop
             foreach (ushort questId in info.Entry.PrerequisiteQuests.Where(q => q != 0u))
                 if (GetQuestState(questId) != QuestState.Completed)
-                    return false;
+                    prequestCheckPassed = false;
+
+            if (!prequestCheckPassed)
+                return false;
 
             if (info.Entry.PrerequisiteId != 0u && !PrerequisiteManager.Instance.Meets(player, info.Entry.PrerequisiteId))
                 return false;

--- a/Source/NexusForever.WorldServer/Game/Prerequisite/PrerequisiteChecks.cs
+++ b/Source/NexusForever.WorldServer/Game/Prerequisite/PrerequisiteChecks.cs
@@ -1,6 +1,7 @@
 ﻿using NexusForever.WorldServer.Game.Entity;
 using NexusForever.WorldServer.Game.Entity.Static;
 using NexusForever.WorldServer.Game.Prerequisite.Static;
+using NexusForever.WorldServer.Game.Quest.Static;
 
 namespace NexusForever.WorldServer.Game.Prerequisite
 {
@@ -11,6 +12,18 @@ namespace NexusForever.WorldServer.Game.Prerequisite
         {
             switch (comparison)
             {
+                case PrerequisiteComparison.Equal:
+                    return player.Level == value;
+                case PrerequisiteComparison.NotEqual:
+                    return player.Level != value;
+                case PrerequisiteComparison.GreaterThan:
+                    return player.Level > value;
+                case PrerequisiteComparison.GreaterThanOrEqual:
+                    return player.Level >= value;
+                case PrerequisiteComparison.LessThan:
+                    return player.Level < value;
+                case PrerequisiteComparison.LessThanOrEqual:
+                    return player.Level <= value;
                 default:
                     log.Warn($"Unhandled PrerequisiteComparison {comparison} for {PrerequisiteType.Level}!");
                     return true;
@@ -37,9 +50,13 @@ namespace NexusForever.WorldServer.Game.Prerequisite
         {
             switch (comparison)
             {
+                case PrerequisiteComparison.Equal:
+                    return player.Class == (Class)value;
+                case PrerequisiteComparison.NotEqual:
+                    return player.Class != (Class)value;
                 default:
                     log.Warn($"Unhandled PrerequisiteComparison {comparison} for {PrerequisiteType.Class}!");
-                    return true;
+                    return false;
             }
         }
 
@@ -48,8 +65,10 @@ namespace NexusForever.WorldServer.Game.Prerequisite
         {
             switch (comparison)
             {
-                case PrerequisiteComparison.Equal: // Active or Completed
-                    return player.QuestManager.GetQuestState((ushort)objectId) == null;
+                case PrerequisiteComparison.Equal:
+                    return player.QuestManager.GetQuestState((ushort)objectId) == (QuestState)value;
+                case PrerequisiteComparison.NotEqual:
+                    return player.QuestManager.GetQuestState((ushort)objectId) != (QuestState)value;
                 default:
                     log.Warn($"Unhandled PrerequisiteComparison {comparison} for {PrerequisiteType.Quest}!");
                     return false;
@@ -62,7 +81,9 @@ namespace NexusForever.WorldServer.Game.Prerequisite
             switch (comparison)
             {
                 case PrerequisiteComparison.Equal:
-                    return player.PathManager.IsPathActive((Path)value);
+                    return player.PathManager.IsPathActive((Path)value) == true;
+                case PrerequisiteComparison.NotEqual:
+                    return player.PathManager.IsPathActive((Path)value) == false;
                 default:
                     log.Warn($"Unhandled PrerequisiteComparison {comparison} for {PrerequisiteType.Path}!");
 
@@ -81,6 +102,51 @@ namespace NexusForever.WorldServer.Game.Prerequisite
                     return player.AchievementManager.HasCompletedAchievement((ushort)objectId);
                 default:
                     log.Warn($"Unhandled PrerequisiteComparison {comparison} for {PrerequisiteType.Achievement}!");
+                    return false;
+            }
+        }
+
+        [PrerequisiteCheck(PrerequisiteType.ItemProficiency)]
+        private static bool PrerequisiteCheckItemProficiency(Player player, PrerequisiteComparison comparison, uint value, uint objectId)
+        {
+            switch (comparison)
+            {
+                case PrerequisiteComparison.NotEqual:
+                    return (player.GetItemProficiencies() & (ItemProficiency)value) == 0;
+                case PrerequisiteComparison.Equal:
+                    return (player.GetItemProficiencies() & (ItemProficiency)value) != 0;
+                default:
+                    log.Warn($"Unhandled PrerequisiteComparison {comparison} for {PrerequisiteType.Achievement}!");
+                    return false;
+            }
+        }
+
+        [PrerequisiteCheck(PrerequisiteType.Gender)]
+        private static bool PrerequisiteCheckGender(Player player, PrerequisiteComparison comparison, uint value, uint objectId)
+        {
+            switch (comparison)
+            {
+                case PrerequisiteComparison.NotEqual:
+                    return player.Sex != (Sex)value;
+                case PrerequisiteComparison.Equal:
+                    return player.Sex == (Sex)value;
+                default:
+                    log.Warn($"Unhandled PrerequisiteComparison {comparison} for {PrerequisiteType.Gender}!");
+                    return false;
+            }
+        }
+
+        [PrerequisiteCheck(PrerequisiteType.Prerequisite)]
+        private static bool PrerequisiteCheckPrerequisite(Player player, PrerequisiteComparison comparison, uint value, uint objectId)
+        {
+            switch (comparison)
+            {
+                case PrerequisiteComparison.NotEqual:
+                    return Instance.Meets(player, objectId) == false;
+                case PrerequisiteComparison.Equal:
+                    return Instance.Meets(player, objectId) == true;
+                default:
+                    log.Warn($"Unhandled PrerequisiteComparison {comparison} for {PrerequisiteType.Prerequisite}!");
                     return false;
             }
         }

--- a/Source/NexusForever.WorldServer/Game/Prerequisite/Static/PrerequisiteComparison.cs
+++ b/Source/NexusForever.WorldServer/Game/Prerequisite/Static/PrerequisiteComparison.cs
@@ -4,9 +4,9 @@
     {
         Equal    = 1,
         NotEqual = 2,
-        LessThan = 3,
-        LessThanOrEqual = 4,
-        GreaterThan = 5,
-        GreaterThanOrEqual = 6
+        GreaterThan = 3,
+        GreaterThanOrEqual = 4,
+        LessThan = 5,
+        LessThanOrEqual = 6
     }
 }

--- a/Source/NexusForever.WorldServer/Game/Prerequisite/Static/PrerequisiteType.cs
+++ b/Source/NexusForever.WorldServer/Game/Prerequisite/Static/PrerequisiteType.cs
@@ -3,15 +3,18 @@
     // TODO: name these from PrerequisiteType.tbl error messages
     public enum PrerequisiteType
     {
-        None        = 0,
-        Level       = 1,
-        Race        = 2,
-        Class       = 3,
-        Faction     = 4,
-        Reputation  = 5,
-        Quest       = 6,
-        Achievement = 7,
-        Path        = 52,
-        SpellBaseId = 214,
+        None            = 0,
+        Level           = 1,
+        Race            = 2,
+        Class           = 3,
+        Faction         = 4,
+        Reputation      = 5,
+        Quest           = 6,
+        Achievement     = 7,
+        ItemProficiency = 8,
+        Gender          = 10,
+        Prerequisite    = 11,
+        Path            = 52,
+        SpellBaseId     = 214,
     }
 }

--- a/Source/NexusForever.WorldServer/Game/Quest/Static/TargetGroupType.cs
+++ b/Source/NexusForever.WorldServer/Game/Quest/Static/TargetGroupType.cs
@@ -10,7 +10,7 @@
         Unknown7            = 7,
         Unknown9            = 9,
         OtherTargetGroup    = 10, // This is used to target other TargetGroup(s) data
-        Unknown11           = 11,
+        OtherTargetGroup2   = 11, // Target other TargetGroup(s) - Used in kill quest.
         CreatureRaceIdGroup = 12, // This targets the Creature2Entry.RaceId
         Unknown13           = 13
     }


### PR DESCRIPTION
- Includes TargetGroup expansion to include TargetGroupType 10 & 11 (which are TargetGroups targeting other TargetGroups) for the existing Creature TargetGroup Cache.
- Includes update for `QuestManager.MeetsPrerequisites` check. The preq_quest values are an OR check.

I went through a bunch of different "numerical range" checks that are listed after my research (https://hackmd.io/@kirmmin/r1DyU2uPI#Prerequisites) and confirmed that all the ones I checked actually inverted GreaterThan/LessThan. It wanted things to be Greater Than or Equal To when Comparison Id 4 was being used. I'm doing my best to make sure I add as much PreReq support as we go, and figured I'd adjust the Enum now and, if we run into issues later, we can investigate. The investigation I did involved over 50 quests through Northern Wilds and Levian Bay.