### PR TITLE
Enable Personal Banking.

### DIFF
--- a/Source/NexusForever.WorldServer/Game/Entity/Static/InventoryLocation.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/Static/InventoryLocation.cs
@@ -9,7 +9,8 @@
         [InventoryLocation(16u)]
         Inventory = 1,
 
-        Unknown2  = 2,
+        [InventoryLocation(32u)]
+        PlayerBank  = 2,
 
         [InventoryLocation(512u)]
         Ability   = 4,


### PR DESCRIPTION
Identified Unknown2 as Player Bank, adding the InventoryLocation attribute enables it in inside Inventory.cs and correctly updates / saves the bag.

Unsure of the Size of the Bag so have set it to the same size as the bank when opened.

Fixes #341