### PR TITLE
Quests/Core: Checklist quests support - WIP

### DIFF
--- a/Source/NexusForever.Database.Auth/AuthContext.cs
+++ b/Source/NexusForever.Database.Auth/AuthContext.cs
@@ -849,6 +849,11 @@ namespace NexusForever.Database.Auth
                     {
                         Id   = 10000,
                         Name = "Other: InstantLogout"
+                    },
+                    new PermissionModel
+                    {
+                        Id   = 105,
+                        Name = "Command: QuestActivate"
                     });
             });
 

--- a/Source/NexusForever.Database.Auth/Migrations/20200929013959_QuestActivateCommand.Designer.cs
+++ b/Source/NexusForever.Database.Auth/Migrations/20200929013959_QuestActivateCommand.Designer.cs
@@ -2,15 +2,17 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NexusForever.Database.Auth;
 
 namespace NexusForever.Database.Auth.Migrations
 {
     [DbContext(typeof(AuthContext))]
-    partial class AuthContextModelSnapshot : ModelSnapshot
+    [Migration("20200929013959_QuestActivateCommand")]
+    partial class QuestActivateCommand
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Source/NexusForever.Database.Auth/Migrations/20200929013959_QuestActivateCommand.cs
+++ b/Source/NexusForever.Database.Auth/Migrations/20200929013959_QuestActivateCommand.cs
@@ -1,0 +1,1479 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace NexusForever.Database.Auth.Migrations
+{
+    public partial class QuestActivateCommand : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 1u,
+                column: "name",
+                value: "Category: Account");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 2u,
+                column: "name",
+                value: "Command: AccountCreate");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 3u,
+                column: "name",
+                value: "Command: AccountDelete");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 4u,
+                column: "name",
+                value: "Category: Help");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 5u,
+                column: "name",
+                value: "Command: CharacterSave");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 6u,
+                column: "name",
+                value: "Command: ItemAdd");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 7u,
+                column: "name",
+                value: "Category: RBAC");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 8u,
+                column: "name",
+                value: "Category: RBACAccount");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 9u,
+                column: "name",
+                value: "Category: RBACAccountPermission");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 10u,
+                column: "name",
+                value: "Command: RBACAccountPermissionGrant");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 11u,
+                column: "name",
+                value: "Command: RBACAccountPermissionRevoke");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 12u,
+                column: "name",
+                value: "Category: RBACAccountRole");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 13u,
+                column: "name",
+                value: "Command: RBACAccountRoleGrant");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 14u,
+                column: "name",
+                value: "Command: RBACAccountRoleRevoke");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 15u,
+                column: "name",
+                value: "Category: Achievement");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 16u,
+                column: "name",
+                value: "Command: AchievementGrant");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 17u,
+                column: "name",
+                value: "Command: AchievementUpdate");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 18u,
+                column: "name",
+                value: "Category: Broadcast");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 19u,
+                column: "name",
+                value: "Command: BroadcastMessage");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 20u,
+                column: "name",
+                value: "Category: Character");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 21u,
+                column: "name",
+                value: "Command: CharacterXP");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 22u,
+                column: "name",
+                value: "Command: CharacterLevel");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 23u,
+                column: "name",
+                value: "Category: Currency");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 24u,
+                column: "name",
+                value: "Category: CurrencyAccount");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 25u,
+                column: "name",
+                value: "Command: CurrencyAccountAdd");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 26u,
+                column: "name",
+                value: "Command: CurrencyAccountList");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 27u,
+                column: "name",
+                value: "Category: CurrencyCharacter");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 28u,
+                column: "name",
+                value: "Command: CurrencyCharacterAdd");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 29u,
+                column: "name",
+                value: "Command: CurrencyCharacterList");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 30u,
+                column: "name",
+                value: "Category: Disable");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 31u,
+                column: "name",
+                value: "Command: DisableInfo");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 32u,
+                column: "name",
+                value: "Command: DisableReload");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 33u,
+                column: "name",
+                value: "Category: Door");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 34u,
+                column: "name",
+                value: "Command: DoorOpen");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 35u,
+                column: "name",
+                value: "Command: DoorClose");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 36u,
+                column: "name",
+                value: "Category: Entitlement");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 37u,
+                column: "name",
+                value: "Category: EntitlementCharacter");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 38u,
+                column: "name",
+                value: "Command: EntitlementCharacterAdd");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 39u,
+                column: "name",
+                value: "Command: EntitlementCharacterList");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 40u,
+                column: "name",
+                value: "Category: EntitlementAccount");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 41u,
+                column: "name",
+                value: "Command: EntitlementAccountAdd");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 42u,
+                column: "name",
+                value: "Command: EntitlementAccountList");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 43u,
+                column: "name",
+                value: "Category: Entity");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 44u,
+                column: "name",
+                value: "Command: EntityInfo");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 45u,
+                column: "name",
+                value: "Command: EntityProperties");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 46u,
+                column: "name",
+                value: "Category: Generic");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 47u,
+                column: "name",
+                value: "Command: GenericUnlock");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 48u,
+                column: "name",
+                value: "Command: GenericUnlockAll");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 49u,
+                column: "name",
+                value: "Command: GenericList");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 50u,
+                column: "name",
+                value: "Category: Teleport");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 51u,
+                column: "name",
+                value: "Command: TeleportCoordinates");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 52u,
+                column: "name",
+                value: "Command: TeleportLocation");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 53u,
+                column: "name",
+                value: "Command: TeleportName");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 54u,
+                column: "name",
+                value: "Category: House");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 55u,
+                column: "name",
+                value: "Category: HouseDecor");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 56u,
+                column: "name",
+                value: "Command: HouseDecorAdd");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 57u,
+                column: "name",
+                value: "Command: HouseDecorLookup");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 58u,
+                column: "name",
+                value: "Command: HouseTeleport");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 59u,
+                column: "name",
+                value: "Category: Item");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 60u,
+                column: "name",
+                value: "Category: EntityModify");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 61u,
+                column: "name",
+                value: "Command: EntityModifyDisplayInfo");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 62u,
+                column: "name",
+                value: "Category: Movement");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 63u,
+                column: "name",
+                value: "Category: MovementSpline");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 64u,
+                column: "name",
+                value: "Command: MovementSplineAdd");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 65u,
+                column: "name",
+                value: "Command: MovementSplineClear");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 66u,
+                column: "name",
+                value: "Command: MovementSplineLaunch");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 67u,
+                column: "name",
+                value: "Category: MovementGenerator");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 68u,
+                column: "name",
+                value: "Command: MovementGeneratorDirect");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 69u,
+                column: "name",
+                value: "Command: MovementGeneratorRandom");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 70u,
+                column: "name",
+                value: "Category: Path");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 71u,
+                column: "name",
+                value: "Command: PathUnlock");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 72u,
+                column: "name",
+                value: "Command: PathActivate");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 73u,
+                column: "name",
+                value: "Command: PathXP");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 74u,
+                column: "name",
+                value: "Category: Pet");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 75u,
+                column: "name",
+                value: "Command: PetUnlockFlair");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 76u,
+                column: "name",
+                value: "Category: Quest");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 77u,
+                column: "name",
+                value: "Command: QuestAdd");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 78u,
+                column: "name",
+                value: "Command: QuestAchieve");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 79u,
+                column: "name",
+                value: "Command: QuestAchieveObjective");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 80u,
+                column: "name",
+                value: "Command: QuestObjective");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 81u,
+                column: "name",
+                value: "Command: QuestKill");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 82u,
+                column: "name",
+                value: "Category: Realm");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 83u,
+                column: "name",
+                value: "Category: Spell");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 84u,
+                column: "name",
+                value: "Command: SpellAdd");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 85u,
+                column: "name",
+                value: "Command: SpellCast");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 86u,
+                column: "name",
+                value: "Command: SpellResetCooldown");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 87u,
+                column: "name",
+                value: "Category: Title");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 88u,
+                column: "name",
+                value: "Command: TitleAdd");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 89u,
+                column: "name",
+                value: "Command: TitleRevoke");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 90u,
+                column: "name",
+                value: "Command: TitleAll");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 91u,
+                column: "name",
+                value: "Command: TitleNone");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 92u,
+                column: "name",
+                value: "Command: ItemLookup");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 94u,
+                column: "name",
+                value: "Command: RealmMOTD");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 95u,
+                column: "name",
+                value: "Category: Story");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 96u,
+                column: "name",
+                value: "Command: StoryPanel");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 97u,
+                column: "name",
+                value: "Command: StoryCommunicator");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 98u,
+                column: "name",
+                value: "Category: Reputation");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 99u,
+                column: "name",
+                value: "Command: ReputationUpdate");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 10000u,
+                column: "name",
+                value: "Other: InstantLogout");
+
+            migrationBuilder.InsertData(
+                table: "permission",
+                columns: new[] { "id", "name" },
+                values: new object[] { 105u, "Command: QuestActivate" });
+
+            migrationBuilder.UpdateData(
+                table: "role",
+                keyColumn: "id",
+                keyValue: 1u,
+                columns: new[] { "flags", "name" },
+                values: new object[] { 1u, "Player" });
+
+            migrationBuilder.UpdateData(
+                table: "role",
+                keyColumn: "id",
+                keyValue: 2u,
+                columns: new[] { "flags", "name" },
+                values: new object[] { 1u, "GameMaster" });
+
+            migrationBuilder.UpdateData(
+                table: "role",
+                keyColumn: "id",
+                keyValue: 3u,
+                columns: new[] { "flags", "name" },
+                values: new object[] { 2u, "Administrator" });
+
+            migrationBuilder.UpdateData(
+                table: "role",
+                keyColumn: "id",
+                keyValue: 4u,
+                columns: new[] { "flags", "name" },
+                values: new object[] { 2u, "Console" });
+
+            migrationBuilder.UpdateData(
+                table: "role",
+                keyColumn: "id",
+                keyValue: 5u,
+                columns: new[] { "flags", "name" },
+                values: new object[] { 2u, "WebSocket" });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 105u);
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 1u,
+                column: "name",
+                value: "Category: Account");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 2u,
+                column: "name",
+                value: "Command: AccountCreate");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 3u,
+                column: "name",
+                value: "Command: AccountDelete");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 4u,
+                column: "name",
+                value: "Category: Help");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 5u,
+                column: "name",
+                value: "Command: CharacterSave");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 6u,
+                column: "name",
+                value: "Command: ItemAdd");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 7u,
+                column: "name",
+                value: "Category: RBAC");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 8u,
+                column: "name",
+                value: "Category: RBACAccount");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 9u,
+                column: "name",
+                value: "Category: RBACAccountPermission");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 10u,
+                column: "name",
+                value: "Command: RBACAccountPermissionGrant");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 11u,
+                column: "name",
+                value: "Command: RBACAccountPermissionRevoke");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 12u,
+                column: "name",
+                value: "Category: RBACAccountRole");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 13u,
+                column: "name",
+                value: "Command: RBACAccountRoleGrant");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 14u,
+                column: "name",
+                value: "Command: RBACAccountRoleRevoke");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 15u,
+                column: "name",
+                value: "Category: Achievement");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 16u,
+                column: "name",
+                value: "Command: AchievementGrant");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 17u,
+                column: "name",
+                value: "Command: AchievementUpdate");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 18u,
+                column: "name",
+                value: "Category: Broadcast");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 19u,
+                column: "name",
+                value: "Command: BroadcastMessage");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 20u,
+                column: "name",
+                value: "Category: Character");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 21u,
+                column: "name",
+                value: "Command: CharacterXP");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 22u,
+                column: "name",
+                value: "Command: CharacterLevel");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 23u,
+                column: "name",
+                value: "Category: Currency");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 24u,
+                column: "name",
+                value: "Category: CurrencyAccount");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 25u,
+                column: "name",
+                value: "Command: CurrencyAccountAdd");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 26u,
+                column: "name",
+                value: "Command: CurrencyAccountList");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 27u,
+                column: "name",
+                value: "Category: CurrencyCharacter");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 28u,
+                column: "name",
+                value: "Command: CurrencyCharacterAdd");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 29u,
+                column: "name",
+                value: "Command: CurrencyCharacterList");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 30u,
+                column: "name",
+                value: "Category: Disable");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 31u,
+                column: "name",
+                value: "Command: DisableInfo");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 32u,
+                column: "name",
+                value: "Command: DisableReload");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 33u,
+                column: "name",
+                value: "Category: Door");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 34u,
+                column: "name",
+                value: "Command: DoorOpen");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 35u,
+                column: "name",
+                value: "Command: DoorClose");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 36u,
+                column: "name",
+                value: "Category: Entitlement");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 37u,
+                column: "name",
+                value: "Category: EntitlementCharacter");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 38u,
+                column: "name",
+                value: "Command: EntitlementCharacterAdd");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 39u,
+                column: "name",
+                value: "Command: EntitlementCharacterList");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 40u,
+                column: "name",
+                value: "Category: EntitlementAccount");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 41u,
+                column: "name",
+                value: "Command: EntitlementAccountAdd");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 42u,
+                column: "name",
+                value: "Command: EntitlementAccountList");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 43u,
+                column: "name",
+                value: "Category: Entity");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 44u,
+                column: "name",
+                value: "Command: EntityInfo");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 45u,
+                column: "name",
+                value: "Command: EntityProperties");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 46u,
+                column: "name",
+                value: "Category: Generic");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 47u,
+                column: "name",
+                value: "Command: GenericUnlock");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 48u,
+                column: "name",
+                value: "Command: GenericUnlockAll");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 49u,
+                column: "name",
+                value: "Command: GenericList");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 50u,
+                column: "name",
+                value: "Category: Teleport");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 51u,
+                column: "name",
+                value: "Command: TeleportCoordinates");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 52u,
+                column: "name",
+                value: "Command: TeleportLocation");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 53u,
+                column: "name",
+                value: "Command: TeleportName");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 54u,
+                column: "name",
+                value: "Category: House");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 55u,
+                column: "name",
+                value: "Category: HouseDecor");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 56u,
+                column: "name",
+                value: "Command: HouseDecorAdd");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 57u,
+                column: "name",
+                value: "Command: HouseDecorLookup");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 58u,
+                column: "name",
+                value: "Command: HouseTeleport");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 59u,
+                column: "name",
+                value: "Category: Item");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 60u,
+                column: "name",
+                value: "Category: EntityModify");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 61u,
+                column: "name",
+                value: "Command: EntityModifyDisplayInfo");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 62u,
+                column: "name",
+                value: "Category: Movement");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 63u,
+                column: "name",
+                value: "Category: MovementSpline");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 64u,
+                column: "name",
+                value: "Command: MovementSplineAdd");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 65u,
+                column: "name",
+                value: "Command: MovementSplineClear");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 66u,
+                column: "name",
+                value: "Command: MovementSplineLaunch");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 67u,
+                column: "name",
+                value: "Category: MovementGenerator");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 68u,
+                column: "name",
+                value: "Command: MovementGeneratorDirect");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 69u,
+                column: "name",
+                value: "Command: MovementGeneratorRandom");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 70u,
+                column: "name",
+                value: "Category: Path");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 71u,
+                column: "name",
+                value: "Command: PathUnlock");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 72u,
+                column: "name",
+                value: "Command: PathActivate");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 73u,
+                column: "name",
+                value: "Command: PathXP");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 74u,
+                column: "name",
+                value: "Category: Pet");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 75u,
+                column: "name",
+                value: "Command: PetUnlockFlair");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 76u,
+                column: "name",
+                value: "Category: Quest");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 77u,
+                column: "name",
+                value: "Command: QuestAdd");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 78u,
+                column: "name",
+                value: "Command: QuestAchieve");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 79u,
+                column: "name",
+                value: "Command: QuestAchieveObjective");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 80u,
+                column: "name",
+                value: "Command: QuestObjective");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 81u,
+                column: "name",
+                value: "Command: QuestKill");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 82u,
+                column: "name",
+                value: "Category: Realm");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 83u,
+                column: "name",
+                value: "Category: Spell");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 84u,
+                column: "name",
+                value: "Command: SpellAdd");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 85u,
+                column: "name",
+                value: "Command: SpellCast");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 86u,
+                column: "name",
+                value: "Command: SpellResetCooldown");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 87u,
+                column: "name",
+                value: "Category: Title");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 88u,
+                column: "name",
+                value: "Command: TitleAdd");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 89u,
+                column: "name",
+                value: "Command: TitleRevoke");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 90u,
+                column: "name",
+                value: "Command: TitleAll");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 91u,
+                column: "name",
+                value: "Command: TitleNone");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 92u,
+                column: "name",
+                value: "Command: ItemLookup");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 94u,
+                column: "name",
+                value: "Command: RealmMOTD");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 95u,
+                column: "name",
+                value: "Category: Story");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 96u,
+                column: "name",
+                value: "Command: StoryPanel");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 97u,
+                column: "name",
+                value: "Command: StoryCommunicator");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 98u,
+                column: "name",
+                value: "Category: Reputation");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 99u,
+                column: "name",
+                value: "Command: ReputationUpdate");
+
+            migrationBuilder.UpdateData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 10000u,
+                column: "name",
+                value: "Other: InstantLogout");
+
+            migrationBuilder.UpdateData(
+                table: "role",
+                keyColumn: "id",
+                keyValue: 1u,
+                columns: new[] { "flags", "name" },
+                values: new object[] { 1u, "Player" });
+
+            migrationBuilder.UpdateData(
+                table: "role",
+                keyColumn: "id",
+                keyValue: 2u,
+                columns: new[] { "flags", "name" },
+                values: new object[] { 1u, "GameMaster" });
+
+            migrationBuilder.UpdateData(
+                table: "role",
+                keyColumn: "id",
+                keyValue: 3u,
+                columns: new[] { "flags", "name" },
+                values: new object[] { 2u, "Administrator" });
+
+            migrationBuilder.UpdateData(
+                table: "role",
+                keyColumn: "id",
+                keyValue: 4u,
+                columns: new[] { "flags", "name" },
+                values: new object[] { 2u, "Console" });
+
+            migrationBuilder.UpdateData(
+                table: "role",
+                keyColumn: "id",
+                keyValue: 5u,
+                columns: new[] { "flags", "name" },
+                values: new object[] { 2u, "WebSocket" });
+        }
+    }
+}

