### PR TITLE
NPC Persistence and Basic Entity Spawning (FIX)

### DIFF
--- a/Source/NexusForever.Database.World/WorldDatabase.cs
+++ b/Source/NexusForever.Database.World/WorldDatabase.cs
@@ -35,6 +35,23 @@ namespace NexusForever.Database.World
             }
         }
 
+        public void SaveEntities(List<EntityModel> entities)
+        {
+            using var context = new WorldContext(config);
+            foreach (EntityModel entity in entities)
+            {
+                if (context.Entity.Where(e => e.Id == entity.Id).Count() > 0)
+                {
+                    context.Entity.Update(entity);
+                }
+                else
+                {
+                    context.Entity.Add(entity);
+                }
+            }
+            context.SaveChanges();
+        }
+
         public ImmutableList<EntityModel> GetEntities(ushort world)
         {
             using var context = new WorldContext(config);
@@ -45,6 +62,13 @@ namespace NexusForever.Database.World
                 .Include(e => e.EntityStat)
                 .AsNoTracking()
                 .ToImmutableList();
+        }
+
+        public uint GetNewEntityId()
+        {
+            using var context = new WorldContext(config);
+            if (context.Entity.Count() == 0) return 1;
+            return context.Entity.Max(x => x.Id) + 1;
         }
 
         public ImmutableList<EntityModel> GetEntitiesWithoutArea()
@@ -64,6 +88,13 @@ namespace NexusForever.Database.World
                 entity.State = EntityState.Modified;
             }
 
+            context.SaveChanges();
+        }
+
+        public void RemoveEntity(EntityModel model)
+        {
+            using var context = new WorldContext(config);
+            context.Entity.Remove(model);
             context.SaveChanges();
         }
 

--- a/Source/NexusForever.Database.World/WorldDatabase.cs
+++ b/Source/NexusForever.Database.World/WorldDatabase.cs
@@ -52,6 +52,16 @@ namespace NexusForever.Database.World
             context.SaveChanges();
         }
 
