### PR TITLE
Social/Core: Fix Whisper echo

### DIFF
--- a/Source/NexusForever.Shared/Network/Message/GameMessageOpcode.cs
+++ b/Source/NexusForever.Shared/Network/Message/GameMessageOpcode.cs
@@ -112,6 +112,7 @@ namespace NexusForever.Shared.Network.Message
         ClientChatList                  = 0x01D2,
         ServerChatResult                = 0x01D3,
         ClientChatWhisper               = 0x01D4,
+        ServerChatWhisperFail           = 0x01D9,
         ServerChatZoneChange            = 0x01DA,
         Server0237                      = 0x0237, // UI related, opens or closes different UI windows (bank, barber, ect...)
         ClientPing                      = 0x0241,

--- a/Source/NexusForever.WorldServer/Network/Message/Model/ServerChatWhisperFail.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Model/ServerChatWhisperFail.cs
@@ -1,0 +1,20 @@
+﻿using NexusForever.Shared.Network;
+using NexusForever.Shared.Network.Message;
+
+namespace NexusForever.WorldServer.Network.Message.Model
+{
+    [Message(GameMessageOpcode.ServerChatWhisperFail)]
+    class ServerChatWhisperFail : IWritable
+    {
+        public string CharacterTo { get; set; }
+        public bool IsAccountWhisper { get; set; }
+        public ushort Unknown1 { get; set; }
+
+        public void Write(GamePacketWriter writer)
+        {
+            writer.WriteStringWide(CharacterTo);
+            writer.Write(IsAccountWhisper);
+            writer.Write(Unknown1); // Result?
+        }
+    }
+}


### PR DESCRIPTION
This fixes a couple errors associated with whispers.

**Channel Switch**
When messaging someone then switching to write in /say (or any other channel), your echo message would be your previously sent whisper but to yourself.

**Message not sent response**
When a whisper is not sent, for whatever reason, it was being responded with manually. This has been corrected to use the correct packet.