### PR TITLE
Entity/Mounts: Fix Dismount phase glitch

### DIFF
--- a/Source/NexusForever.WorldServer/Game/Entity/Vehicle.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/Vehicle.cs
@@ -232,18 +232,20 @@ namespace NexusForever.WorldServer.Game.Entity
             player.VehicleGuid = 0;
             player.MovementManager.SetPosition(Position);
             player.MovementManager.SetRotation(Rotation);
+            player.MovementManager.BroadcastCommands();
 
-            EnqueueToVisible(new ServerVehiclePassengerRemove
-            {
-                Self      = Guid,
-                Passenger = passenger.Guid
-            }, true);
 
             if (passenger.SeatType == VehicleSeatType.Pilot)
                 player.SetControl(player);
 
             passengers.Remove(passenger);
             OnPassengerRemove(player, passenger.SeatType, passenger.SeatPosition);
+
+            EnqueueToVisible(new ServerVehiclePassengerRemove
+            {
+                Self      = Guid,
+                Passenger = passenger.Guid
+            }, true);
 
             // this probably isn't correct for all cases
             if (passengers.Count == 0)


### PR DESCRIPTION
There is a slight issue when dismounting where surrounding entities will phase out and then come back. I had it bug up the other day where it got stuck in some weird loop and the entities would phase in to view, then out, then in, then out, and it would repeat until I either mounted or restarted client.

It appears to be down to the fact that when the mount is removed, depending on when the server's next tick happens, the game still thinks the player is at `<0, 0, 0>` until it gets an Entity Commands update, but in the interim, it phases out entities near the player. Anyway, this resolves that issue by immediately sending the Entity Commands, and then handling removing the mount and restoring control to the right place, etc.