### PR TITLE
Spells/Telegraphs: Reworked Init & Target Selection (v1.1)

### DIFF
--- a/Source/NexusForever.Shared/MathsExtensions.cs
+++ b/Source/NexusForever.Shared/MathsExtensions.cs
@@ -85,6 +85,16 @@ namespace NexusForever.Shared
         }
 
         /// <summary>
+        /// Returns a <see cref="Vector3"/> which has been offset by supplied angle and distance. Only for use in Telegraphs.
+        /// </summary>
+        public static Vector3 GetPointForTelegraph(this Vector3 v, float angle, float distance)
+        {
+            float x = v.X + MathF.Cos(angle) * distance;
+            float z = v.Z - MathF.Sin(angle) * distance;
+            return new Vector3(x, v.Y, z);
+        }
+
+        /// <summary>
         /// Returns a <see cref="Vector3"/> which has been offset by supplied angle and distance.
         /// </summary>
         public static Vector3 GetPoint2D(this Vector3 v, float angle, float distance)
@@ -97,6 +107,28 @@ namespace NexusForever.Shared
         public static float GetDistance(this Vector3 v1, Vector3 v2)
         {
             return MathF.Sqrt(MathF.Pow(v1.X - v2.X, 2) + MathF.Pow(v1.Z - v2.Z, 2));
+        }
+
+        /// <summary>
+        /// Returns a <see cref="Vector3"/> representing Euler degrees rotation towards a target <see cref="Vector3"/>, given a <see cref="Vector3"/> representing position.
+        /// </summary>
+        public static Vector3 GetRotationTo(this Vector3 v, Vector3 targetVector)
+        {
+            return new Vector3(v.GetAngle(targetVector), 0f, 0f);
+        }
+
+        /// <summary>
+        /// Returns a value, in radians, that repesents rotation between PI & -PI
+        /// </summary>
+        public static float CondenseRadianIntoRotationRadian(this float radians)
+        {
+            if (radians > MathF.PI)
+                return -MathF.PI + (radians.NormaliseRadians());
+
+            if (radians < -MathF.PI)
+                return MathF.PI + (radians.NormaliseRadians());
+
+            return radians.NormaliseRadians();
         }
     }
 }

--- a/Source/NexusForever.WorldServer/Command/Handler/SpellCommandCategory.cs
+++ b/Source/NexusForever.WorldServer/Command/Handler/SpellCommandCategory.cs
@@ -5,7 +5,7 @@ using NexusForever.WorldServer.Game.Spell;
 
 namespace NexusForever.WorldServer.Command.Handler
 {
-    [Command(Permission.Spell, "A collection of commands to manage spells.")]
+    [Command(Permission.Spell, "A collection of commands to manage spells.", "spell")]
     public class SpellCommandCategory : CommandCategory
     {
         [Command(Permission.SpellAdd, "Add a base spell to character, optionally supplying the tier.", "add")]

--- a/Source/NexusForever.WorldServer/Game/Entity/Simple.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/Simple.cs
@@ -17,6 +17,20 @@ namespace NexusForever.WorldServer.Game.Entity
         {
         }
 
+        public Simple(uint creatureId)
+            : base(EntityType.Simple)
+        {
+            CreatureId = creatureId;
+
+            // temp
+            DisplayInfo = 24413;
+            SetProperty(Property.BaseHealth, 100.0f);
+
+            SetStat(Stat.Health, 800u);
+            SetStat(Stat.Level, 3u);
+            SetStat(Stat.Sheathed, 800u);
+        }
+
         public override void Initialise(EntityModel model)
         {
             base.Initialise(model);

--- a/Source/NexusForever.WorldServer/Game/Entity/Simple.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/Simple.cs
@@ -17,20 +17,6 @@ namespace NexusForever.WorldServer.Game.Entity
         {
         }
 
-        public Simple(uint creatureId)
-            : base(EntityType.Simple)
-        {
-            CreatureId = creatureId;
-
-            // temp
-            DisplayInfo = 24413;
-            SetProperty(Property.BaseHealth, 100.0f);
-
-            SetStat(Stat.Health, 800u);
-            SetStat(Stat.Level, 3u);
-            SetStat(Stat.Sheathed, 800u);
-        }
-
         public override void Initialise(EntityModel model)
         {
             base.Initialise(model);

--- a/Source/NexusForever.WorldServer/Game/Entity/UnitEntity.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/UnitEntity.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Numerics;
 using NexusForever.Database.World.Model;
-using NexusForever.Shared.Game;
 using NexusForever.Shared.GameTable;
 using NexusForever.Shared.GameTable.Model;
 using NexusForever.WorldServer.Game.Entity.Static;
@@ -28,8 +26,20 @@ namespace NexusForever.WorldServer.Game.Entity
         public override void Initialise(EntityModel model)
         {
             base.Initialise(model);
+        }
 
-            InitialiseHitRadius();
+        private void InitialiseHitRadius()
+        {
+            if (CreatureId == 0u)
+                return;
+
+            Creature2Entry creatureEntry = GameTableManager.Instance.Creature2.GetEntry(CreatureId);
+            if (creatureEntry == null)
+                return;
+
+            Creature2ModelInfoEntry modelInfoEntry = GameTableManager.Instance.Creature2ModelInfo.GetEntry(creatureEntry.Creature2ModelInfoId);
+            if (modelInfoEntry != null)
+                HitRadius = modelInfoEntry.HitRadius * creatureEntry.ModelScale;
         }
 
         public override void Update(double lastTick)
@@ -130,20 +140,6 @@ namespace NexusForever.WorldServer.Game.Entity
         {
             Spell.Spell spell = pendingSpells.SingleOrDefault(s => s.CastingId == castingId);
             spell?.CancelCast(CastResult.SpellCancelled);
-        }
-
-        private void InitialiseHitRadius()
-        {
-            if (CreatureId == 0u)
-                return;
-
-            Creature2Entry creatureEntry = GameTableManager.Instance.Creature2.GetEntry(CreatureId);
-            if (creatureEntry == null)
-                return;
-                    
-            Creature2ModelInfoEntry modelInfoEntry = GameTableManager.Instance.Creature2ModelInfo.GetEntry(creatureEntry.Creature2ModelInfoId);
-            if (modelInfoEntry != null)
-                HitRadius = modelInfoEntry.HitRadius * creatureEntry.ModelScale;
         }
     }
 }

--- a/Source/NexusForever.WorldServer/Game/Entity/UnitEntity.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/UnitEntity.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Numerics;
+using NexusForever.Database.World.Model;
+using NexusForever.Shared.Game;
 using NexusForever.Shared.GameTable;
 using NexusForever.Shared.GameTable.Model;
 using NexusForever.WorldServer.Game.Entity.Static;
@@ -14,9 +17,19 @@ namespace NexusForever.WorldServer.Game.Entity
     {
         private readonly List<Spell.Spell> pendingSpells = new();
 
+        public float HitRadius { get; protected set; } = 1f;
+
         protected UnitEntity(EntityType type)
             : base(type)
         {
+            InitialiseHitRadius();
+        }
+
+        public override void Initialise(EntityModel model)
+        {
+            base.Initialise(model);
+
+            InitialiseHitRadius();
         }
 
         public override void Update(double lastTick)
@@ -117,6 +130,20 @@ namespace NexusForever.WorldServer.Game.Entity
         {
             Spell.Spell spell = pendingSpells.SingleOrDefault(s => s.CastingId == castingId);
             spell?.CancelCast(CastResult.SpellCancelled);
+        }
+
+        private void InitialiseHitRadius()
+        {
+            if (CreatureId == 0u)
+                return;
+
+            Creature2Entry creatureEntry = GameTableManager.Instance.Creature2.GetEntry(CreatureId);
+            if (creatureEntry == null)
+                return;
+                    
+            Creature2ModelInfoEntry modelInfoEntry = GameTableManager.Instance.Creature2ModelInfo.GetEntry(creatureEntry.Creature2ModelInfoId);
+            if (modelInfoEntry != null)
+                HitRadius = modelInfoEntry.HitRadius * creatureEntry.ModelScale;
         }
     }
 }

--- a/Source/NexusForever.WorldServer/Game/Map/Search/SearchCheckTelegraph.cs
+++ b/Source/NexusForever.WorldServer/Game/Map/Search/SearchCheckTelegraph.cs
@@ -16,7 +16,13 @@ namespace NexusForever.WorldServer.Game.Map.Search
 
         public bool CheckEntity(GridEntity entity)
         {
-            return entity is UnitEntity && caster != entity && telegraph.InsideTelegraph(entity.Position, (entity as UnitEntity).HitRadius);
+            if (entity is not UnitEntity unit)
+                return false;
+
+            if (entity == caster)
+                return false;
+
+            return telegraph.InsideTelegraph(entity.Position, unit.HitRadius);
         }
     }
 }

