### PR TITLE
Player/Movement: Fix Position/Rotation emit errors

### DIFF
--- a/Source/NexusForever.WorldServer/Game/Entity/Movement/MovementManager.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/Movement/MovementManager.cs
@@ -109,7 +109,7 @@ namespace NexusForever.WorldServer.Game.Entity.Movement
             AddCommand(new SetPositionCommand
             {
                 Position = new Position(position)
-            }, true);
+            }, !(owner is Player));
         }
 
         /// <summary>
@@ -124,7 +124,7 @@ namespace NexusForever.WorldServer.Game.Entity.Movement
             AddCommand(new SetRotationCommand
             {
                 Position = new Position(rotation)
-            }, true);
+            }, !(owner is Player));
         }
 
         /// <summary>

--- a/Source/NexusForever.WorldServer/Network/Message/Handler/EntityHandler.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Handler/EntityHandler.cs
@@ -34,10 +34,12 @@ namespace NexusForever.WorldServer.Network.Message.Handler
                         // session.Player.CancelSpellsOnMove();
 
                         mover.Map.EnqueueRelocate(mover, setPosition.Position.Vector);
+                        mover.MovementManager.SetPosition(setPosition.Position.Vector);
                         break;
                     }
                     case SetRotationCommand setRotation:
                         mover.Rotation = setRotation.Position.Vector;
+                        mover.MovementManager.SetRotation(setRotation.Position.Vector);
                         break;
                 }
             }


### PR DESCRIPTION
This resolves the issue where Players don't show up for other Players when the other player enters range until the first player moves. Complicated way to say: Now, when a player enters range of another, you will immediately see them!