### PR TITLE
Spells/Core: Support cancel-only effects

### DIFF
--- a/Source/NexusForever.WorldServer/Game/Spell/SpellParameters.cs
+++ b/Source/NexusForever.WorldServer/Game/Spell/SpellParameters.cs
@@ -12,5 +12,6 @@ namespace NexusForever.WorldServer.Game.Spell
         public uint PrimaryTargetId { get; set; }
         public Position Position { get; set; }
         public ushort TaxiNode { get; set; }
+        public bool ForceCancelOnly { get; set; }
     }
 }

--- a/Source/NexusForever.WorldServer/Game/Spell/Static/SpellEffectFlags.cs
+++ b/Source/NexusForever.WorldServer/Game/Spell/Static/SpellEffectFlags.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace NexusForever.WorldServer.Game.Spell.Static
+{
+    [Flags]
+    public enum SpellEffectFlags
+    {
+        None       = 0x00,
+        CancelOnly = 0x02,
+    }
+}

--- a/Source/NexusForever.WorldServer/Game/Spell/Static/SpellStatus.cs
+++ b/Source/NexusForever.WorldServer/Game/Spell/Static/SpellStatus.cs
@@ -5,6 +5,7 @@
         Initiating,
         Casting,
         Executing,
-        Finished
+        Finished,
+        Finishing
     }
 }


### PR DESCRIPTION
This adds support to the server to allow for permanent duration spells & effects, that are only removed by being forced to end - either by another spell / effect, or a user interaction (like clicking off a buff). This allows us to end spells from continuously running in the server.