+        /// <summary>
+        /// Retrieve Unique World IDs of Mobs In Entity Database
+        /// </summary>
+        /// <returns></returns>
+        public List<ushort> GetUniqueWorlds()
+        {
+            using var context = new WorldContext(config);
+            return context.Entity.Select(e => e.World).Distinct().ToList();
+        }
+
         public ImmutableList<EntityModel> GetEntities(ushort world)
         {
             using var context = new WorldContext(config);

--- a/Source/NexusForever.WorldServer/Command/Handler/EntityCommandCategory.cs
+++ b/Source/NexusForever.WorldServer/Command/Handler/EntityCommandCategory.cs
@@ -1,19 +1,106 @@
 ﻿using System.Linq;
 using System.Text;
+using NexusForever.Database.World.Model;
+using NexusForever.Shared.Database;
 using NexusForever.Shared.GameTable;
 using NexusForever.Shared.GameTable.Model;
 using NexusForever.Shared.GameTable.Static;
 using NexusForever.WorldServer.Command.Context;
 using NexusForever.WorldServer.Game.Entity;
 using NexusForever.WorldServer.Game.Entity.Static;
+using NexusForever.WorldServer.Game.Map;
 using NexusForever.WorldServer.Game.RBAC.Static;
+using NLog;
 
 namespace NexusForever.WorldServer.Command.Handler
 {
+
     [Command(Permission.Entity, "A collection of commands to modify and query information about an entity.", "entity")]
     [CommandTarget(typeof(WorldEntity))]
     public class EntityCommandCategory : CommandCategory
     {
+        private static readonly Logger log = LogManager.GetCurrentClassLogger();
+        [Command(Permission.Entity, "Add an Entity by Creature Id", "heal")]
+        public void HandleEntityHeal(ICommandContext context)
+        {
+            
+        }
+
+        [Command(Permission.Entity, "Add an Entity by Creature Id", "add")]
+        public void HandleEntityAdd(ICommandContext context,
+            uint unitId)
+        {
+            var creatureEntry = GameTableManager.Instance.Creature2.GetEntry(unitId);
+
+            if (creatureEntry == null)
+            {
+                context.SendMessage($"Invalid creature id {unitId}!");
+                return;
+            }
+
+            var npcModel = new EntityModel()
+            {
+                Id = DatabaseManager.Instance.WorldDatabase.GetNewEntityId(),
+                Creature = unitId,
+                Area = (ushort)context.GetTargetOrInvoker<Player>().Zone.Id,
+                DisplayInfo = creatureEntry.Id,
+                OutfitInfo = (ushort)creatureEntry.Creature2OutfitGroupId,
+                X = context.Invoker.Position.X,
+                Y = context.Invoker.Position.Y,
+                Z = context.Invoker.Position.Z,
+                Rx = context.Invoker.Rotation.X,
+                Ry = context.Invoker.Rotation.Y,
+                Rz = context.Invoker.Rotation.Z,
+                World = (ushort)context.Invoker.Map.Entry.Id,
+                Faction1 = (ushort)creatureEntry.FactionId,
+                Faction2 = (ushort)creatureEntry.FactionId,
+                Type = (byte)creatureEntry.CreationTypeEnum
+            };
+
+            npcModel.Id = DatabaseManager.Instance.WorldDatabase.GetNewEntityId();
+            
+            var entity = new NonPlayer();
+            entity.Initialise(npcModel, context.Invoker.Position, context.Invoker.Rotation);
+            context.GetTargetOrInvoker<Player>().Map.EnqueueAdd(entity, context.Invoker.Position);
+
+            // Add New Entity to the EntityCache
+            var cache = EntityCacheManager.Instance.GetEntityCache((ushort)context.Invoker.Map.Entry.Id);
+            cache.AddEntity(npcModel);
+            var activeNPCGrid = context.Invoker.Map.GetGrid(context.Invoker.Position);
+            var l = cache.GetEntities(activeNPCGrid.Coord.X, activeNPCGrid.Coord.Z).ToList();
+
+            // Make sure we have the entity information stored
+            DatabaseManager.Instance.WorldDatabase.SaveEntities(l);
+                        
+        }
+
+        [Command(Permission.Entity, "Delete an Entity by Target", "del")]
+        public void HandleEntityDelete(ICommandContext context)
+        {
+            
+            if (context.Target == null)
+            {
+                context.SendMessage($"Invalid target!");
+                return;
+            }
+
+            if (context.Target is Player player)
+            {
+                context.SendMessage($"You cannot delete a player...");
+                return;
+            }
+            
+            context.Target.RemoveFromMap();
+            var model = DatabaseManager.Instance.WorldDatabase
+                .GetEntities((ushort)context.Invoker.Map.Entry.Id)
+                .Where(x => x.Id == context.Target.EntityId)
+                .FirstOrDefault();
+            EntityCacheManager.Instance.GetEntityCache((ushort)context.Invoker.Map.Entry.Id).DelEntity(model);
+            DatabaseManager.Instance.WorldDatabase.RemoveEntity(model);
+
+
+        }
+
         [Command(Permission.EntityModify, "A collection of commands to modify an entity.", "modify")]
         public class EntityModifyCommandCategory : CommandCategory
         {

--- a/Source/NexusForever.WorldServer/Command/Handler/EntityCommandCategory.cs
+++ b/Source/NexusForever.WorldServer/Command/Handler/EntityCommandCategory.cs
@@ -102,7 +102,7 @@ namespace NexusForever.WorldServer.Command.Handler
                 .FirstOrDefault();
 
             // Remove Entity from Entity Cache (In-Game Object)
-            EntityCacheManager.Instance.GetEntityCache((ushort)context.Invoker.Map.Entry.Id).DelEntity(model);
+            EntityCacheManager.Instance.GetEntityCache((ushort)context.Invoker.Map.Entry.Id).DeleteEntity(model);
 
             // Remove Entity from Database (Persistence)
             DatabaseManager.Instance.WorldDatabase.RemoveEntity(model);

--- a/Source/NexusForever.WorldServer/Command/Handler/EntityCommandCategory.cs
+++ b/Source/NexusForever.WorldServer/Command/Handler/EntityCommandCategory.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using Newtonsoft.Json;
 using NexusForever.Database.World.Model;
 using NexusForever.Shared.Database;
@@ -37,18 +38,47 @@ namespace NexusForever.WorldServer.Command.Handler
         {
             // TODO: Convert to Sub-Commands
 
-            // Create CreatureList.json for NPCSpawnTool
-            if (filter.ToLower() == "npctool")
+            // Generates an NPC Template List
+            if (filter.ToLower() == "template")
             {
                 var creatureData = GameTableManager.Instance.Creature2.Entries;
                 List<NPCSpawnModel> CreatureList = new List<NPCSpawnModel>();
-                var filterList = creatureData.Where(x => !x.Description.Contains('[') && !string.IsNullOrEmpty(x.Description)).ToList();
-                foreach(var c in filterList)
+                List<EntityModel> dbEntities = new List<EntityModel>();
+
+                var WorldList = DatabaseManager.Instance.WorldDatabase.GetUniqueWorlds();
+                foreach(ushort worldid in WorldList)
                 {
-                    CreatureList.Add(new NPCSpawnModel { Id = c.Id, Description = c.Description.Trim() });
+                    dbEntities.AddRange(DatabaseManager.Instance.WorldDatabase.GetEntities(worldid));
                 }
 
-                File.WriteAllText("CreatureList.json", JsonConvert.SerializeObject(CreatureList));
+                List<string> EnteredNames = new List<string>();
+                
+                foreach(var entity in dbEntities)
+                {
+
+                    string entityName = creatureData.Where(e => e.Id == entity.Creature).Select(x => x.Description).FirstOrDefault();
+                    if(EnteredNames.Count > 0)
+                    {
+                        if (EnteredNames.Contains(entityName)) continue;
+                    }
+                        
+                    EnteredNames.Add(entityName);
+
+                    // Link the Creature2 Entry Description with an existing world entity
+                    CreatureList.Add(new NPCSpawnModel { 
+                        Creature = entity.Creature,
+                        Description = entityName,
+                        Type = entity.Type,
+                        activePropId = entity.ActivePropId,
+                        displayInfo = entity.DisplayInfo,
+                        OutfitInfo = entity.OutfitInfo,
+                        faction1 = entity.Faction1,
+                        faction2 = entity.Faction2
+                    });
+                }
+                
+
+                File.WriteAllText("NPCTemplates.json", JsonConvert.SerializeObject(CreatureList));
             }
 
             // Create creatures_ByDisplayGroupId.json, Creatures Grouped by DisplayGroupId (file size in excess of 180mb)
@@ -72,30 +102,89 @@ namespace NexusForever.WorldServer.Command.Handler
             }
         }
 
+        // Temporary Disable: Adjusting The Way It Adds NPCs
         [Command(Permission.Entity, "Add an Entity by Creature Id", "add")]
         public void HandleEntityAdd(ICommandContext context,
-            uint unitId)
+            [Parameter("X coordinate for target teleport position.")]
+            string creatureId,
+            [Parameter("X coordinate for target teleport position.")]
+            string creatureType,
+            [Parameter("X coordinate for target teleport position.")]
+            string displayInfo,
+            [Parameter("X coordinate for target teleport position.")]
+            string outfitInfo,
+            [Parameter("X coordinate for target teleport position.")]
+            string faction1,
+            [Parameter("X coordinate for target teleport position.")]
+            string faction2,
+            [Parameter("X coordinate for target teleport position.")]
+            string activePropId)
         {
-            var creatureEntry = GameTableManager.Instance.Creature2.GetEntry(unitId);
-
-            if (creatureEntry == null)
+            if(string.IsNullOrEmpty(activePropId))
             {
-                context.SendMessage($"Invalid creature id {unitId}!");
+                context.SendError("Invalid property.");
                 return;
             }
 
-            SpawnObject(context, creatureEntry, unitId);
+            if (string.IsNullOrEmpty(faction2))
+            {
+                context.SendError("Invalid property.");
+                return;
+            }
+
+            if (string.IsNullOrEmpty(faction1))
+            {
+                context.SendError("Invalid property.");
+                return;
+            }
+            if (string.IsNullOrEmpty(outfitInfo))
+            {
+                context.SendError("Invalid property.");
+                return;
+            }
+            if (string.IsNullOrEmpty(displayInfo))
+            {
+                context.SendError("Invalid property.");
+                return;
+            }
+            if (string.IsNullOrEmpty(creatureType))
+            {
+                context.SendError("Invalid property.");
+                return;
+            }
+            if (string.IsNullOrEmpty(creatureId))
+            {
+                context.SendError("Invalid property.");
+                return;
+            }
+
+            var creatureEntry = GameTableManager.Instance.Creature2.GetEntry(ulong.Parse(creatureId));
+
+            if (creatureEntry == null)
+            {
+                context.SendMessage($"Invalid creature id!");
+                return;
+            }
+
+            SpawnObject(context, creatureId, creatureType, displayInfo, outfitInfo, faction1, faction2, activePropId);
         }
 
-        private void SpawnObject(ICommandContext context, Creature2Entry creatureEntry, uint unitId)
+        private void SpawnObject(ICommandContext context,
+            string creatureId,
+            string creatureType,
+            string displayInfo,
+            string outfitInfo,
+            string faction1,
+            string faction2,
+            string activePropId)
         {
             var npcModel = new EntityModel()
             {
                 Id = DatabaseManager.Instance.WorldDatabase.GetNewEntityId(),
-                Creature = unitId,
+                Creature = uint.Parse(creatureId),
                 Area = (ushort)context.Invoker.Zone.Id,
-                DisplayInfo = creatureEntry.Creature2DisplayGroupId,
-                OutfitInfo = (ushort)creatureEntry.Creature2OutfitGroupId,
+                DisplayInfo = uint.Parse(displayInfo),
+                OutfitInfo = ushort.Parse(outfitInfo),
                 X = context.Invoker.Position.X,
                 Y = context.Invoker.Position.Y,
                 Z = context.Invoker.Position.Z,
@@ -103,36 +192,71 @@ namespace NexusForever.WorldServer.Command.Handler
                 Ry = context.Invoker.Rotation.Y,
                 Rz = context.Invoker.Rotation.Z,
                 World = (ushort)context.Invoker.Map.Entry.Id,
-                Faction1 = (ushort)creatureEntry.FactionId,
-                Faction2 = (ushort)creatureEntry.FactionId,
-                Type = (byte)creatureEntry.CreationTypeEnum
+                Faction1 = ushort.Parse(faction1),
+                Faction2 = ushort.Parse(faction2),
+                Type = byte.Parse(creatureType)
             };
-
-            npcModel.Id = DatabaseManager.Instance.WorldDatabase.GetNewEntityId();
 
             var entity = new NonPlayer();
             entity.CreateFlags = EntityCreateFlag.SpawnAnimation;
             entity.Initialise(npcModel, context.Invoker.Position, context.Invoker.Rotation);
             // Cannot use "context.GetTargetOrInvoker()" because if you are targeting an NPC it returns the NPC
             context.Invoker.Map.EnqueueAdd(entity, context.Invoker.Position);
-
-            // Add New Entity to the EntityCache
-            var cache = EntityCacheManager.Instance.GetEntityCache((ushort)context.Invoker.Map.Entry.Id);
-            cache.AddEntity(npcModel);
-            var activeNPCGrid = context.Invoker.Map.GetGrid(context.Invoker.Position);
-            var entityList = cache.GetEntities(activeNPCGrid.Coord.X, activeNPCGrid.Coord.Z).ToList();
-
-            // This function sets all the properties like health and shield etc, also prevents from spawning dead.
             entity.CalculateProperties();
 
-            // Save Entity to Database (Entity Table)
-            DatabaseManager.Instance.WorldDatabase.SaveEntities(entityList);
+            // Add New Entity to the EntityCache
+            //var cache = EntityCacheManager.Instance.GetEntityCache((ushort)context.Invoker.Map.Entry.Id);
+            //cache.AddEntity(npcModel);
+
+            #region Old Spawn Code
+            //var creatureModels = GameTableManager.Instance.Creature2DisplayInfo.GetEntry(creatureEntry.Creature2DisplayGroupId);
+
+            //var npcModel = new EntityModel()
+            //{
+            //    Id = DatabaseManager.Instance.WorldDatabase.GetNewEntityId(),
+            //    Creature = unitId,
+            //    Area = (ushort)context.Invoker.Zone.Id,
+            //    DisplayInfo = creatureModels.ModelTextureId00,
+            //    OutfitInfo = (ushort)creatureEntry.Creature2OutfitGroupId,
+            //    X = context.Invoker.Position.X,
+            //    Y = context.Invoker.Position.Y,
+            //    Z = context.Invoker.Position.Z,
+            //    Rx = context.Invoker.Rotation.X,
+            //    Ry = context.Invoker.Rotation.Y,
+            //    Rz = context.Invoker.Rotation.Z,
+            //    World = (ushort)context.Invoker.Map.Entry.Id,
+            //    Faction1 = (ushort)creatureEntry.FactionId,
+            //    Faction2 = (ushort)creatureEntry.FactionId,
+            //    Type = (byte)creatureEntry.CreationTypeEnum
+            //};
+
+            //npcModel.Id = DatabaseManager.Instance.WorldDatabase.GetNewEntityId();
+
+            //var entity = new NonPlayer();
+            //entity.CreateFlags = EntityCreateFlag.SpawnAnimation;
+            //entity.Initialise(npcModel, context.Invoker.Position, context.Invoker.Rotation);
+            //// Cannot use "context.GetTargetOrInvoker()" because if you are targeting an NPC it returns the NPC
+            //context.Invoker.Map.EnqueueAdd(entity, context.Invoker.Position);
+
+            //// Add New Entity to the EntityCache
+            //var cache = EntityCacheManager.Instance.GetEntityCache((ushort)context.Invoker.Map.Entry.Id);
+            //cache.AddEntity(npcModel);
+            //var activeNPCGrid = context.Invoker.Map.GetGrid(context.Invoker.Position);
+            //var entityList = cache.GetEntities(activeNPCGrid.Coord.X, activeNPCGrid.Coord.Z).ToList();
+
+            //// This function sets all the properties like health and shield etc, also prevents from spawning dead.
+            //entity.CalculateProperties();
+
+            //// Save Entity to Database (Entity Table)
+            //DatabaseManager.Instance.WorldDatabase.SaveEntities(entityList);
+            #endregion
         }
 
+        // Disabling Delete. Entities spawned are not persistent for now.
         [Command(Permission.Entity, "Delete an Entity by Target", "del")]
         public void HandleEntityDelete(ICommandContext context)
         {
-            
+
             if (context.Target == null)
             {
                 context.SendMessage($"Invalid target!");
@@ -144,18 +268,18 @@ namespace NexusForever.WorldServer.Command.Handler
                 context.SendMessage($"You cannot delete a player...");
                 return;
             }
-            
+
             context.Target.RemoveFromMap();
-            var model = DatabaseManager.Instance.WorldDatabase
-                .GetEntities((ushort)context.Invoker.Map.Entry.Id)
-                .Where(x => x.Id == context.Target.EntityId)
-                .FirstOrDefault();
+            //var model = DatabaseManager.Instance.WorldDatabase
+            //    .GetEntities((ushort)context.Invoker.Map.Entry.Id)
+            //    .Where(x => x.Id == context.Target.EntityId)
+            //    .FirstOrDefault();
 
-            // Remove Entity from Entity Cache (In-Game Object)
-            EntityCacheManager.Instance.GetEntityCache((ushort)context.Invoker.Map.Entry.Id).DeleteEntity(model);
+            //// Remove Entity from Entity Cache (In-Game Object)
+            //EntityCacheManager.Instance.GetEntityCache((ushort)context.Invoker.Map.Entry.Id).DeleteEntity(model);
 
-            // Remove Entity from Database (Persistence)
-            DatabaseManager.Instance.WorldDatabase.RemoveEntity(model);
+            //// Remove Entity from Database (Persistence)
+            //DatabaseManager.Instance.WorldDatabase.RemoveEntity(model);
         }
 
         [Command(Permission.EntityModify, "A collection of commands to modify an entity.", "modify")]

--- a/Source/NexusForever.WorldServer/Game/Entity/NewFolder/NPCSpawnModel.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/NewFolder/NPCSpawnModel.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NexusForever.WorldServer.Game.Entity
+{
+    public class NPCSpawnModel
+    {
+        public uint Id { get; set; }
+        public string Description { get; set; }
+    }
+}

--- a/Source/NexusForever.WorldServer/Game/Entity/NewFolder/NPCSpawnModel.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/NewFolder/NPCSpawnModel.cs
@@ -6,7 +6,13 @@ namespace NexusForever.WorldServer.Game.Entity
 {
     public class NPCSpawnModel
     {
-        public uint Id { get; set; }
+        public uint Creature { get; set; }
         public string Description { get; set; }
+        public uint Type { get; set; }
+        public uint displayInfo { get; set; }
+        public uint OutfitInfo { get; set; }
+        public uint faction1 { get; set; }
+        public uint faction2 { get; set; }
+        public ulong activePropId { get; set; }
     }
 }

--- a/Source/NexusForever.WorldServer/Game/Entity/NonPlayer.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/NonPlayer.cs
@@ -39,31 +39,47 @@ namespace NexusForever.WorldServer.Game.Entity
             };
         }
 