--- a/Source/NexusForever.Shared/GameTable/Model/Quest2Entry.cs
+++ b/Source/NexusForever.Shared/GameTable/Model/Quest2Entry.cs
@@ -90,10 +90,10 @@ namespace NexusForever.Shared.GameTable.Model
         public uint VirtualItemPushedObjectiveFlagsEnum02;
         public uint VirtualItemPushedObjectiveFlagsEnum03;
         public uint QuestDirectionIdCompletion;
-        public uint Faction2IdRewardReputation00;
-        public uint Faction2IdRewardReputation01;
-        public float RewardReputationOverride00;
-        public float RewardReputationOverride01;
+        [GameTableFieldArray(2u)]
+        public uint[] Faction2IdRewardReputations;
+        [GameTableFieldArray(2u)]
+        public float[] RewardReputationOverrides;
         public uint QuestCategoryId;
         public uint LocalizedTextIdGiverSayDecline;
         public uint PeriodicQuestGroupId;

--- a/Source/NexusForever.WorldServer/Command/Handler/EntityCommandCategory.cs
+++ b/Source/NexusForever.WorldServer/Command/Handler/EntityCommandCategory.cs
@@ -73,7 +73,7 @@ namespace NexusForever.WorldServer.Command.Handler
         private void BuildHeader(ICommandContext context, StringBuilder builder, WorldEntity target)
         {
             builder.AppendLine("=============================");
-            builder.AppendLine($"UnitId: {target.Guid} | DB ID: {target.EntityId} | Type: {target.Type} | CreatureID: {target.CreatureId} | Name: {GetName(target, context.Language)}");
+            builder.AppendLine($"UnitId: {target.Guid} | DB ID: {target.EntityId} | Type: {target.Type} | CreatureID: {target.CreatureId} | Name: {GetName(target, context.Language)} | QuestChecklistIdx: {target.QuestChecklistIdx}");
         }
 
         private string GetName(WorldEntity target, Language language)

