### PR TITLE
Fixes for not being able to /ginvite somone who is guildless.

### DIFF
--- a/Source/NexusForever.WorldServer/Game/Guild/GuildManager.cs
+++ b/Source/NexusForever.WorldServer/Game/Guild/GuildManager.cs
@@ -277,7 +277,7 @@ namespace NexusForever.WorldServer.Game.Guild
             if (guild == null)
                 return new GuildResultInfo(GuildResult.NotAGuild);
 
-            if (CanStoreGuildType(guild.Type))
+            if (!CanStoreGuildType(guild.Type))
                 return new GuildResultInfo(GuildResult.CharacterCannotJoinMoreGuilds, referenceString: owner.Name);
 
             if (pendingInvite != null)


### PR DESCRIPTION
CharacterCannotJoinMoreGuilds was mistakenly sent if the character could join more guilds, meaning it was impossible to /ginvite someone who wasn't already in a guild.