### PR TITLE
Auto move materials to satchel then the bag if full

### DIFF
--- a/Source/NexusForever.WorldServer/Game/Entity/Inventory.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/Inventory.cs
@@ -321,6 +321,12 @@ namespace NexusForever.WorldServer.Game.Entity
             if (itemEntry == null)
                 throw new ArgumentNullException();
 
+            // auto move materials into satchel but not when moving mats to bag from satchel
+            if (reason != ItemUpdateReason.ResourceConversion) {
+                if (GameTableManager.Instance.TradeskillMaterial.Entries.SingleOrDefault(i => i.Item2IdStatRevolution == itemEntry.Id) != null)
+                    count = player.SupplySatchelManager.AddAmount(new Item(characterId, itemEntry, count, charges), count);
+            }
+
             Bag bag = GetBag(InventoryLocation.Inventory);
             Debug.Assert(bag != null);
 

--- a/Source/NexusForever.WorldServer/Game/Entity/Inventory.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/Inventory.cs
@@ -322,7 +322,8 @@ namespace NexusForever.WorldServer.Game.Entity
                 throw new ArgumentNullException();
 
             // auto move materials into satchel but not when moving mats to bag from satchel
-            if (reason != ItemUpdateReason.ResourceConversion) {
+            if (reason != ItemUpdateReason.ResourceConversion) 
+            {
                 if (GameTableManager.Instance.TradeskillMaterial.Entries.SingleOrDefault(i => i.Item2IdStatRevolution == itemEntry.Id) != null)
                     count = player.SupplySatchelManager.AddAmount(new Item(characterId, itemEntry, count, charges), count);
             }


### PR DESCRIPTION
Added check against ItemUpdateReason which only allows adding to satchel if not moving items from satchel to bag. From this I check if the itemEntry is a material and attempt to add the amount being added to the satchel and returning the leftover to be added to the bag.