--- a/Source/NexusForever.WorldServer/Command/Handler/QuestCommandCategory.cs
+++ b/Source/NexusForever.WorldServer/Command/Handler/QuestCommandCategory.cs
@@ -86,14 +86,31 @@ namespace NexusForever.WorldServer.Command.Handler
             var target = context.GetTargetOrInvoker<Player>();
             target.QuestManager.ObjectiveUpdate(QuestObjectiveType.KillCreature, creatureId, quantity.Value);
             target.QuestManager.ObjectiveUpdate(QuestObjectiveType.KillCreature2, creatureId, quantity.Value);
-
-            foreach (uint targetGroupId in AssetManager.Instance.GetTargetGroupsForCreatureId(creatureId) ?? Enumerable.Empty<uint>())
-            {
-                target.QuestManager.ObjectiveUpdate(QuestObjectiveType.KillTargetGroup, targetGroupId, quantity.Value);
-                target.QuestManager.ObjectiveUpdate(QuestObjectiveType.KillTargetGroups, targetGroupId, quantity.Value);
-            }
+            target.QuestManager.ObjectiveUpdate(QuestObjectiveType.KillCreature, creatureId, quantity.Value);
+            target.QuestManager.ObjectiveUpdate(QuestObjectiveType.KillCreature2, creatureId, quantity.Value);
+            target.QuestManager.ObjectiveUpdate(QuestObjectiveType.KillTargetGroup, creatureId, quantity.Value);
+            target.QuestManager.ObjectiveUpdate(QuestObjectiveType.KillTargetGroups, creatureId, quantity.Value);
 
             context.SendMessage($"Success! You've killed {quantity} of Creature ID: {creatureId}");