--- a/Source/NexusForever.WorldServer/Game/Map/Search/SearchCheckTelegraph.cs
+++ b/Source/NexusForever.WorldServer/Game/Map/Search/SearchCheckTelegraph.cs
@@ -16,7 +16,7 @@ namespace NexusForever.WorldServer.Game.Map.Search
 
         public bool CheckEntity(GridEntity entity)
         {
-            return entity is UnitEntity && caster != entity && telegraph.InsideTelegraph(entity.Position);
+            return entity is UnitEntity && caster != entity && telegraph.InsideTelegraph(entity.Position, (entity as UnitEntity).HitRadius);
         }
     }
 }

--- a/Source/NexusForever.WorldServer/Game/Spell/Spell.cs
+++ b/Source/NexusForever.WorldServer/Game/Spell/Spell.cs
@@ -79,7 +79,7 @@ namespace NexusForever.WorldServer.Game.Spell
 
             // It's assumed that non-player entities will be stood still to cast (most do). 
             // TODO: There are a handful of telegraphs that are attached to moving units (specifically rotating units) which this needs to be updated to account for.
-            if (!(caster is Player))
+            if (caster is not Player)
                 InitialiseTelegraphs();
 
             SendSpellStart();
@@ -290,47 +290,52 @@ namespace NexusForever.WorldServer.Game.Spell
 
         private void SendSpellStart()
         {
-            ServerSpellStart spellStart = new ServerSpellStart
+            var spellStart = new ServerSpellStart
             {
-                CastingId            = CastingId,
-                CasterId             = caster.Guid,
-                PrimaryTargetId      = caster.Guid,
-                Spell4Id             = parameters.SpellInfo.Entry.Id,
-                RootSpell4Id         = parameters.RootSpellInfo?.Entry.Id ?? 0,
-                ParentSpell4Id       = parameters.ParentSpellInfo?.Entry.Id ?? 0,
-                FieldPosition        = new Position(caster.Position),
-                Yaw                  = caster.Rotation.X,
+                CastingId              = CastingId,
+                CasterId               = caster.Guid,
+                PrimaryTargetId        = caster.Guid,
+                Spell4Id               = parameters.SpellInfo.Entry.Id,
+                RootSpell4Id           = parameters.RootSpellInfo?.Entry.Id ?? 0,
+                ParentSpell4Id         = parameters.ParentSpellInfo?.Entry.Id ?? 0,
+                FieldPosition          = new Position(caster.Position),
+                Yaw                    = caster.Rotation.X,
                 UserInitiatedSpellCast = parameters.UserInitiatedSpellCast,
-                InitialPositionData  = new List<ServerSpellStart.InitialPosition>(),
-                TelegraphPositionData = new List<ServerSpellStart.TelegraphPosition>()
+                InitialPositionData    = new List<ServerSpellStart.InitialPosition>(),
+                TelegraphPositionData  = new List<ServerSpellStart.TelegraphPosition>()
             };
 
-            List<UnitEntity> unitsCasting = new List<UnitEntity>();
+            var unitsCasting = new List<UnitEntity>();
             if (parameters.PrimaryTargetId > 0)
                 unitsCasting.Add(caster.GetVisible<UnitEntity>(parameters.PrimaryTargetId));
             else
                 unitsCasting.Add(caster);
 
             foreach (UnitEntity unit in unitsCasting)
+            {
                 spellStart.InitialPositionData.Add(new ServerSpellStart.InitialPosition
                 {
-                    UnitId = unit.Guid,
-                    Position = new Position(unit.Position),
+                    UnitId      = unit.Guid,
+                    Position    = new Position(unit.Position),
                     TargetFlags = 3,
-                    Yaw = unit.Rotation.X
+                    Yaw         = unit.Rotation.X
                 });
+            }
 
             foreach (UnitEntity unit in unitsCasting)
+            {
                 foreach (Telegraph telegraph in telegraphs)
+                {
                     spellStart.TelegraphPositionData.Add(new ServerSpellStart.TelegraphPosition
                     {
-                        TelegraphId = (ushort)telegraph.TelegraphDamage.Id,
+                        TelegraphId    = (ushort)telegraph.TelegraphDamage.Id,
                         AttachedUnitId = unit.Guid,
-                        TargetFlags = 3,
-                        Position = new Position(telegraph.Position),
-                        Yaw = telegraph.Rotation.X
+                        TargetFlags    = 3,
+                        Position       = new Position(telegraph.Position),
+                        Yaw            = telegraph.Rotation.X
                     });
-
+                }
+            }
 
             caster.EnqueueToVisible(spellStart, true);
         }
@@ -398,30 +403,36 @@ namespace NexusForever.WorldServer.Game.Spell
                 serverSpellGo.TargetInfoData.Add(networkTargetInfo);
             }
 
-            List<UnitEntity> unitsCasting = new List<UnitEntity>
-                {
-                    caster
-                };
+            var unitsCasting = new List<UnitEntity>
+            {
+                caster
+            };
 
             foreach (UnitEntity unit in unitsCasting)
