### PR TITLE
Item: Fix a special case where BagIndex can be out of sync

### DIFF
--- a/Source/NexusForever.WorldServer/Game/Entity/Bag.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/Bag.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using NexusForever.Database.Character;
 using NexusForever.WorldServer.Game.Entity.Static;
 using NLog;
 
@@ -21,6 +22,22 @@ namespace NexusForever.WorldServer.Game.Entity
             items    = new Item[capacity];
 
             log.Trace($"Initialised new bag {Location} with {capacity} slots.");
+        }
+
+        public void Save(CharacterContext context)
+        {
+            for (uint i = 0; i < items.Length; ++i)
+            {
+                // Item does not exist in slot
+                if (items[i] == null)
+                    continue;
+
+                // Item has incorrect slot, setting the BagIndex to the current index
+                if (i != items[i].BagIndex)
+                    items[i].BagIndex = i;
+
+                items[i].Save(context);
+            }
         }
 
         /// <summary>

--- a/Source/NexusForever.WorldServer/Game/Entity/Bag.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/Bag.cs
@@ -34,7 +34,10 @@ namespace NexusForever.WorldServer.Game.Entity
 
                 // Item has incorrect slot, setting the BagIndex to the current index
                 if (i != items[i].BagIndex)
+                {
+                    log.Warn($"Item with guid: 0x{items[i].Guid:X16} has incorrect slot: {items[i].BagIndex}, setting to slot: {i}");
                     items[i].BagIndex = i;
+                }
 
                 items[i].Save(context);
             }

--- a/Source/NexusForever.WorldServer/Game/Entity/Inventory.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/Inventory.cs
@@ -84,10 +84,8 @@ namespace NexusForever.WorldServer.Game.Entity
             
             deletedItems.Clear();
 
-            foreach (Item item in bags.Values
-                .Where(b => b.Location != InventoryLocation.Ability)
-                .SelectMany(i => i))
-                item.Save(context);
+            foreach (Bag bag in bags.Values.Where(b => b.Location != InventoryLocation.Ability))
+                bag.Save(context);
         }
 
         /// <summary>

--- a/Source/NexusForever.WorldServer/Network/Message/Handler/CharacterHandler.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Handler/CharacterHandler.cs
@@ -27,11 +27,11 @@ using NexusForever.WorldServer.Game.Static;
 using NexusForever.WorldServer.Network.Message.Model;
 using NexusForever.WorldServer.Network.Message.Model.Shared;
 using NexusForever.WorldServer.Network.Message.Static;
+using NLog;
 using CostumeEntity = NexusForever.WorldServer.Game.Entity.Costume;
 using Item = NexusForever.WorldServer.Game.Entity.Item;
 using Residence = NexusForever.WorldServer.Game.Housing.Residence;
 using NetworkMessage = NexusForever.Shared.Network.Message.Model.Shared.Message;