-        private void CalculateProperties()
+        /// <summary>
+        /// Updates Properties on Creature2 Entry (Submitted by SilentCLD in Discord)
+        /// </summary>
+        public void CalculateProperties()
         {
             Creature2Entry creatureEntry = GameTableManager.Instance.Creature2.GetEntry(CreatureId);
 
-            // TODO: research this some more
-            /*float[] values = new float[200];
+            // TODO: research this some more, is this giving the correct values?
+            float[] values = new float[200];
+            System.Random random = new System.Random();
+            ulong level = 1;
 
-            CreatureLevelEntry levelEntry = GameTableManager.Instance.CreatureLevel.GetEntry(6);
+            // TODO: Get the level for the entity instance from the db
+            if (creatureEntry != null)
+                level = (ulong)random.Next((int)creatureEntry.MinLevel, (int)creatureEntry.MaxLevel);
+
+            CreatureLevelEntry levelEntry = GameTableManager.Instance.CreatureLevel.GetEntry(level);
             for (uint i = 0u; i < levelEntry.UnitPropertyValue.Length; i++)
                 values[i] = levelEntry.UnitPropertyValue[i];
 
             Creature2ArcheTypeEntry archeTypeEntry = GameTableManager.Instance.Creature2ArcheType.GetEntry(creatureEntry.Creature2ArcheTypeId);
-            for (uint i = 0u; i < archeTypeEntry.UnitPropertyMultiplier.Length; i++)
-                values[i] *= archeTypeEntry.UnitPropertyMultiplier[i];
+            if (archeTypeEntry != null)
+                for (uint i = 0u; i < archeTypeEntry.UnitPropertyMultiplier.Length; i++)
+                    values[i] *= archeTypeEntry.UnitPropertyMultiplier[i];
 
             Creature2DifficultyEntry difficultyEntry = GameTableManager.Instance.Creature2Difficulty.GetEntry(creatureEntry.Creature2DifficultyId);
-            for (uint i = 0u; i < difficultyEntry.UnitPropertyMultiplier.Length; i++)
-                values[i] *= archeTypeEntry.UnitPropertyMultiplier[i];
+            if (difficultyEntry != null)
+                for (uint i = 0u; i < difficultyEntry.UnitPropertyMultiplier.Length; i++)
+                    values[i] *= difficultyEntry.UnitPropertyMultiplier[i];
 
             Creature2TierEntry tierEntry = GameTableManager.Instance.Creature2Tier.GetEntry(creatureEntry.Creature2TierId);
-            for (uint i = 0u; i < tierEntry.UnitPropertyMultiplier.Length; i++)
-                values[i] *= archeTypeEntry.UnitPropertyMultiplier[i];
+            if (tierEntry != null)
+                for (uint i = 0u; i < tierEntry.UnitPropertyMultiplier.Length; i++)
+                    values[i] *= tierEntry.UnitPropertyMultiplier[i];
 
             for (uint i = 0u; i < levelEntry.UnitPropertyValue.Length; i++)
-                SetProperty((Property)i, values[i]);*/
+                SetProperty((Property)i, values[i], values[i]);
+
+            SetStat(Stat.Level, (uint)level);
+            SetStat(Stat.Health, (uint)GetPropertyValue(Property.BaseHealth));
+            SetStat(Stat.Shield, (uint)GetPropertyValue(Property.ShieldCapacityMax));
         }
     }
 }