-                serverSpellGo.InitialPositionData.Add(new Network.Message.Model.Shared.InitialPosition
+            {
+                serverSpellGo.InitialPositionData.Add(new InitialPosition
                 {
-                    UnitId = unit.Guid,
-                    Position = new Position(unit.Position),
+                    UnitId      = unit.Guid,
+                    Position    = new Position(unit.Position),
                     TargetFlags = 3,
-                    Yaw = unit.Rotation.X
+                    Yaw         = unit.Rotation.X
                 });
+            }
 
             foreach (UnitEntity unit in unitsCasting)
+            {
                 foreach (Telegraph telegraph in telegraphs)
+                {
                     serverSpellGo.TelegraphPositionData.Add(new TelegraphPosition
                     {
-                        TelegraphId = (ushort)telegraph.TelegraphDamage.Id,
+                        TelegraphId    = (ushort)telegraph.TelegraphDamage.Id,
                         AttachedUnitId = unit.Guid,
-                        TargetFlags = 3,
-                        Position = new Position(telegraph.Position),
-                        Yaw = telegraph.Rotation.X
+                        TargetFlags    = 3,
+                        Position       = new Position(telegraph.Position),
+                        Yaw            = telegraph.Rotation.X
                     });
+                }
+            }
 
             caster.EnqueueToVisible(serverSpellGo, true);
         }

--- a/Source/NexusForever.WorldServer/Game/Spell/SpellEffectHandler.cs
+++ b/Source/NexusForever.WorldServer/Game/Spell/SpellEffectHandler.cs
@@ -193,5 +193,10 @@ namespace NexusForever.WorldServer.Game.Spell
 
             player.TitleManager.AddTitle((ushort)info.Entry.DataBits00);
         }
+
+        [SpellEffectHandler(SpellEffectType.Fluff)]
+        private void HandleEffectFluff(UnitEntity target, SpellTargetInfo.SpellTargetEffectInfo info)
+        {
+        }
     }
 }

