### PR TITLE
POC: Map Load Improvements - WIP

### DIFF
--- a/Source/NexusForever.Shared/Network/GameSession.cs
+++ b/Source/NexusForever.Shared/Network/GameSession.cs
@@ -153,7 +153,7 @@ namespace NexusForever.Shared.Network
             IReadable message = MessageManager.Instance.GetMessage(packet.Opcode);
             if (message == null)
             {
-                log.Warn($"Received unknown packet {packet.Opcode:X}");
+                //log.Warn($"Received unknown packet {packet.Opcode:X}");
                 return;
             }
 

--- a/Source/NexusForever.WorldServer/Game/Entity/GridEntity.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/GridEntity.cs
@@ -62,17 +62,17 @@ namespace NexusForever.WorldServer.Game.Entity
         /// <summary>
         /// Invoked when <see cref="GridEntity"/> is enqueued to be added to <see cref="BaseMap"/>.
         /// </summary>
-        public virtual void OnEnqueueAddToMap()
+        public virtual void OnEnqueueAddToMap(BaseMap map, uint guid, Vector3 vector)
         {
+            Guid = guid;
             // deliberately empty
         }
 
         /// <summary>
         /// Invoked when <see cref="GridEntity"/> is added to <see cref="BaseMap"/>.
         /// </summary>
-        public virtual void OnAddToMap(BaseMap map, uint guid, Vector3 vector)
+        public virtual void OnAddToMap(BaseMap map, Vector3 vector)
         {
-            Guid     = guid;
             Map      = map;
             Position = vector;
 

--- a/Source/NexusForever.WorldServer/Game/Entity/Mount.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/Mount.cs
@@ -63,9 +63,9 @@ namespace NexusForever.WorldServer.Game.Entity
             return entityCreate;
         }
 
-        public override void OnAddToMap(BaseMap map, uint guid, Vector3 vector)
+        public override void OnAddToMap(BaseMap map, Vector3 vector)
         {
-            base.OnAddToMap(map, guid, vector);
+            base.OnAddToMap(map, vector);
 
             CreateFlags &= ~EntityCreateFlag.SpawnAnimation;
             CreateFlags |= EntityCreateFlag.NoSpawnAnimation;

--- a/Source/NexusForever.WorldServer/Game/Entity/VanityPet.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/VanityPet.cs
@@ -51,9 +51,9 @@ namespace NexusForever.WorldServer.Game.Entity
             };
         }
 
-        public override void OnAddToMap(BaseMap map, uint guid, Vector3 vector)
+        public override void OnAddToMap(BaseMap map, Vector3 vector)
         {
-            base.OnAddToMap(map, guid, vector);
+            base.OnAddToMap(map, vector);
 
             Player owner = GetVisible<Player>(OwnerGuid);
             if (owner == null)

--- a/Source/NexusForever.WorldServer/Game/Entity/WorldEntity.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/WorldEntity.cs
@@ -34,7 +34,7 @@ namespace NexusForever.WorldServer.Game.Entity
 
         public Vector3 LeashPosition { get; protected set; }
         public float LeashRange { get; protected set; } = 15f;
-        public MovementManager MovementManager { get; private set; }
+        public MovementManager MovementManager { get; protected set; }
 
         public uint Health
         {
@@ -99,17 +99,19 @@ namespace NexusForever.WorldServer.Game.Entity
                 stats.Add((Stat)statModel.Stat, new StatValue(statModel));
         }
 
-        public override void OnAddToMap(BaseMap map, uint guid, Vector3 vector)
+        public override void OnAddToMap(BaseMap map, Vector3 vector)
         {
             LeashPosition   = vector;
-            MovementManager = new MovementManager(this, vector, Rotation);
-            base.OnAddToMap(map, guid, vector);
+            if (this is not Player)
+                MovementManager = new MovementManager(this, vector, Rotation);
+            base.OnAddToMap(map, vector);
         }
 
         public override void OnRemoveFromMap()
         {
             base.OnRemoveFromMap();
-            MovementManager = null;
+            if (this is not Player)
+                MovementManager = null;
         }
 
         /// <summary>

--- a/Source/NexusForever.WorldServer/Game/Map/CommunityMap.cs
+++ b/Source/NexusForever.WorldServer/Game/Map/CommunityMap.cs
@@ -2,6 +2,8 @@
 {
     public class CommunityMap : BaseMap
     {
-        
+        public CommunityMap(MapInfo info) : base(info)
+        {
+        }
     }
 }

--- a/Source/NexusForever.WorldServer/Game/Map/GridActionRemove.cs
+++ b/Source/NexusForever.WorldServer/Game/Map/GridActionRemove.cs
@@ -5,10 +5,13 @@ namespace NexusForever.WorldServer.Game.Map
     public class GridActionRemove : IGridAction
     {
         public GridEntity Entity { get; }
+        public bool DropUnitId { get; private set; } = true;
 
         public GridActionRemove(GridEntity entity)
         {
             Entity = entity;
+            if (entity is Player player && player.IsTeleporting())
+                DropUnitId = false;
         }
     }
 }