--- a/Source/NexusForever.WorldServer/Game/Entity/NonPlayer.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/NonPlayer.cs
@@ -56,6 +56,7 @@ namespace NexusForever.WorldServer.Game.Entity
                 level = (ulong)random.Next((int)creatureEntry.MinLevel, (int)creatureEntry.MaxLevel);
 
             CreatureLevelEntry levelEntry = GameTableManager.Instance.CreatureLevel.GetEntry(level);
+            if(levelEntry != null)
             for (uint i = 0u; i < levelEntry.UnitPropertyValue.Length; i++)
                 values[i] = levelEntry.UnitPropertyValue[i];
 
@@ -73,9 +74,9 @@ namespace NexusForever.WorldServer.Game.Entity
             if (tierEntry != null)
                 for (uint i = 0u; i < tierEntry.UnitPropertyMultiplier.Length; i++)
                     values[i] *= tierEntry.UnitPropertyMultiplier[i];
-
-            for (uint i = 0u; i < levelEntry.UnitPropertyValue.Length; i++)
-                SetProperty((Property)i, values[i], values[i]);
+            if (levelEntry != null)
+                for (uint i = 0u; i < levelEntry.UnitPropertyValue.Length; i++)
+                    SetProperty((Property)i, values[i], values[i]);
 
             SetStat(Stat.Level, (uint)level);
             SetStat(Stat.Health, (uint)GetPropertyValue(Property.BaseHealth));