--- a/Source/NexusForever.WorldServer/Game/Spell/Static/DamageShape.cs
+++ b/Source/NexusForever.WorldServer/Game/Spell/Static/DamageShape.cs
@@ -4,7 +4,7 @@
     {
         Circle        = 0,
         Ring          = 1,
-        Square = 2,
+        Square        = 2,
         // 3 - Seems like a Cross shape
         Cone          = 4,
         /// <summary>

--- a/Source/NexusForever.WorldServer/Game/Spell/Static/DamageShape.cs
+++ b/Source/NexusForever.WorldServer/Game/Spell/Static/DamageShape.cs
@@ -3,8 +3,15 @@
     public enum DamageShape
     {
         Circle        = 0,
-        Quadrilateral = 2,
+        Ring          = 1,
+        Square = 2,
+        // 3 - Seems like a Cross shape
         Cone          = 4,
+        /// <summary>
+        /// This is a pie shape, where the radius value is the size of the missing slice.
+        /// </summary>
+        Pie           = 5,
+        // 6 - Seems Aura related?
         Rectangle     = 7,
         LongCone      = 8
     }

--- a/Source/NexusForever.WorldServer/Game/Spell/Telegraph.cs
+++ b/Source/NexusForever.WorldServer/Game/Spell/Telegraph.cs
@@ -16,16 +16,62 @@ namespace NexusForever.WorldServer.Game.Spell
         private static readonly ILogger log = LogManager.GetCurrentClassLogger();
 
         public UnitEntity Caster { get; }
-        public Vector3 Position { get; }
-        public Vector3 Rotation { get; }
+        public Vector3 Position { get; private set; }
+        public Vector3 Rotation { get; private set; }
         public TelegraphDamageEntry TelegraphDamage { get; }
+
+        private float casterHitRadius = 0f;
+        private bool npcsSpawned = false;
 
         public Telegraph(TelegraphDamageEntry telegraphDamageEntry, UnitEntity caster, Vector3 position, Vector3 rotation)
         {
             TelegraphDamage = telegraphDamageEntry;
-            Caster          = caster;
-            Position        = position;
-            Rotation        = rotation;
+            Caster = caster;
+            Position = position;
+            Rotation = rotation;
+            casterHitRadius = Caster.HitRadius * 0.5f;
+
+            ApplyPositionOffsets();
+            ApplyRotationOffsets();
+
+            // TODO: Allow for Telegraph debug mode, where we spawn entities to prove telegraph positioning.
+
+            //if ((DamageShape)TelegraphDamage.DamageShapeEnum == DamageShape.Cone || (DamageShape)TelegraphDamage.DamageShapeEnum == DamageShape.LongCone)
+            //{
+            //    Caster.Map.EnqueueAdd(new Simple(16718u), Position.GetPointForTelegraph(Rotation.X + MathF.PI / 2, TelegraphDamage.Param00 - (Caster.HitRadius * 0.5f)));
+            //    Vector3 endPos = Position.GetPointForTelegraph(Rotation.X + MathF.PI / 2, TelegraphDamage.Param01 + (Caster.HitRadius * 0.5f));
+            //    endPos.Y = Caster.Map.GetTerrainHeight(endPos.X, endPos.Z);
+            //    Caster.Map.EnqueueAdd(new Simple(16718u), endPos);
+            //}
+        }
+
+        private void ApplyPositionOffsets()
+        {
+            if (TelegraphDamage.ZPositionOffset == 0u && TelegraphDamage.XPositionOffset == 0u && TelegraphDamage.YPositionOffset == 0u)
+                return;
+
+            Vector3 startingPosition = Position;
+            if (TelegraphDamage.ZPositionOffset != 0u)
+                startingPosition = Position.GetPointForTelegraph(Rotation.X + MathF.PI / 2, TelegraphDamage.ZPositionOffset);
+
+            startingPosition.Y += TelegraphDamage.YPositionOffset;
+
+            Position = startingPosition.GetPointForTelegraph(Rotation.X + MathF.PI, TelegraphDamage.XPositionOffset);
+        }
+
+        private void ApplyRotationOffsets()
+        {
+            if (TelegraphDamage.RotationDegrees == 0u)
+                return;
+
+            float rotationRadians = Rotation.X + TelegraphDamage.RotationDegrees.ToRadians();
+
+            if (rotationRadians > MathF.PI)
+                rotationRadians -= 2 * MathF.PI;
+            else if (rotationRadians <= -MathF.PI)
+                rotationRadians += 2 * MathF.PI;
+
+            Rotation = new Vector3(rotationRadians, Rotation.Y, Rotation.Z);
         }
 
         /// <summary>
@@ -40,70 +86,80 @@ namespace NexusForever.WorldServer.Game.Spell
         /// <summary>
         /// Returns whether the supplied <see cref="Vector3"/> is inside the telegraph.
         /// </summary>
-        public bool InsideTelegraph(Vector3 position)
+        public bool InsideTelegraph(Vector3 position, float hitRadius)
         {
+            hitRadius *= 0.5f;
+
             switch ((DamageShape)TelegraphDamage.DamageShapeEnum)
             {
                 case DamageShape.Circle:
-                    return Vector3.Distance(Position, position) < TelegraphDamage.Param00;
+                    float telegraphRange = TelegraphDamage.Param00;
+
+                    return Vector2.Distance(new Vector2(Position.X, Position.Z), new Vector2(position.X, position.Z)) <= telegraphRange + hitRadius;
                 case DamageShape.Cone:
                 case DamageShape.LongCone:
-                {
-                    float angleRadian = Position.GetAngle(position);
-                    angleRadian -= Rotation.X;
-                    angleRadian = angleRadian.NormaliseRadians();
+                    {
+                        float telegraphStart = TelegraphDamage.Param00 - casterHitRadius;
+                        float telegraphRadius = TelegraphDamage.Param01 + casterHitRadius;
+                        float telegraphAngleInDegrees = TelegraphDamage.Param02 + (TelegraphDamage.Param00 / 2f);
 
-                    float angleDegrees = MathF.Abs(angleRadian.ToDegrees());
-                    if (angleDegrees > TelegraphDamage.Param02 / 2f)
-                        return false;
-
-                    return Vector3.Distance(Position, position) < TelegraphDamage.Param01;
-                }
-                case DamageShape.Quadrilateral:
-                {
-                    float telegraphLength = TelegraphDamage.Param01;
-                    float telegraphHeight = TelegraphDamage.Param02;
-
-                    // TODO: If target is higher or lower than telegraph height, this should not hit. Confirm functionality.
-                    if (position.Y >= Position.Y + telegraphHeight || position.Y <= Position.Y - telegraphHeight)
-                        return false;
-
-                    // TODO: Confirm whether it's necessary to add the model's hit box to the Z Offset (it probably is needed).
-                    Vector3 startingPosition = Position.GetPoint2D(-Rotation.X - MathF.PI / 2, TelegraphDamage.ZPositionOffset);
-                    startingPosition.Y += TelegraphDamage.YPositionOffset;
-
-                    float leftAngle     = -Rotation.X + MathF.PI / 2;
-                    Vector3 bottomLeft  = startingPosition.GetPoint2D(leftAngle, (telegraphLength / 2f) + TelegraphDamage.XPositionOffset);
-                    Vector3 bottomRight = startingPosition.GetPoint2D(leftAngle + MathF.PI / 2, (telegraphLength / 2f) + TelegraphDamage.XPositionOffset);
-                    Vector3 topRight    = bottomRight.GetPoint2D(-Rotation.X - MathF.PI / 4, telegraphLength);
-                    Vector3 topLeft     = bottomLeft.GetPoint2D(-Rotation.X - MathF.PI / 4, telegraphLength);
-
-                    // TODO: Add appropriate check that takes Hit Box from Creature2Model TBL into account with check
-                    return IsPointInsidePolygon(new Vector2(position.X, position.Z), bottomLeft, bottomRight, topRight, topLeft);
-                }
+                        return IsHitInsideAngle(position, hitRadius, telegraphStart, telegraphRadius, telegraphAngleInDegrees);
+                    }
+                case DamageShape.Square:
                 case DamageShape.Rectangle:
-                {
-                    float telegraphWidth  = TelegraphDamage.Param00;
-                    float telegraphHeight = TelegraphDamage.Param01;
-                    float telegraphLength = TelegraphDamage.Param02;
+                    {
+                        /// <remarks>This is not perfect. It works, but there are more efficient options like https://yal.cc/rot-rect-vs-circle-intersection </remarks>
+                        float telegraphWidth = TelegraphDamage.Param00;
+                        float telegraphHeight = TelegraphDamage.Param01;
+                        float telegraphLength = TelegraphDamage.Param02;
 
-                    // TODO: If target is higher or lower than telegraph height, this should not hit. Confirm functionality.
-                    if (position.Y >= Position.Y + telegraphHeight || position.Y <= Position.Y - telegraphHeight)
-                        return false;
+                        // TODO: If target is higher or lower than telegraph height, this should not hit. Confirm functionality.
+                        if (position.Y >= Position.Y + telegraphHeight || position.Y <= Position.Y - telegraphHeight)
+                            return false;
 
-                    // TODO: Confirm whether it's necessary to add the model's hit box to the Z Offset (it probably is needed).
-                    Vector3 startingPosition = Position.GetPoint2D(-Rotation.X - MathF.PI / 2, TelegraphDamage.ZPositionOffset);
-                    startingPosition.Y += TelegraphDamage.YPositionOffset;
+                        // Find the points in the local co-ordinate space
+                        var bottomRight = new Vector3(-telegraphWidth, 0, -telegraphLength);
+                        var bottomLeft = new Vector3(telegraphWidth, 0, -telegraphLength);
+                        var topRight = new Vector3(-telegraphWidth, 0, telegraphLength);
+                        var topLeft = new Vector3(telegraphWidth, 0, telegraphLength);
 
-                    float leftAngle     = -Rotation.X + MathF.PI;
-                    Vector3 bottomLeft  = startingPosition.GetPoint2D(leftAngle, (telegraphWidth / 2f) + TelegraphDamage.XPositionOffset);
-                    Vector3 bottomRight = startingPosition.GetPoint2D(leftAngle + MathF.PI, (telegraphWidth / 2f) + TelegraphDamage.XPositionOffset);
-                    Vector3 topRight    = bottomRight.GetPoint2D(-Rotation.X - MathF.PI / 2, telegraphLength);
-                    Vector3 topLeft     = bottomLeft.GetPoint2D(-Rotation.X - MathF.PI / 2, telegraphLength);
+                        // Rectangle's origin is at it's base, so adjust the starting points appropriately.
+                        if ((DamageShape)TelegraphDamage.DamageShapeEnum == DamageShape.Rectangle)
+                        {
+                            bottomRight.Z = 0;
+                            bottomLeft.Z = 0;
+                        }
 
-                    // TODO: Add appropriate check that takes Hit Box from Creature2Model TBL into account with check
-                    return IsPointInsidePolygon(new Vector2(position.X, position.Z), bottomLeft, bottomRight, topRight, topLeft);
-                }
+                        // Translate points to global co-ordinate space, and apply rotation based on the Telegraph's rotation
+                        bottomLeft = Vector3.Add(RotatePoint(bottomLeft, Rotation.X), Position);
+                        bottomRight = Vector3.Add(RotatePoint(bottomRight, Rotation.X), Position);
+                        topLeft = Vector3.Add(RotatePoint(topLeft, Rotation.X), Position);
+                        topRight = Vector3.Add(RotatePoint(topRight, Rotation.X), Position);
+
+                        Vector3[] points = new Vector3[] { bottomLeft, topLeft, topRight, bottomRight };
+
+                        // TODO: Allow for Telegraph debug mode, where we spawn entities to prove telegraph positioning.
+
+                        //if (!npcsSpawned)
+                        //{
+                        //    foreach (Vector3 point in points)
+                        //        Caster.Map.EnqueueAdd(new Simple(16718u), point);
+                        //    npcsSpawned = true;
+                        //}
+
+                        return IsHitInsidePolygon(points, position, hitRadius);
+                    }
+                case DamageShape.Pie:
+                    {
+                        float telegraphRadius = TelegraphDamage.Param01;
+                        float telegraphAngleInDegrees = TelegraphDamage.Param02;
+
+                        float closestDistance = Position.GetDistance(position) - hitRadius;
+                        if (closestDistance > telegraphRadius)
+                            return false;
+
+                        return !IsHitInsideAngle(position, hitRadius, 0f, telegraphRadius, telegraphAngleInDegrees);
+                    }
                 default:
                     log.Warn($"Unhandled telegraph shape {(DamageShape)TelegraphDamage.DamageShapeEnum}.");
                     return false;
@@ -119,7 +175,7 @@ namespace NexusForever.WorldServer.Game.Spell
                 case DamageShape.Cone:
                 case DamageShape.LongCone:
                     return TelegraphDamage.Param01;
-                case DamageShape.Quadrilateral:
+                case DamageShape.Square:
                 case DamageShape.Rectangle:
                     return TelegraphDamage.Param01;
                 default:
@@ -127,30 +183,214 @@ namespace NexusForever.WorldServer.Game.Spell
             }
         }
 
-        /// <summary>
-        /// Returns a boolean whether a point sits in a horizontal plane of points.
-        /// </summary>
+        private static bool IsHitInsidePolygon(Vector3[] polygon, Vector3 targetPosition, float hitRadius)
+        {
+            if (IsPointInsidePolygon(polygon, targetPosition))
+                return true;
+
+            if (IsRadiusInsidePolygon(polygon, targetPosition, hitRadius))
+                return true;
+
+            return false;
+        }
+
+        private bool IsHitInsideAngle(Vector3 targetPosition, float hitRadius, float startRadius, float telegraphRadius, float angle)
+        {
+            float distance = Position.GetDistance(targetPosition);
+
+            if (distance - hitRadius > telegraphRadius)
+                return false;
+
+            if (distance + hitRadius < startRadius)
+                return false;
+
+            float angleRadian = (Position.GetAngle(targetPosition) - Rotation.X).CondenseRadianIntoRotationRadian();
+
+            float angleDegrees = MathF.Abs(angleRadian.NormaliseRadians().ToDegrees());
+            if (angleDegrees > angle / 2f || angleDegrees < -angle / 2f)
+            {
+                // Checks for edge radius is skipped if the caster is not a Player. This optimises this method, but also allows for player's to dodge attacks appropriately.
+                if (!(Caster is Player))
+                    return false;
+
+                if (angleDegrees > angle || angleDegrees < -angle)
+                    return false;
+
+                if (angleRadian.ToDegrees() < 0f)
+                {
+                    Vector3 rightEdge;
+                    if (startRadius > 0f)
+                    {
+                        Vector3 rightStartPosition = Position.GetPointForTelegraph(((angle / 2f) * -1f).ToRadians() + Rotation.X + MathF.PI / 2, startRadius);
+                        rightEdge = rightStartPosition.GetPointForTelegraph(((angle / 2f) * -1f).ToRadians() + Rotation.X + MathF.PI / 2, telegraphRadius);
+                    }
+                    else
+                        rightEdge = Position.GetPointForTelegraph(((angle / 2f) * -1f).ToRadians() + Rotation.X + MathF.PI / 2, telegraphRadius);
+                    //Caster.Map.EnqueueAdd(new Simple(16718u), new Vector3(rightEdge.X, Caster.Map.GetTerrainHeight(rightEdge.X, rightEdge.Z), rightEdge.Z));
+                    if (IsRadiusIntersectingLine(Position, rightEdge, targetPosition, hitRadius))
+                        return true;
+                }
+                else
+                {
+                    Vector3 leftEdge;
+                    if (startRadius > 0f)
+                    {
+                        Vector3 leftStartPosition = Position.GetPointForTelegraph((angle / 2f).ToRadians() + Rotation.X + MathF.PI / 2, startRadius);
+                        leftEdge = leftStartPosition.GetPointForTelegraph((angle / 2f).ToRadians() + Rotation.X + MathF.PI / 2, telegraphRadius);
+                    }
+                    else
+                        leftEdge = Position.GetPointForTelegraph((angle / 2f).ToRadians() + Rotation.X + MathF.PI / 2, telegraphRadius);
+                    //Caster.Map.EnqueueAdd(new Simple(16718u), new Vector3(leftEdge.X, Caster.Map.GetTerrainHeight(leftEdge.X, leftEdge.Z), leftEdge.Z));
+                    if (IsRadiusIntersectingLine(Position, leftEdge, targetPosition, hitRadius))
+                        return true;
+                }
+
+                return false;
+            }
+
+            return true;
+        }
+
+        #region Math Stuff
         /// <remarks>
-        /// Based on code available in https://github.com/substack/point-in-polygon/ and the algorithm from https://wrf.ecse.rpi.edu//Research/Short_Notes/pnpoly.html/
+        /// Based on code available in http://www.jeffreythompson.org/collision-detection/poly-circle.php
         /// </remarks>
-        private static bool IsPointInsidePolygon(Vector2 point, params Vector3[] polygon)
+        private static bool IsPointInsidePolygon(Vector3[] polygon, Vector3 position)
         {
             bool isInside = false;
-            for (int i = 0, j = polygon.Length- 1; i < polygon.Length; j = i++)
+
+            // Go through each of the vertices, plus the next vertex in the list
+            for (int current = 0; current < polygon.Length; current++)
             {
-                float xi = polygon[i].X;
-                float yi = polygon[i].Z;
-                float xj = polygon[j].X;
-                float yj = polygon[j].Z;
+                // Get next vertex in list. If we've hit the end, wrap around to first
+                int next = current + 1;
+                if (next == polygon.Length)
+                    next = 0;
 
-                bool intersect = ((yi > point.Y) != (yj > point.Y))
-                    && (point.X < (xj - xi) * (point.Y - yi) / (yj - yi) + xi);
+                Vector3 vc = polygon[current];
+                Vector3 vn = polygon[next];
 
-                if (intersect)
+                if (((vc.Z > position.Z && vn.Z < position.Z) || (vc.Z < position.Z && vn.Z > position.Z)) &&
+                    (position.X < (vn.X - vc.X) * (position.Z - vc.Z) / (vn.Z - vc.Z) + vc.X))
                     isInside = !isInside;
             }
 
             return isInside;
         }
+
+        private static bool IsRadiusInsidePolygon(Vector3[] polygon, Vector3 position, float hitRadius)
+        {
+            // go through each of the vertices, plus
+            // the next vertex in the list
+            int next = 0;
+            for (int current = 0; current < polygon.Length; current++)
+            {
+
+                // get next vertex in list
+                // if we've hit the end, wrap around to 0
+                next = current + 1;
+                if (next == polygon.Length)
+                    next = 0;
+
+                // get the PVectors at our current position
+                // this makes our if statement a little cleaner
+                Vector3 vc = polygon[current];    // c for "current"
+                Vector3 vn = polygon[next];       // n for "next"
+
+                // check for collision between the circle and
+                // a line formed between the two vertices
+                bool collision = IsRadiusIntersectingLine(vc, vn, position, hitRadius);
+                if (collision) return true;
+            }
+
+            return false;
+        }
+
+        private static bool IsRadiusIntersectingLine(Vector3 lineStart, Vector3 lineEnd, Vector3 circleOrigin, float radius)
+        {
+
+            // is either end INSIDE the circle?
+            // if so, return true immediately
+            bool inside1 = lineStart.GetDistance(circleOrigin) < radius;
+            bool inside2 = lineEnd.GetDistance(circleOrigin) < radius;
+            if (inside1 || inside2)
+                return true;
+
+            Vector2 closestPoint = GetClosestPoint(new Vector2(lineStart.X, lineStart.Z), new Vector2(lineEnd.X, lineEnd.Z), new Vector2(circleOrigin.X, circleOrigin.Z));
+
+            // is this point actually on the line segment?
+            // if so keep going, but if not, return false
+            bool onSegment = IsPointIntersectingLine(lineStart.X, lineStart.Z, lineEnd.X, lineEnd.Z, closestPoint.X, closestPoint.Y);
+            if (!onSegment)
+                return false;
+
+            // get distance to closest point
+            float distX = closestPoint.X - circleOrigin.X;
+            float distZ = closestPoint.Y - circleOrigin.Z;
+            float distance = MathF.Sqrt((distX * distX) + (distZ * distZ));
+
+            // is the circle on the line?
+            if (distance <= radius)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private static Vector2 GetClosestPoint(Vector2 startPoint, Vector2 endPoint, Vector2 circleOrigin)
+        {
+            // get length of the line
+            float distX = startPoint.X - endPoint.X;
+            float distZ = startPoint.Y - endPoint.Y;
+            float len = MathF.Sqrt((distX * distX) + (distZ * distZ));
+
+            // get dot product of the line and circle
+            float dot = (((circleOrigin.X - startPoint.X) * (endPoint.X - startPoint.X)) + ((circleOrigin.Y - startPoint.Y) * (endPoint.Y - startPoint.Y))) / MathF.Pow(len, 2);
+            // float dot = (((cx - x1) * (x2 - x1)) + ((cy - y1) * (y2 - y1))) / MathF.Pow(len, 2);
+
+            // find the closest point on the line
+            float closestX = startPoint.X + (dot * (endPoint.X - startPoint.X));
+            float closestY = startPoint.Y + (dot * (endPoint.Y - startPoint.Y));
+
+            return new Vector2(closestX, closestY);
+        }
+
+        private static bool IsPointIntersectingLine(float x1, float y1, float x2, float y2, float px, float py)
+        {
+
+            // get distance from the point to the two ends of the line
+            float d1 = Vector2.Distance(new Vector2(px, py), new Vector2(x1, y1));
+            float d2 = Vector2.Distance(new Vector2(px, py), new Vector2(x2, y2));
+
+            // get the length of the line
+            float lineLen = Vector2.Distance(new Vector2(x1, y1), new Vector2(x2, y2));
+
+            // since floats are so minutely accurate, add
+            // a little buffer zone that will give collision
+            float buffer = 0.1f;    // higher # = less accurate
+
+            // if the two distances are equal to the line's
+            // length, the point is on the line!
+            // note we use the buffer here to give a range, rather
+            // than one #
+            if (d1 + d2 >= lineLen - buffer && d1 + d2 <= lineLen + buffer)
+            {
+                return true;
+            }
+            return false;
+        }
+
+        private static Vector3 RotatePoint(Vector3 point, float rotation)
+        {
+            var newX = ((point.X) * MathF.Cos(rotation) + (point.Z) * MathF.Sin(rotation));
+            var newY = ((-point.X) * MathF.Sin(rotation) + (point.Z) * MathF.Cos(rotation));
+
+            newX = -newX;
+            newY = -newY;
+
+            return new Vector3(newX, point.Y, newY);
+        }
+        #endregion
     }
 }