+        }
+
+        [Command(Permission.QuestActivate, "Update all quest objectives that require activating a given creature id.", "activate")]
+        public void HandleQuestActivate(ICommandContext context,
+            [Parameter("Creature id to match quest objectives against.")]
+            uint creatureId,
+            [Parameter("Quantity to update quest objectives by.")]
+            uint? quantity)
+        {
+            quantity ??= 1u;
+
+            var target = context.GetTargetOrInvoker<Player>();
+            target.QuestManager.ObjectiveUpdate(QuestObjectiveType.ActivateEntity, creatureId, quantity.Value);
+            target.QuestManager.ObjectiveUpdate(QuestObjectiveType.ActivateEntity2, creatureId, quantity.Value);
+            target.QuestManager.ObjectiveUpdate(QuestObjectiveType.ActivateTargetGroup, creatureId, quantity.Value);
+            target.QuestManager.ObjectiveUpdate(QuestObjectiveType.ActivateTargetGroupChecklist, creatureId, quantity.Value); // quantity.Value should be the QuestChecklistIdx of the entity
+            target.QuestManager.ObjectiveUpdate(QuestObjectiveType.SucceedCSI, creatureId, quantity.Value);
+
+            context.SendMessage($"Success! You've activated {quantity} of Creature ID: {creatureId}");
         }
     }
 }