--- a/Source/NexusForever.WorldServer/Game/Entity/Player.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/Player.cs
@@ -764,6 +764,12 @@ namespace NexusForever.WorldServer.Game.Entity
             XpManager.GrantXp(xp, reason);
         }
 
+        public void DealDamage(uint damage)
+        {
+            uint? newHealth = GetStatInteger(Stat.Health) - damage;
+            SetStat(Stat.Health, (uint)newHealth);
+        }
+
         /// <summary>
         /// Send <see cref="GenericError"/> to <see cref="Player"/>.
         /// </summary>

--- a/Source/NexusForever.WorldServer/Game/Entity/UnitEntity.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/UnitEntity.cs
@@ -31,6 +31,17 @@ namespace NexusForever.WorldServer.Game.Entity
             }
         }
 
+        public void DealDamage(uint amount)
+        {
+            if (this is Player player)
+            {
+                player.DealDamage(amount);
+            } else if (this is WorldEntity entity)
+            {
+                entity.DealDamage(amount);
+            }
+        }
+
         /// <summary>
         /// Cast a <see cref="Spell"/> with the supplied spell id and <see cref="SpellParameters"/>.
         /// </summary>

--- a/Source/NexusForever.WorldServer/Game/Entity/WorldEntity.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/WorldEntity.cs
@@ -197,6 +197,34 @@ namespace NexusForever.WorldServer.Game.Entity
             // deliberately empty
         }
 