--- a/Source/NexusForever.WorldServer/Game/Spell/Telegraph.cs
+++ b/Source/NexusForever.WorldServer/Game/Spell/Telegraph.cs
@@ -20,34 +20,24 @@ namespace NexusForever.WorldServer.Game.Spell
         public Vector3 Rotation { get; private set; }
         public TelegraphDamageEntry TelegraphDamage { get; }
 
-        private float casterHitRadius = 0f;
-        private bool npcsSpawned = false;
+        private float casterHitRadius => Caster.HitRadius * 0.5f;
 
         public Telegraph(TelegraphDamageEntry telegraphDamageEntry, UnitEntity caster, Vector3 position, Vector3 rotation)
         {
             TelegraphDamage = telegraphDamageEntry;
-            Caster = caster;
-            Position = position;
-            Rotation = rotation;
-            casterHitRadius = Caster.HitRadius * 0.5f;
+            Caster          = caster;
+            Position        = position;
+            Rotation        = rotation;
 
             ApplyPositionOffsets();
             ApplyRotationOffsets();
-
-            // TODO: Allow for Telegraph debug mode, where we spawn entities to prove telegraph positioning.
-
-            //if ((DamageShape)TelegraphDamage.DamageShapeEnum == DamageShape.Cone || (DamageShape)TelegraphDamage.DamageShapeEnum == DamageShape.LongCone)
-            //{
-            //    Caster.Map.EnqueueAdd(new Simple(16718u), Position.GetPointForTelegraph(Rotation.X + MathF.PI / 2, TelegraphDamage.Param00 - (Caster.HitRadius * 0.5f)));
-            //    Vector3 endPos = Position.GetPointForTelegraph(Rotation.X + MathF.PI / 2, TelegraphDamage.Param01 + (Caster.HitRadius * 0.5f));
-            //    endPos.Y = Caster.Map.GetTerrainHeight(endPos.X, endPos.Z);
-            //    Caster.Map.EnqueueAdd(new Simple(16718u), endPos);
-            //}
         }
 
         private void ApplyPositionOffsets()
         {
-            if (TelegraphDamage.ZPositionOffset == 0u && TelegraphDamage.XPositionOffset == 0u && TelegraphDamage.YPositionOffset == 0u)
+            if (TelegraphDamage.ZPositionOffset == 0u
+                && TelegraphDamage.XPositionOffset == 0u
+                && TelegraphDamage.YPositionOffset == 0u)
                 return;
 
             Vector3 startingPosition = Position;
@@ -93,73 +83,64 @@ namespace NexusForever.WorldServer.Game.Spell
             switch ((DamageShape)TelegraphDamage.DamageShapeEnum)
             {
                 case DamageShape.Circle:
+                {
                     float telegraphRange = TelegraphDamage.Param00;
-
                     return Vector2.Distance(new Vector2(Position.X, Position.Z), new Vector2(position.X, position.Z)) <= telegraphRange + hitRadius;
+                }
                 case DamageShape.Cone:
                 case DamageShape.LongCone:
-                    {
-                        float telegraphStart = TelegraphDamage.Param00 - casterHitRadius;
-                        float telegraphRadius = TelegraphDamage.Param01 + casterHitRadius;
-                        float telegraphAngleInDegrees = TelegraphDamage.Param02 + (TelegraphDamage.Param00 / 2f);
+                {
+                    float telegraphStart = TelegraphDamage.Param00 - casterHitRadius;
+                    float telegraphRadius = TelegraphDamage.Param01 + casterHitRadius;
+                    float telegraphAngleInDegrees = TelegraphDamage.Param02 + (TelegraphDamage.Param00 / 2f);
 
-                        return IsHitInsideAngle(position, hitRadius, telegraphStart, telegraphRadius, telegraphAngleInDegrees);
-                    }
+                    return IsHitInsideAngle(position, hitRadius, telegraphStart, telegraphRadius, telegraphAngleInDegrees);
+                }
                 case DamageShape.Square:
                 case DamageShape.Rectangle:
+                {
+                    /// <remarks>This is not perfect. It works, but there are more efficient options like https://yal.cc/rot-rect-vs-circle-intersection </remarks>
+                    float telegraphWidth  = TelegraphDamage.Param00;
+                    float telegraphHeight = TelegraphDamage.Param01;
+                    float telegraphLength = TelegraphDamage.Param02;
+
+                    // TODO: If target is higher or lower than telegraph height, this should not hit. Confirm functionality.
+                    if (position.Y >= Position.Y + telegraphHeight || position.Y <= Position.Y - telegraphHeight)
+                        return false;
+
+                    // Find the points in the local co-ordinate space
+                    var bottomRight = new Vector3(-telegraphWidth, 0, -telegraphLength);
+                    var bottomLeft  = new Vector3(telegraphWidth, 0, -telegraphLength);
+                    var topRight    = new Vector3(-telegraphWidth, 0, telegraphLength);
+                    var topLeft     = new Vector3(telegraphWidth, 0, telegraphLength);
+
+                    // Rectangle's origin is at it's base, so adjust the starting points appropriately.
+                    if ((DamageShape)TelegraphDamage.DamageShapeEnum == DamageShape.Rectangle)
                     {
-                        /// <remarks>This is not perfect. It works, but there are more efficient options like https://yal.cc/rot-rect-vs-circle-intersection </remarks>
-                        float telegraphWidth = TelegraphDamage.Param00;
-                        float telegraphHeight = TelegraphDamage.Param01;
-                        float telegraphLength = TelegraphDamage.Param02;
-
-                        // TODO: If target is higher or lower than telegraph height, this should not hit. Confirm functionality.
-                        if (position.Y >= Position.Y + telegraphHeight || position.Y <= Position.Y - telegraphHeight)
-                            return false;
-
-                        // Find the points in the local co-ordinate space
-                        var bottomRight = new Vector3(-telegraphWidth, 0, -telegraphLength);
-                        var bottomLeft = new Vector3(telegraphWidth, 0, -telegraphLength);
-                        var topRight = new Vector3(-telegraphWidth, 0, telegraphLength);
-                        var topLeft = new Vector3(telegraphWidth, 0, telegraphLength);
-
-                        // Rectangle's origin is at it's base, so adjust the starting points appropriately.
-                        if ((DamageShape)TelegraphDamage.DamageShapeEnum == DamageShape.Rectangle)
-                        {
-                            bottomRight.Z = 0;
-                            bottomLeft.Z = 0;
-                        }
-
-                        // Translate points to global co-ordinate space, and apply rotation based on the Telegraph's rotation
-                        bottomLeft = Vector3.Add(RotatePoint(bottomLeft, Rotation.X), Position);
-                        bottomRight = Vector3.Add(RotatePoint(bottomRight, Rotation.X), Position);
-                        topLeft = Vector3.Add(RotatePoint(topLeft, Rotation.X), Position);
-                        topRight = Vector3.Add(RotatePoint(topRight, Rotation.X), Position);
-
-                        Vector3[] points = new Vector3[] { bottomLeft, topLeft, topRight, bottomRight };
-
-                        // TODO: Allow for Telegraph debug mode, where we spawn entities to prove telegraph positioning.
-
-                        //if (!npcsSpawned)
-                        //{
-                        //    foreach (Vector3 point in points)
-                        //        Caster.Map.EnqueueAdd(new Simple(16718u), point);
-                        //    npcsSpawned = true;
-                        //}
-
-                        return IsHitInsidePolygon(points, position, hitRadius);
+                        bottomRight.Z = 0;
+                        bottomLeft.Z  = 0;
                     }
+
+                    // Translate points to global co-ordinate space, and apply rotation based on the Telegraph's rotation
+                    bottomLeft  = Vector3.Add(RotatePoint(bottomLeft, Rotation.X), Position);
+                    bottomRight = Vector3.Add(RotatePoint(bottomRight, Rotation.X), Position);
+                    topLeft     = Vector3.Add(RotatePoint(topLeft, Rotation.X), Position);
+                    topRight    = Vector3.Add(RotatePoint(topRight, Rotation.X), Position);
+
+                    Vector3[] points = new Vector3[] { bottomLeft, topLeft, topRight, bottomRight };
+                    return IsHitInsidePolygon(points, position, hitRadius);
+                }
                 case DamageShape.Pie:
-                    {
-                        float telegraphRadius = TelegraphDamage.Param01;
-                        float telegraphAngleInDegrees = TelegraphDamage.Param02;
+                {
+                    float telegraphRadius         = TelegraphDamage.Param01;
+                    float telegraphAngleInDegrees = TelegraphDamage.Param02;
 
-                        float closestDistance = Position.GetDistance(position) - hitRadius;
-                        if (closestDistance > telegraphRadius)
-                            return false;
+                    float closestDistance = Position.GetDistance(position) - hitRadius;
+                    if (closestDistance > telegraphRadius)
+                        return false;
 
-                        return !IsHitInsideAngle(position, hitRadius, 0f, telegraphRadius, telegraphAngleInDegrees);
-                    }
+                    return !IsHitInsideAngle(position, hitRadius, 0f, telegraphRadius, telegraphAngleInDegrees);
+                }
                 default:
                     log.Warn($"Unhandled telegraph shape {(DamageShape)TelegraphDamage.DamageShapeEnum}.");
                     return false;
@@ -210,7 +191,7 @@ namespace NexusForever.WorldServer.Game.Spell
             if (angleDegrees > angle / 2f || angleDegrees < -angle / 2f)
             {
                 // Checks for edge radius is skipped if the caster is not a Player. This optimises this method, but also allows for player's to dodge attacks appropriately.
-                if (!(Caster is Player))
+                if (Caster is not Player)
                     return false;
 
                 if (angleDegrees > angle || angleDegrees < -angle)
@@ -226,7 +207,7 @@ namespace NexusForever.WorldServer.Game.Spell
                     }
                     else
                         rightEdge = Position.GetPointForTelegraph(((angle / 2f) * -1f).ToRadians() + Rotation.X + MathF.PI / 2, telegraphRadius);
-                    //Caster.Map.EnqueueAdd(new Simple(16718u), new Vector3(rightEdge.X, Caster.Map.GetTerrainHeight(rightEdge.X, rightEdge.Z), rightEdge.Z));
+
                     if (IsRadiusIntersectingLine(Position, rightEdge, targetPosition, hitRadius))
                         return true;
                 }
@@ -240,7 +221,7 @@ namespace NexusForever.WorldServer.Game.Spell
                     }
                     else
                         leftEdge = Position.GetPointForTelegraph((angle / 2f).ToRadians() + Rotation.X + MathF.PI / 2, telegraphRadius);