--- a/Source/NexusForever.WorldServer/Game/Entity/NonPlayer.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/NonPlayer.cs
@@ -35,7 +35,7 @@ namespace NexusForever.WorldServer.Game.Entity
             return new NonPlayerEntityModel
             {
                 CreatureId = CreatureId,
-                QuestChecklistIdx = 0
+                QuestChecklistIdx = QuestChecklistIdx
             };
         }
 

--- a/Source/NexusForever.WorldServer/Game/Entity/QuestManager.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/QuestManager.cs
@@ -400,8 +400,8 @@ namespace NexusForever.WorldServer.Game.Entity
             if (quest.State != QuestState.Accepted)
                 throw new QuestException($"Player {player.CharacterId} tried to achieve quest {questId} with invalid state!");
 
-            foreach (QuestObjectiveEntry entry in quest.Info.Objectives)
-                quest.ObjectiveUpdate((QuestObjectiveType)entry.Type, entry.Data, entry.Count);
+            foreach (QuestObjective objective in quest)
+                quest.CompleteObjective(objective);
         }
 
         /// <summary>
@@ -423,7 +423,7 @@ namespace NexusForever.WorldServer.Game.Entity
             if (objective == null)
                 throw new QuestException();
 
-            quest.ObjectiveUpdate((QuestObjectiveType)objective.Entry.Type, objective.Entry.Data, objective.Entry.Count);
+            quest.CompleteObjective(objective);
         }
 
         /// <summary>
