### PR TITLE
Spells/Telegraphs: DamageFlag MVP & Esper Support

### DIFF
--- a/Source/NexusForever.WorldServer/Game/Entity/WorldEntity.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/WorldEntity.cs
@@ -192,7 +192,7 @@ namespace NexusForever.WorldServer.Game.Entity
         /// <summary>
         /// Return the <see cref="float"/> value of the supplied <see cref="Stat"/>.
         /// </summary>
-        protected float? GetStatFloat(Stat stat)
+        public float? GetStatFloat(Stat stat)
         {
             StatAttribute attribute = EntityManager.Instance.GetStatAttribute(stat);
             if (attribute?.Type != StatType.Float)
@@ -207,7 +207,7 @@ namespace NexusForever.WorldServer.Game.Entity
         /// <summary>
         /// Return the <see cref="uint"/> value of the supplied <see cref="Stat"/>.
         /// </summary>
-        protected uint? GetStatInteger(Stat stat)
+        public uint? GetStatInteger(Stat stat)
         {
             StatAttribute attribute = EntityManager.Instance.GetStatAttribute(stat);
             if (attribute?.Type != StatType.Integer)

--- a/Source/NexusForever.WorldServer/Game/Spell/Static/CastMethod.cs
+++ b/Source/NexusForever.WorldServer/Game/Spell/Static/CastMethod.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NexusForever.WorldServer.Game.Spell.Static
+{
+    public enum CastMethod
+    {
+        Normal                  = 0x0000,
+        Channeled               = 0x0001,
+        PressHold               = 0x0002,
+        ChanneledField          = 0x0003,
+        UNUSED04                = 0x0004,
+        ClientSideInteraction   = 0x0005,
+        RapidTap                = 0x0006,
+        ChargeRelease           = 0x0007,
+        Multiphase              = 0x0008,
+        Transactional           = 0x0009,
+        Aura                    = 0x000A
+    }
+}

--- a/Source/NexusForever.WorldServer/Game/Spell/Static/TelegraphDamageFlag.cs
+++ b/Source/NexusForever.WorldServer/Game/Spell/Static/TelegraphDamageFlag.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NexusForever.WorldServer.Game.Spell.Static
+{
+    /// <summary>
+    /// TelegraphDamageFlags in the TelegraphEntry TBL seem to all be calculated server side. Unable to find information in the client on them.
+    /// This is assumed value meaning based on complete speculation when comparing telegraphs.
+    /// </summary>
+    [Flags]
+    public enum TelegraphDamageFlag
+    {
+        SpellMustBeMultiPhase   = 0x0020,
+        TargetMustBeUnit        = 0x0200,
+        CasterMustBePlayer      = 0x0400,
+        CasterMustBeNPC         = 0x1000,
+    }
+}


### PR DESCRIPTION
**Features**

- Supports Telegraph DamageFlag which is a property that appears to be calculated server side.  This mostly fixes the duplication of damage that we're seeing, currently. Clearly, Wildstar had multiple Telegraphs that were being checked (many either invisible or visible only in certain states). I did investigate DisplayFlags and only figured out 1 of the bits so far, but it's honestly not important at this time because we only care about tracking whether or not the telegraph should apply "damage" (or healing or buffs) to the right targets.
    - I went through about 100 Telegraphs and compared the Flags based on the caster, class, expectations of the spell (from it's text and videos) and narrowed down a few of the bits in the mask. 
    - They are, obviously, up to in interpretation - they don't seem to be used in the client at all, or if they are, they are deep in the code.
- This also adds some support for Esper Psi Points. With the #326 PR, Vitals will allow for spell costing and this extends that to consume the rest of the Esper's Psi Points and also determine the right effects to cast based on the current Psi Points.
- This also introduces the CastMethod Enum from the Mega Spells PR because I needed to check a CastMethod as part of the DamageFlag.