-                    //Caster.Map.EnqueueAdd(new Simple(16718u), new Vector3(leftEdge.X, Caster.Map.GetTerrainHeight(leftEdge.X, leftEdge.Z), leftEdge.Z));
+
                     if (IsRadiusIntersectingLine(Position, leftEdge, targetPosition, hitRadius))
                         return true;
                 }
@@ -252,6 +233,7 @@ namespace NexusForever.WorldServer.Game.Spell
         }
 
         #region Math Stuff
+
         /// <remarks>
         /// Based on code available in http://www.jeffreythompson.org/collision-detection/poly-circle.php
         /// </remarks>
@@ -282,13 +264,11 @@ namespace NexusForever.WorldServer.Game.Spell
         {
             // go through each of the vertices, plus
             // the next vertex in the list
-            int next = 0;
             for (int current = 0; current < polygon.Length; current++)
             {
-
                 // get next vertex in list
                 // if we've hit the end, wrap around to 0
-                next = current + 1;
+                int next = current + 1;
                 if (next == polygon.Length)
                     next = 0;
 
@@ -299,8 +279,8 @@ namespace NexusForever.WorldServer.Game.Spell
 
                 // check for collision between the circle and
                 // a line formed between the two vertices
-                bool collision = IsRadiusIntersectingLine(vc, vn, position, hitRadius);
-                if (collision) return true;
+                if (IsRadiusIntersectingLine(vc, vn, position, hitRadius)) 
+                    return true;
             }
 
             return false;
@@ -308,7 +288,6 @@ namespace NexusForever.WorldServer.Game.Spell
 
         private static bool IsRadiusIntersectingLine(Vector3 lineStart, Vector3 lineEnd, Vector3 circleOrigin, float radius)
         {
-
             // is either end INSIDE the circle?
             // if so, return true immediately
             bool inside1 = lineStart.GetDistance(circleOrigin) < radius;
@@ -320,20 +299,17 @@ namespace NexusForever.WorldServer.Game.Spell
 
             // is this point actually on the line segment?
             // if so keep going, but if not, return false
-            bool onSegment = IsPointIntersectingLine(lineStart.X, lineStart.Z, lineEnd.X, lineEnd.Z, closestPoint.X, closestPoint.Y);
-            if (!onSegment)
+            if (!IsPointIntersectingLine(lineStart.X, lineStart.Z, lineEnd.X, lineEnd.Z, closestPoint.X, closestPoint.Y))
                 return false;
 
             // get distance to closest point
-            float distX = closestPoint.X - circleOrigin.X;
-            float distZ = closestPoint.Y - circleOrigin.Z;
+            float distX    = closestPoint.X - circleOrigin.X;
+            float distZ    = closestPoint.Y - circleOrigin.Z;
             float distance = MathF.Sqrt((distX * distX) + (distZ * distZ));
 
             // is the circle on the line?
             if (distance <= radius)
-            {
                 return true;
-            }
 
             return false;
         }
@@ -343,7 +319,7 @@ namespace NexusForever.WorldServer.Game.Spell
             // get length of the line
             float distX = startPoint.X - endPoint.X;
             float distZ = startPoint.Y - endPoint.Y;
-            float len = MathF.Sqrt((distX * distX) + (distZ * distZ));
+            float len   = MathF.Sqrt((distX * distX) + (distZ * distZ));
 
             // get dot product of the line and circle
             float dot = (((circleOrigin.X - startPoint.X) * (endPoint.X - startPoint.X)) + ((circleOrigin.Y - startPoint.Y) * (endPoint.Y - startPoint.Y))) / MathF.Pow(len, 2);
@@ -358,7 +334,6 @@ namespace NexusForever.WorldServer.Game.Spell
 
         private static bool IsPointIntersectingLine(float x1, float y1, float x2, float y2, float px, float py)
         {
-
             // get distance from the point to the two ends of the line
             float d1 = Vector2.Distance(new Vector2(px, py), new Vector2(x1, y1));
             float d2 = Vector2.Distance(new Vector2(px, py), new Vector2(x2, y2));
@@ -375,9 +350,8 @@ namespace NexusForever.WorldServer.Game.Spell
             // note we use the buffer here to give a range, rather
             // than one #
             if (d1 + d2 >= lineLen - buffer && d1 + d2 <= lineLen + buffer)
-            {
                 return true;
-            }
+
             return false;
         }
 
@@ -391,6 +365,7 @@ namespace NexusForever.WorldServer.Game.Spell
 
             return new Vector3(newX, point.Y, newY);
         }