--- a/Source/NexusForever.WorldServer/Game/Map/IMapInstance.cs
+++ b/Source/NexusForever.WorldServer/Game/Map/IMapInstance.cs
@@ -4,9 +4,8 @@ using NexusForever.WorldServer.Game.Entity;
 
 namespace NexusForever.WorldServer.Game.Map
 {
-    public interface IMap : IUpdate
+    public interface IMapInstance : IMap
     {
-        void Initialise();
-        void EnqueueAdd(GridEntity entity, Vector3 position);
+        void CreateInstance(MapInfo info, Player player);
     }
 }

--- a/Source/NexusForever.WorldServer/Game/Map/InstancedMap.cs
+++ b/Source/NexusForever.WorldServer/Game/Map/InstancedMap.cs
@@ -6,16 +6,20 @@ using NexusForever.WorldServer.Game.Entity;
 
 namespace NexusForever.WorldServer.Game.Map
 {
-    public sealed class InstancedMap<T> : IInstancedMap where T : IMap, new()
+    public sealed class InstancedMap<T> : IInstancedMap where T : IMapInstance, new()
     {
         private WorldEntry entry;
         private readonly Dictionary</*instanceId*/ uint, T> instances = new();
         private readonly Queue<T> pendingInstances = new();
         private readonly QueuedCounter instanceCounter = new();
-        
-        public void Initialise(MapInfo info, Player player)
+
+        public InstancedMap(MapInfo info)
         {
             entry = info.Entry;
+        }
+        
+        public void Initialise()
+        {
         }
 
         public void EnqueueAdd(GridEntity entity, Vector3 position)
@@ -48,7 +52,7 @@ namespace NexusForever.WorldServer.Game.Map
             }
 
             var newInstance = new T();
-            newInstance.Initialise(info, player);
+            newInstance.CreateInstance(info, player);
             pendingInstances.Enqueue(newInstance);
             return newInstance;
         }

--- a/Source/NexusForever.WorldServer/Game/Map/ResidenceMap.cs
+++ b/Source/NexusForever.WorldServer/Game/Map/ResidenceMap.cs
@@ -15,7 +15,7 @@ using NLog;
 
 namespace NexusForever.WorldServer.Game.Map
 {
-    public class ResidenceMap : BaseMap
+    public class ResidenceMap : BaseMap, IMapInstance
     {
         private static readonly ILogger log = LogManager.GetCurrentClassLogger();
 
@@ -25,18 +25,25 @@ namespace NexusForever.WorldServer.Game.Map
 
         private Residence residence;
 
-        public override void Initialise(MapInfo info, Player player)
+        public void CreateInstance(MapInfo info, Player player)
         {
-            base.Initialise(info, player);
+            Info = info;
+            Entry = info.Entry;
+            InstanceId = info.InstanceId;
 
-            if (info.ResidenceId != 0u)
+            if (Info.ResidenceId != 0u)
             {
-                residence = ResidenceManager.Instance.GetCachedResidence(info.ResidenceId);
+                residence = ResidenceManager.Instance.GetCachedResidence(Info.ResidenceId);
                 if (residence == null)
                     throw new InvalidOperationException();
             }
             else
                 residence = ResidenceManager.Instance.CreateResidence(player);
+        }
+
+        public override void Initialise()
+        {
+            base.Initialise();
 
             // initialise plug entities
             foreach (Plot plot in residence.GetPlots().Where(p => p.PlugEntry != null))

--- a/Source/NexusForever.WorldServer/Network/Message/Handler/EntityHandler.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Handler/EntityHandler.cs
@@ -20,6 +20,9 @@ namespace NexusForever.WorldServer.Network.Message.Handler
         [MessageHandler(GameMessageOpcode.ClientEntityCommand)]
         public static void HandleEntityCommand(WorldSession session, ClientEntityCommand entityCommand)
         {
+            if (session.Player.IsLoading)
+                return;
+
             WorldEntity mover = session.Player;
             if (session.Player.ControlGuid != session.Player.Guid)
                 mover = session.Player.GetVisible<WorldEntity>(session.Player.ControlGuid);


### PR DESCRIPTION
**This is a proof of concept - not for merge!**

There's a number of issues with map performance at the moment, namely:
- When teleporting, the entire server waits for new map to be created. All data received does not get processed until after the new map has loaded.
- Players are stuck walking around in a map they won't be a part of while no processing occurs.
- - If, for whatever reason, the map fails to load, the server can experience bad state. They would've been removed from the existing Map on the server, and not added to the new one, but they would not be removed from game.
- Load screens are not being utilised correctly. We're not passing in all entities, setting up entities, spells, etc. properly before the player is put into the world, and that can sometimes cause the client to freak out or "be laggy" upon loading in.
   - Note; This is not resolved as part of this proof of concept, but would be a lot easier to accomplish with this type of framework.

This work focuses on allowing individual map instances to Initialise within their own update loop, and take advantage of "instant teleports" having the Player wait in the loading screen to be added to the new map, all the while taking strain off of the previous map. I experience 5-10s load times for most maps on my dev box and this greatly improved performance client side. We would need async map updates for this to work most effectively, which I know is coming.

This is my hacking as per our conversation yesterday, @Rawaho 