+        public void DealDamage(uint amount)
+        {
+            // Hit Shields First
+            var unitHealth = GetStatInteger(Stat.Health);
+            var unitShields = GetStatInteger(Stat.Shield);
+
+            if(unitShields == 0)
+            {
+                if (unitHealth < amount) unitHealth = 0;
+                else unitHealth -= amount;
+
+            } else
+            {
+                if (unitShields <= amount)
+                {
+                    unitHealth = unitHealth - (amount - unitShields);
+                    unitShields = 0;
+                }
+                else if (unitShields > amount)
+                {
+                    unitShields -= amount;
+                }
+            }
+
+            SetStat(Stat.Shield, (uint)unitShields);
+            SetStat(Stat.Health, (uint)unitHealth);
+        }
+
         protected void SetProperty(Property property, float value, float baseValue = 0.0f)
         {
             if (Properties.ContainsKey(property))
@@ -294,6 +322,11 @@ namespace NexusForever.WorldServer.Game.Entity
             {
                 statValue = new StatValue(stat, value);
                 stats.Add(stat, statValue);
+            }
+
+            if(stat == Stat.Health)
+            {
+                
             }
 
             if (attribute.SendUpdate)

--- a/Source/NexusForever.WorldServer/Game/Entity/WorldEntity.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/WorldEntity.cs
@@ -95,6 +95,28 @@ namespace NexusForever.WorldServer.Game.Entity
 
             foreach (EntityStatModel statModel in model.EntityStat)
                 stats.Add((Stat)statModel.Stat, new StatValue(statModel));
+
+        }
+
+        /// <summary>
+        /// Initialise <see cref="WorldEntity"/> from an existing database model.
+        /// </summary>
+        public virtual void Initialise(EntityModel model, Vector3 position, Vector3 rotation)
+        {
+            EntityId = model.Id;
+            CreatureId = model.Creature;
+            Rotation = new Vector3(rotation.X, rotation.Y, rotation.Z);
+            DisplayInfo = model.DisplayInfo;
+            OutfitInfo = model.OutfitInfo;
+            Faction1 = (Faction)model.Faction1;
+            Faction2 = (Faction)model.Faction2;
+            ActivePropId = model.ActivePropId;
+            WorldSocketId = model.WorldSocketId;
+            Position = new Vector3(position.X, position.Y, position.Z);
+            
+            foreach (EntityStatModel statModel in model.EntityStat)
+                stats.Add((Stat)statModel.Stat, new StatValue(statModel));
+
         }
 
         public override void OnAddToMap(BaseMap map, uint guid, Vector3 vector)