+
         #endregion
     }
 }

--- a/Source/NexusForever.WorldServer/Network/Message/Model/ServerSpellStart.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Model/ServerSpellStart.cs
@@ -10,39 +10,39 @@ namespace NexusForever.WorldServer.Network.Message.Model
     {
         public class InitialPosition : IWritable
         {   
-            public uint   CasterId { get; set; }
-            public byte   Unknown4 { get; set; }
+            public uint  UnitId { get; set; }
+            public byte  TargetFlags { get; set; }
             public Position Position { get; set; } = new Position();
-            public float  Yaw { get; set; }
-            public uint   Unknown21 { get; set; }
+            public float Yaw { get; set; }
+            public float Pitch { get; set; }
 
             public void Write(GamePacketWriter writer)
             {
-                writer.Write(CasterId);
-                writer.Write(Unknown4);
+                writer.Write(UnitId);
+                writer.Write(TargetFlags);
                 Position.Write(writer);
                 writer.Write(Yaw);
-                writer.Write(Unknown21);
+                writer.Write(Pitch);
             }
         }
 
         public class TelegraphPosition : IWritable
         {   
-            public ushort Unknown0 { get; set; }
-            public uint   CasterId { get; set; }
-            public byte   Unknown6 { get; set; }
+            public ushort TelegraphId { get; set; }
+            public uint   AttachedUnitId { get; set; }
+            public byte   TargetFlags { get; set; }
             public Position Position { get; set; } = new Position();
             public float  Yaw { get; set; }
-            public uint   Unknown23 { get; set; }
+            public float  Pitch { get; set; }
 
             public void Write(GamePacketWriter writer)
             {
-                writer.Write(Unknown0);
-                writer.Write(CasterId);
-                writer.Write(Unknown6);
+                writer.Write(TelegraphId);
+                writer.Write(AttachedUnitId);
+                writer.Write(TargetFlags);
                 Position.Write(writer);
                 writer.Write(Yaw);
-                writer.Write(Unknown23);
+                writer.Write(Pitch);
             }
         }
 


### PR DESCRIPTION
**Features**
- Reworked telegraph initialisation, greatly reducing the number of telegraphs that exist in memory at any given time.
- Changed target selection logic, increasing accuracy and performance.
- Added support for "Pie" damage shape.
- Added HitRadius support for entities.
- Fleshed out DamageShape enum

_Thanks to @dyl10s for their work on telegraphs in a closed PR. I utilised it in replacing Rect & Square Telegraph logic because it was more performant._