@@ -515,6 +515,12 @@ namespace NexusForever.WorldServer.Game.Entity
             uint money = info.GetRewardMoney();
             if (money != 0u)
                 player.CurrencyManager.CurrencyAddAmount(CurrencyType.Credits, money);
+
+            foreach ((uint faction2Id, float rep) in info.GetRewardReputation())
+            {
+                if (faction2Id != 0u)
+                    player.ReputationManager.UpdateReputation((Faction)faction2Id, rep);
+            }
         }
 
         private void RewardQuest(Quest2RewardEntry entry)

--- a/Source/NexusForever.WorldServer/Game/Entity/Simple.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/Simple.cs
@@ -4,14 +4,13 @@ using NexusForever.Shared.GameTable.Model;
 using NexusForever.WorldServer.Game.Entity.Network;
 using NexusForever.WorldServer.Game.Entity.Network.Model;
 using NexusForever.WorldServer.Game.Entity.Static;
+using NexusForever.WorldServer.Game.Quest.Static;
 
 namespace NexusForever.WorldServer.Game.Entity
 {
     [DatabaseEntity(EntityType.Simple)]
     public class Simple : UnitEntity
     {
-        public byte QuestChecklistIdx { get; private set; }
-
         public Simple()
             : base(EntityType.Simple)
         {
@@ -68,6 +67,10 @@ namespace NexusForever.WorldServer.Game.Entity
                 }
             }
 
+            activator.QuestManager.ObjectiveUpdate(QuestObjectiveType.ActivateEntity, CreatureId, 1u);
+            activator.QuestManager.ObjectiveUpdate(QuestObjectiveType.SucceedCSI, CreatureId, 1u);
+            activator.QuestManager.ObjectiveUpdate(QuestObjectiveType.ActivateTargetGroupChecklist, CreatureId, QuestChecklistIdx);
+            
             //TODO: cast "116,Generic Quest Spell - Activating - Activate - Tier 1" by 0x07FD
         }
     }

--- a/Source/NexusForever.WorldServer/Game/Entity/WorldEntity.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/WorldEntity.cs
@@ -29,6 +29,8 @@ namespace NexusForever.WorldServer.Game.Entity
         public Faction Faction1 { get; set; }
         public Faction Faction2 { get; set; }
 