--- a/Source/NexusForever.WorldServer/Game/Entity/WorldEntity.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/WorldEntity.cs
@@ -92,6 +92,7 @@ namespace NexusForever.WorldServer.Game.Entity
             Faction2     = (Faction)model.Faction2;
             ActivePropId = model.ActivePropId;
             WorldSocketId = model.WorldSocketId;
+            Position = new Vector3(model.X, model.Y, model.Z);
 
             foreach (EntityStatModel statModel in model.EntityStat)
                 stats.Add((Stat)statModel.Stat, new StatValue(statModel));

--- a/Source/NexusForever.WorldServer/Game/Map/BaseMap.cs
+++ b/Source/NexusForever.WorldServer/Game/Map/BaseMap.cs
@@ -204,6 +204,11 @@ namespace NexusForever.WorldServer.Game.Map
             return grids[gridZ * MapDefines.WorldGridCount + gridX];
         }
 
+        /// <summary>
+        /// Returns Grid X and Z Values Based On A Given <see cref="Vector3"/> World Position 
+        /// </summary>
+        /// <param name="vector"></param>
+        /// <returns><see cref="MapGrid"/></returns>
         public MapGrid GetGrid(Vector3 vector)
         {
             (uint gridX, uint gridZ) = MapGrid.GetGridCoord(vector);

--- a/Source/NexusForever.WorldServer/Game/Map/BaseMap.cs
+++ b/Source/NexusForever.WorldServer/Game/Map/BaseMap.cs
@@ -204,7 +204,7 @@ namespace NexusForever.WorldServer.Game.Map
             return grids[gridZ * MapDefines.WorldGridCount + gridX];
         }
 
