### PR TITLE
[AuthServer] Send first online server to client instead of first in the db

### DIFF
--- a/Source/NexusForever.AuthServer/Network/Message/Handler/AuthenticationHandler.cs
+++ b/Source/NexusForever.AuthServer/Network/Message/Handler/AuthenticationHandler.cs
@@ -44,7 +44,7 @@ namespace NexusForever.AuthServer.Network.Message.Handler
                 }
 
                 // TODO: might want to make this smarter in the future, eg: select a server the user has characters on
-                ServerInfo server = ServerManager.Instance.Servers.FirstOrDefault();
+                ServerInfo server = ServerManager.Instance.Servers.FirstOrDefault(s => s.IsOnline);
                 if (server == null)
                 {
                     SendServerAuthDenied(NpLoginResult.NoRealmsAvailableAtThisTime);


### PR DESCRIPTION
Title. Also the server will now send `NpLoginResult.NoRealmsAvailableAtThisTime` when no servers are online.