+        public byte QuestChecklistIdx { get; set; }
+
         public ulong ActivePropId { get; private set; }
         public ushort WorldSocketId { get; private set; }
 
@@ -85,15 +87,16 @@ namespace NexusForever.WorldServer.Game.Entity
         /// </summary>
         public virtual void Initialise(EntityModel model)
         {
-            EntityId     = model.Id;
-            CreatureId   = model.Creature;
-            Rotation     = new Vector3(model.Rx, model.Ry, model.Rz);
-            DisplayInfo  = model.DisplayInfo;
-            OutfitInfo   = model.OutfitInfo;
-            Faction1     = (Faction)model.Faction1;
-            Faction2     = (Faction)model.Faction2;
-            ActivePropId = model.ActivePropId;
-            WorldSocketId = model.WorldSocketId;
+            EntityId          = model.Id;
+            CreatureId        = model.Creature;
+            Rotation          = new Vector3(model.Rx, model.Ry, model.Rz);
+            DisplayInfo       = model.DisplayInfo;
+            OutfitInfo        = model.OutfitInfo;
+            Faction1          = (Faction)model.Faction1;
+            Faction2          = (Faction)model.Faction2;
+            QuestChecklistIdx = model.QuestChecklistIdx;
+            ActivePropId      = model.ActivePropId;
+            WorldSocketId     = model.WorldSocketId;
 
             foreach (EntityStatModel statModel in model.EntityStat)
                 stats.Add((Stat)statModel.Stat, new StatValue(statModel));

--- a/Source/NexusForever.WorldServer/Game/Quest/QuestInfo.cs
+++ b/Source/NexusForever.WorldServer/Game/Quest/QuestInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using NexusForever.Shared.GameTable;
@@ -86,6 +87,33 @@ namespace NexusForever.WorldServer.Game.Quest
 
             GameFormulaEntry entry = GameTableManager.Instance.GameFormula.GetEntry(530);
             return (uint)(MathF.Pow(Entry.ConLevel, entry.Datafloat0) * DifficultyEntry.CashRewardMultiplier);
+        }
+
+        /// <summary>
+        /// Return reputation rewarded on completion.
+        /// </summary>
+        public Dictionary<uint, float> GetRewardReputation()
+        {
+            Dictionary<uint, float> reputationRewards = new Dictionary<uint, float>();
+
+            for (int i = 0; i < Entry.Faction2IdRewardReputations.Length - 1; i++)
+            {
+                uint faction2Id = Entry.Faction2IdRewardReputations[i];
+
+                if (faction2Id == 0u)
+                    continue;
+
+                if (Entry.RewardReputationOverrides[i] > 0f)
+                {
+                    reputationRewards.Add(faction2Id, Entry.RewardReputationOverrides[i]);
+                    continue;
+                }
+
+                XpPerLevelEntry entry = GameTableManager.Instance.XpPerLevel.GetEntry(Entry.ConLevel);
+                reputationRewards.Add(faction2Id, DifficultyEntry.RepRewardMultiplier * entry.BaseRepRewardPerLevel);
+            }
+
+            return reputationRewards;
         }
     }
 }

--- a/Source/NexusForever.WorldServer/Game/Quest/QuestObjective.cs
+++ b/Source/NexusForever.WorldServer/Game/Quest/QuestObjective.cs
@@ -1,15 +1,21 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using NexusForever.Database.Character;
 using NexusForever.Database.Character.Model;
 using NexusForever.Shared;
+using NexusForever.Shared.GameTable;
 using NexusForever.Shared.GameTable.Model;
 using NexusForever.WorldServer.Game.Quest.Static;
+using NLog;
 
 namespace NexusForever.WorldServer.Game.Quest
 {
     public class QuestObjective : IUpdate
     {
+        private static readonly ILogger log = LogManager.GetCurrentClassLogger();
+
         public QuestInfo Info { get; }
 
         public QuestObjectiveType Type => (QuestObjectiveType)Entry.Type;
@@ -41,6 +47,8 @@ namespace NexusForever.WorldServer.Game.Quest
 
         private uint? timer;
 
+        private List<uint> targetIds = new List<uint>();
+
         private QuestObjectiveSaveMask saveMask;
 
         /// <summary>
@@ -53,6 +61,9 @@ namespace NexusForever.WorldServer.Game.Quest
             Index    = model.Index;
             progress = model.Progress;
             timer    = model.Timer;
+
+            if (IsChecklist() || UsesTargetGroups())
+                BuildTargets();
         }
 
         /// <summary>
@@ -69,7 +80,28 @@ namespace NexusForever.WorldServer.Game.Quest
                 // TODO
             }
 
