### PR TITLE
Housing PlotIndex support - addresses #218 in the develop branch

### DIFF
--- a/Source/NexusForever.Game.Abstract/Housing/IDecor.cs
+++ b/Source/NexusForever.Game.Abstract/Housing/IDecor.cs
@@ -26,7 +26,7 @@ namespace NexusForever.Game.Abstract.Housing
         /// <summary>
         /// Move <see cref="IDecor"/> to supplied position.
         /// </summary>
-        void Move(DecorType type, Vector3 position, Quaternion rotation, float scale);
+        void Move(DecorType type, Vector3 position, Quaternion rotation, float scale, uint plotIndex);
 
         /// <summary>
         /// Move <see cref="IDecor"/> to the crate.

--- a/Source/NexusForever.Game/Housing/Decor.cs
+++ b/Source/NexusForever.Game/Housing/Decor.cs
@@ -297,12 +297,13 @@ namespace NexusForever.Game.Housing
         /// <summary>
         /// Move <see cref="IDecor"/> to supplied position.
         /// </summary>
-        public void Move(DecorType type, Vector3 position, Quaternion rotation, float scale)
+        public void Move(DecorType type, Vector3 position, Quaternion rotation, float scale, uint plotIndex)
         {
-            Type     = type;
-            Position = position;
-            Rotation = rotation;
-            Scale    = scale;
+            Type      = type;
+            Position  = position;
+            Rotation  = rotation;
+            Scale     = scale;
+            PlotIndex = plotIndex;
         }
 
         /// <summary>
@@ -310,7 +311,7 @@ namespace NexusForever.Game.Housing
         /// </summary>
         public void Crate()
         {
-            Move(DecorType.Crate, Vector3.Zero, Quaternion.Identity, 0f);
+            Move(DecorType.Crate, Vector3.Zero, Quaternion.Identity, 0f, int.MaxValue);
             DecorParentId = 0u;
         }
 

--- a/Source/NexusForever.Game/Map/Instance/ResidenceMapInstance.cs
+++ b/Source/NexusForever.Game/Map/Instance/ResidenceMapInstance.cs
@@ -443,7 +443,7 @@ namespace NexusForever.Game.Map.Instance
                     }
 
                     // crate->world
-                    decor.Move(update.DecorType, update.Position, update.Rotation, update.Scale);
+                    decor.Move(update.DecorType, update.Position, update.Rotation, update.Scale, update.PlotIndex);
                 }
                 else
                 {
@@ -452,7 +452,7 @@ namespace NexusForever.Game.Map.Instance
                     else
                     {
                         // world->world
-                        decor.Move(update.DecorType, update.Position, update.Rotation, update.Scale);
+                        decor.Move(update.DecorType, update.Position, update.Rotation, update.Scale, update.PlotIndex);
                         decor.DecorParentId = update.ParentDecorId;
                     }
                 }

--- a/Source/NexusForever.GameTable/GameTableManager.cs
+++ b/Source/NexusForever.GameTable/GameTableManager.cs
@@ -679,6 +679,7 @@ namespace NexusForever.GameTable
         [GameData]
         public GameTable<WorldSkyEntry> WorldSky { get; private set; }
 
+        [GameData]
         public GameTable<WorldSocketEntry> WorldSocket { get; private set; }
         public GameTable<WorldWaterEnvironmentEntry> WorldWaterEnvironment { get; private set; }
         public GameTable<WorldWaterFogEntry> WorldWaterFog { get; private set; }


### PR DESCRIPTION
As mentioned in the commit message, the known issues are:
1) Currently requires the plotIndex database default to be set
to 0 in order to properly set the plotIndex when placing on PlotIndex=0
from the vendor.
2) When placing in PlotIndex=0, the Y value in the database is not what you
see in game. The position as placed in game does persist as expected across
server loads so long as the plotIndex in the database is properly set to 0
(see 1). If the plotIndex is set to Int.MaxValue instead of 0, the item will
raise from its intended location after a server restart.