-        private MapGrid GetGrid(Vector3 vector)
+        public MapGrid GetGrid(Vector3 vector)
         {
             (uint gridX, uint gridZ) = MapGrid.GetGridCoord(vector);
             return GetGrid(gridX, gridZ);

--- a/Source/NexusForever.WorldServer/Game/Map/EntityCache.cs
+++ b/Source/NexusForever.WorldServer/Game/Map/EntityCache.cs
@@ -34,6 +34,14 @@ namespace NexusForever.WorldServer.Game.Map
             entities[coord].Add(model);
         }
 
+        public void DelEntity(EntityModel model)
+        {
+            var vector = new Vector3(model.X, model.Y, model.Z);
+            (uint GridX, uint GridZ) coord = MapGrid.GetGridCoord(vector);
+
+            entities.Remove(coord);
+        }
+
         /// <summary>
         /// Return all <see cref="EntityModel"/>'s to be spawned for parent <see cref="MapGrid"/>.
         /// </summary>
@@ -41,5 +49,6 @@ namespace NexusForever.WorldServer.Game.Map
         {
             return entities.TryGetValue((gridX, gridZ), out HashSet<EntityModel> cellEntities) ? cellEntities : Enumerable.Empty<EntityModel>();
         }
+
     }
 }

--- a/Source/NexusForever.WorldServer/Game/Map/EntityCache.cs
+++ b/Source/NexusForever.WorldServer/Game/Map/EntityCache.cs
@@ -34,7 +34,11 @@ namespace NexusForever.WorldServer.Game.Map
             entities[coord].Add(model);
         }
 
-        public void DelEntity(EntityModel model)
+        /// <summary>
+        /// Removes <see cref="EntityModel"/> from <see cref="EntityCache"/> at a given <see cref="Vector3"/> World Position
+        /// </summary>
+        /// <param name="model"></param>
+        public void DeleteEntity(EntityModel model)
         {
             var vector = new Vector3(model.X, model.Y, model.Z);
             (uint GridX, uint GridZ) coord = MapGrid.GetGridCoord(vector);

--- a/Source/NexusForever.WorldServer/Game/Social/SocialManager.cs
+++ b/Source/NexusForever.WorldServer/Game/Social/SocialManager.cs
@@ -110,6 +110,22 @@ namespace NexusForever.WorldServer.Game.Social
             }
         }
 
+        /// <summary>
+        /// Clears Local Chat after using a ! command in chat
+        /// </summary>
+        /// <param name="session"></param>
+        public void SendCommandChatAccept(WorldSession session)
+        {
+            session.EnqueueMessageEncrypted(new ServerChatAccept { 
+                 
+            });
+            //session.EnqueueMessageEncrypted(new ServerChatAccept
+            //{
+            //    Name = session.Player.Name,
+            //    Guid = session.Player.Guid
+            //});
+        }
+
         private void SendChatAccept(WorldSession session)
         {
             session.EnqueueMessageEncrypted(new ServerChatAccept

--- a/Source/NexusForever.WorldServer/Game/Spell/SpellEffectHandler.cs
+++ b/Source/NexusForever.WorldServer/Game/Spell/SpellEffectHandler.cs
@@ -18,6 +18,7 @@ namespace NexusForever.WorldServer.Game.Spell
         private void HandleEffectDamage(UnitEntity target, SpellTargetInfo.SpellTargetEffectInfo info)
         {
             // TODO: calculate damage
+            target.DealDamage(1337);
             info.AddDamage((DamageType)info.Entry.DamageType, 1337);
         }
 

--- a/Source/NexusForever.WorldServer/Network/Message/Handler/SocialHandler.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Handler/SocialHandler.cs
@@ -31,6 +31,9 @@ namespace NexusForever.WorldServer.Network.Message.Handler
                     var target  = session.Player.GetVisible<WorldEntity>(session.Player.TargetGuid);
                     var context = new WorldSessionCommandContext(session.Player, target);
                     CommandManager.Instance.HandleCommand(context, chat.Message.Substring(CommandPrefix.Length));
+                    // Send Accept Chat from Command Usage Okay
+                    Player player = context.Invoker as Player;
+                    SocialManager.Instance.SendCommandChatAccept(player.Session);
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
When copying over my files after a fork, apparently I forgot the WorldDatabase file (It only opened the worldserver project apparently)... SO...

Original: 
This is only the functionality of actually getting NPCs in the world through !entity add|del commands.

The NPCs are dead on spawn, which is the next step. I don't know if they will 'be resurrected' when the health is restored after re-initialization on server boot, so i wouldn't recommend going nuts spawning mobs yet.

Known Issue: The graphical display and the ID of the actual creature are not really ... right. The name is right but the models don't seem to match up for some reason on certain things.