+            if (IsChecklist() || UsesTargetGroups())
+                BuildTargets();
+
             saveMask = QuestObjectiveSaveMask.Create;
+        }
+
+        /// <summary>
+        /// Builds the target ID list for this <see cref="QuestObjective"/>.
+        /// </summary>
+        private void BuildTargets()
+        {
+            uint targetGroupId = Entry.Data > 0 ? Entry.Data : Entry.TargetGroupIdRewardPane;
+            if (targetGroupId == 0u)
+                throw new InvalidOperationException();
+
+            targetIds = AssetManager.Instance.GetQuestObjectiveTargetIds(Entry.Id).ToList();
+            if (targetIds.Count == 0u)
+                return;
+
+            if (targetIds.Count < Entry.Count)
+                for (int i = targetIds.Count - 1; i < Entry.Count; i++)
+                    targetIds.Add(targetIds[0]);
         }
 
         public void Save(CharacterContext context, ulong characterId)
@@ -130,16 +162,53 @@ namespace NexusForever.WorldServer.Game.Quest
         }
 
         /// <summary>
-        /// Return if the objective has been completed.
+        /// Return if this <see cref="QuestObjective"/> is a checklist type.
+        /// </summary>
+        public bool IsChecklist()
+        {
+            // TODO: Determine other Types that are also Checklists
+            return Type == QuestObjectiveType.ActivateTargetGroupChecklist;
+        }
+
+        /// <summary>
+        /// Return if this <see cref="QuestObjective"/> uses target group data to complete.
+        /// </summary>
+        public bool UsesTargetGroups()
+        {
+            // TODO: Determine other Types that are also using Target Groups
+            return (Type == QuestObjectiveType.ActivateTargetGroup ||
+               Type == QuestObjectiveType.ActivateTargetGroupChecklist ||
+               Type == QuestObjectiveType.KillTargetGroup ||
+               Type == QuestObjectiveType.KillTargetGroups ||
+               Type == QuestObjectiveType.TalkToTargetGroup ||
+               Type == QuestObjectiveType.ActivateEntity && Entry.TargetGroupIdRewardPane != 0u);
+        }
+
+        /// <summary>
+        /// Return if the <see cref="QuestObjective"/> has been completed.
         /// </summary>
         public bool IsComplete()
         {
             return progress >= GetMaxValue();
         }
 
+        /// <summary>
+        /// Return if the <see cref="QuestObjective"/> requires the given ID to complete.
+        /// </summary>
+        public bool IsTarget(uint id)
+        {
+            return (Entry.Data == id || targetIds.Contains(id));
+        }
+
         private uint GetMaxValue()
         {
-            return IsDynamic() ? 1000u : Entry.Count;
+            if (IsChecklist())
+                return (uint)(1 << (int)Entry.Count) - 1;
+
+            if (IsDynamic())
+                return 1000u;
+
+            return Entry.Count;
         }
 
         /// <summary>
@@ -147,10 +216,20 @@ namespace NexusForever.WorldServer.Game.Quest
         /// </summary>
         public void ObjectiveUpdate(uint update)
         {
-            if (IsDynamic())
+            if (IsChecklist())
+                update = (uint)(1 << (int)update);
+            else if (IsDynamic())
                 update = (uint)(((float)update / Entry.Count) * 1000f);
 
             Progress = Math.Min(progress + update, GetMaxValue());
+        }
+
+        /// <summary>
+        /// Complete this <see cref="QuestObjective"/>.
+        /// </summary>
+        public void Complete()
+        {
+            Progress = GetMaxValue();
         }
     }
 }

--- a/Source/NexusForever.WorldServer/Game/RBAC/Static/Permission.cs
+++ b/Source/NexusForever.WorldServer/Game/RBAC/Static/Permission.cs
@@ -131,6 +131,7 @@
         QuestAchieveObjective       = 79,
         QuestObjective              = 80,
         QuestKill                   = 81,
+        QuestActivate               = 105,
 
         // spell
         Spell                       = 83,


### PR DESCRIPTION
Contributes towards #306 

For this to function properly, entities that are part of a Checklist Quest will need to have their database entries updated/re-dumped with the `QuestChecklistIdx` from a sniff included.

This is used in quests like the Housing Starting Quest (Exile: http://www.jabbithole.com/quests/housing-of-the-future-9160) where you have to interact with certain entities and they update the quest appropriately.

This also includes the Reputation Rewards being sent to the Player after completing a quest.