### PR TITLE
Fixed a network issue where, if the 4096-byte buffer filled up fully …

### DIFF
--- a/Source/NexusForever.Shared/NexusForever.Shared.csproj
+++ b/Source/NexusForever.Shared/NexusForever.Shared.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="NLog" Version="4.7.6" />
+    <PackageReference Include="System.IO.Pipelines" Version="5.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
…and the 4 bytes starting a packet straddled the end of the buffer, it would cause disconnections. Often caused failed logins on characters on big plots.