-using NLog;
 
 namespace NexusForever.WorldServer.Network.Message.Handler
 {

--- a/Source/NexusForever.WorldServer/Network/Message/Handler/CharacterHandler.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Handler/CharacterHandler.cs
@@ -31,11 +31,14 @@ using CostumeEntity = NexusForever.WorldServer.Game.Entity.Costume;
 using Item = NexusForever.WorldServer.Game.Entity.Item;
 using Residence = NexusForever.WorldServer.Game.Housing.Residence;
 using NetworkMessage = NexusForever.Shared.Network.Message.Model.Shared.Message;
+using NLog;
 
 namespace NexusForever.WorldServer.Network.Message.Handler
 {
     public static class CharacterHandler
     {
+        private static readonly ILogger log = LogManager.GetCurrentClassLogger();
+
         [MessageHandler(GameMessageOpcode.ClientRealmList)]
         public static void HandleRealmList(WorldSession session, ClientRealmList realmList)
         {
@@ -162,49 +165,57 @@ namespace NexusForever.WorldServer.Network.Message.Handler
 
                     maxCharacterLevelAchieved = (byte)Math.Max(maxCharacterLevelAchieved, character.Level);
 
-                    // create a temporary Inventory and CostumeManager to show equipped gear
-                    var inventory      = new Inventory(null, character);
-                    var costumeManager = new CostumeManager(null, session.Account, character);
-
-                    CostumeEntity costume = null;
-                    if (character.ActiveCostumeIndex >= 0)
-                        costume = costumeManager.GetCostume((byte)character.ActiveCostumeIndex);
-
-                    listCharacter.GearMask = costume?.Mask ?? 0xFFFFFFFF;
-
-                    foreach (ItemVisual itemVisual in inventory.GetItemVisuals(costume))
-                        listCharacter.Gear.Add(itemVisual);
-
-                    foreach (CharacterAppearanceModel appearance in character.Appearance)
+                    try
                     {
-                        listCharacter.Appearance.Add(new ItemVisual
+                        // create a temporary Inventory and CostumeManager to show equipped gear
+                        var inventory = new Inventory(null, character);
+                        var costumeManager = new CostumeManager(null, session.Account, character);
+
+                        CostumeEntity costume = null;
+                        if (character.ActiveCostumeIndex >= 0)
+                            costume = costumeManager.GetCostume((byte)character.ActiveCostumeIndex);
+
+                        listCharacter.GearMask = costume?.Mask ?? 0xFFFFFFFF;
+
+                        foreach (ItemVisual itemVisual in inventory.GetItemVisuals(costume))
+                            listCharacter.Gear.Add(itemVisual);
+
+                        foreach (CharacterAppearanceModel appearance in character.Appearance)
                         {
-                            Slot      = (ItemSlot)appearance.Slot,
-                            DisplayId = appearance.DisplayId
-                        });
-                    }
-
-                    /*foreach (CharacterCustomisation customisation in character.CharacterCustomisation)
-                    {
-                        listCharacter.Labels.Add(customisation.Label);
-                        listCharacter.Values.Add(customisation.Value);
-                    }*/
-
-                    foreach (CharacterBoneModel bone in character.Bone.OrderBy(bone => bone.BoneIndex))
-                    {
-                        listCharacter.Bones.Add(bone.Bone);
-                    }
-
-                    foreach (CharacterStatModel stat in character.Stat)
-                    {
-                        if ((Stat)stat.Stat == Stat.Level)
-                        {
-                            listCharacter.Level = (uint)stat.Value;
-                            break;
+                            listCharacter.Appearance.Add(new ItemVisual
+                            {
+                                Slot = (ItemSlot)appearance.Slot,
+                                DisplayId = appearance.DisplayId
+                            });
                         }
-                    }
 
-                    serverCharacterList.Characters.Add(listCharacter);
+                        /*foreach (CharacterCustomisation customisation in character.CharacterCustomisation)
+                        {
+                            listCharacter.Labels.Add(customisation.Label);
+                            listCharacter.Values.Add(customisation.Value);
+                        }*/
+
+                        foreach (CharacterBoneModel bone in character.Bone.OrderBy(bone => bone.BoneIndex))
+                        {
+                            listCharacter.Bones.Add(bone.Bone);
+                        }
+
+                        foreach (CharacterStatModel stat in character.Stat)
+                        {
+                            if ((Stat)stat.Stat == Stat.Level)
+                            {
+                                listCharacter.Level = (uint)stat.Value;
+                                break;
+                            }
+                        }
+
+                        serverCharacterList.Characters.Add(listCharacter);
+                    }
+                    catch (Exception ex)
+                    {
+                        log.Fatal(ex, $"An error has occured while loading character '{character.Name}'");
+                        continue;
+                    }
                 }
 
                 session.EnqueueMessageEncrypted(new ServerMaxCharacterLevelAchieved


### PR DESCRIPTION
- Fixed the special case where `item.BagIndex` can be out of sync of the assigned Bag slot.
- Wrapped character loading into a try catch statement so the character enum can continue loading while there is an error