### PR TITLE
Fixed WorldServer crash when English text table is not loaded.

### DIFF
--- a/Source/NexusForever.WorldServer/Game/Entity/Player.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/Player.cs
@@ -459,7 +459,10 @@ namespace NexusForever.WorldServer.Game.Entity
             if (Zone != null)
             {
                 TextTable tt = GameTableManager.Instance.GetTextTable(Language.English);
-                SocialManager.Instance.SendMessage(Session, $"New Zone: ({Zone.Id}){tt.GetEntry(Zone.LocalizedTextIdName)}");
+                if (tt != null)
+                {
+                    SocialManager.Instance.SendMessage(Session, $"New Zone: ({Zone.Id}){tt.GetEntry(Zone.LocalizedTextIdName)}");
+                }
 
                 uint tutorialId = AssetManager.Instance.GetTutorialIdForZone(Zone.Id);
                 if (tutorialId > 0)


### PR DESCRIPTION
It took me a while to find the en-US client and I came across this crash while using the de-DE client. 