### PR TITLE
Quest/Core: Quest mentions & optional objective complete

### DIFF
--- a/Source/NexusForever.WorldServer/Game/Quest/CommunicatorMessage.cs
+++ b/Source/NexusForever.WorldServer/Game/Quest/CommunicatorMessage.cs
@@ -11,6 +11,7 @@ namespace NexusForever.WorldServer.Game.Quest
 {
     public class CommunicatorMessage
     {
+        public uint Id => entry.Id;
         public ushort QuestId => (ushort)entry.QuestIdDelivered;
 
         private readonly CommunicatorMessagesEntry entry;

--- a/Source/NexusForever.WorldServer/Game/Quest/QuestInfo.cs
+++ b/Source/NexusForever.WorldServer/Game/Quest/QuestInfo.cs
@@ -13,7 +13,7 @@ namespace NexusForever.WorldServer.Game.Quest
         public Quest2DifficultyEntry DifficultyEntry { get; }
 
         public ImmutableList<Quest2Entry> PrerequisiteQuests { get; private set; }
-        public ImmutableList<QuestObjectiveEntry> Objectives { get; private set; }
+        public ImmutableList<QuestObjectiveInfo> Objectives { get; private set; }
         public ImmutableDictionary<uint, Quest2RewardEntry> Rewards { get; private set; }
 
         public bool IsQuestMentioned => GlobalQuestManager.Instance.GetQuestCommunicatorMessages((ushort)Entry.Id).ToList().Count > 0u;
@@ -42,9 +42,9 @@ namespace NexusForever.WorldServer.Game.Quest
 
         private void InitialiseObjectives()
         {
-            ImmutableList<QuestObjectiveEntry>.Builder builder = ImmutableList.CreateBuilder<QuestObjectiveEntry>();
+            ImmutableList<QuestObjectiveInfo>.Builder builder = ImmutableList.CreateBuilder<QuestObjectiveInfo>();
             foreach (uint objectiveId in Entry.Objectives.Where(o => o != 0u))
-                builder.Add(GameTableManager.Instance.QuestObjective.GetEntry(objectiveId));
+                builder.Add(new QuestObjectiveInfo(GameTableManager.Instance.QuestObjective.GetEntry(objectiveId)));
 
             Objectives = builder.ToImmutable();
         }

--- a/Source/NexusForever.WorldServer/Game/Quest/QuestInfo.cs
+++ b/Source/NexusForever.WorldServer/Game/Quest/QuestInfo.cs
@@ -11,9 +11,12 @@ namespace NexusForever.WorldServer.Game.Quest
     {
         public Quest2Entry Entry { get; }
         public Quest2DifficultyEntry DifficultyEntry { get; }
+
         public ImmutableList<Quest2Entry> PrerequisiteQuests { get; private set; }
         public ImmutableList<QuestObjectiveEntry> Objectives { get; private set; }
         public ImmutableDictionary<uint, Quest2RewardEntry> Rewards { get; private set; }
+
+        public bool IsQuestMentioned => GlobalQuestManager.Instance.GetQuestCommunicatorMessages((ushort)Entry.Id).ToList().Count > 0u;
 
         /// <summary>
         /// Create a new <see cref="QuestInfo"/> using supplied <see cref="Quest2Entry"/>.
@@ -66,7 +69,12 @@ namespace NexusForever.WorldServer.Game.Quest
         /// </summary>
         public bool IsCommunicatorReceived()
         {
-            return (Entry.Flags & 0x08) != 0;
+            return (Entry.Flags & 0x08) != 0 ;
+        }
+
+        public bool CanBeCalledBack()
+        {
+            return (Entry.Flags & 0x04) != 0;
         }
 
         public bool CannotAbandon()

--- a/Source/NexusForever.WorldServer/Game/Quest/QuestObjective.cs
+++ b/Source/NexusForever.WorldServer/Game/Quest/QuestObjective.cs
@@ -152,5 +152,13 @@ namespace NexusForever.WorldServer.Game.Quest
 
             Progress = Math.Min(progress + update, GetMaxValue());
         }
+
+        /// <summary>
+        /// Complete this <see cref="QuestObjective"/>.
+        /// </summary>
+        public void Complete()
+        {
+            Progress = GetMaxValue();
+        }
     }
 }

--- a/Source/NexusForever.WorldServer/Game/Quest/QuestObjective.cs
+++ b/Source/NexusForever.WorldServer/Game/Quest/QuestObjective.cs
@@ -10,10 +10,8 @@ namespace NexusForever.WorldServer.Game.Quest
 {
     public class QuestObjective : IUpdate
     {
-        public QuestInfo Info { get; }
-
-        public QuestObjectiveType Type => (QuestObjectiveType)Entry.Type;
-        public QuestObjectiveEntry Entry { get; }
+        public QuestInfo QuestInfo { get; }
+        public QuestObjectiveInfo ObjectiveInfo { get; }
 
         public byte Index { get; }
 
@@ -46,25 +44,25 @@ namespace NexusForever.WorldServer.Game.Quest
         /// <summary>
         /// Create a new <see cref="QuestObjective"/> from an existing database model.
         /// </summary>
-        public QuestObjective(QuestInfo info, QuestObjectiveEntry entry, CharacterQuestObjectiveModel model)
+        public QuestObjective(QuestInfo questInfo, QuestObjectiveInfo objectiveInfo, CharacterQuestObjectiveModel model)
         {
-            Info     = info;
-            Entry    = entry;
-            Index    = model.Index;
-            progress = model.Progress;
-            timer    = model.Timer;
+            QuestInfo     = questInfo;
+            ObjectiveInfo = objectiveInfo;
+            Index         = model.Index;
+            progress      = model.Progress;
+            timer         = model.Timer;
         }
 
         /// <summary>
         /// Create a new <see cref="QuestObjective"/> from supplied <see cref="QuestObjectiveEntry"/>.
         /// </summary>
-        public QuestObjective(QuestInfo info, QuestObjectiveEntry entry, byte index)
+        public QuestObjective(QuestInfo questInfo, QuestObjectiveInfo objectiveInfo, byte index)
         {
-            Info  = info;
-            Entry = entry;
-            Index = index;
+            QuestInfo     = questInfo;
+            ObjectiveInfo = objectiveInfo;
+            Index         = index;
 
-            if (Entry.MaxTimeAllowedMS != 0u)
+            if (objectiveInfo.Entry.MaxTimeAllowedMS != 0u)
             {
                 // TODO
             }
@@ -82,7 +80,7 @@ namespace NexusForever.WorldServer.Game.Quest
                 context.Add(new CharacterQuestObjectiveModel
                 {
                     Id       = characterId,
-                    QuestId  = (ushort)Info.Entry.Id,
+                    QuestId  = (ushort)QuestInfo.Entry.Id,
                     Index    = Index,
                     Progress = Progress
                 });
@@ -92,7 +90,7 @@ namespace NexusForever.WorldServer.Game.Quest
                 var model = new CharacterQuestObjectiveModel
                 {
                     Id      = characterId,
-                    QuestId = (ushort)Info.Entry.Id,
+                    QuestId = (ushort)QuestInfo.Entry.Id,
                     Index   = Index
                 };
 
@@ -120,13 +118,13 @@ namespace NexusForever.WorldServer.Game.Quest
         private bool IsDynamic()
         {
             // dynamic objectives have their progress based on percentage rather than count
-            return (Type == QuestObjectiveType.KillCreature
-                || Type == QuestObjectiveType.KillTargetGroups
-                || Type == QuestObjectiveType.Unknown15
-                || Type == QuestObjectiveType.KillTargetGroup
-                || Type == QuestObjectiveType.KillCreature2)
-                && Entry.Count > 1u
-                && (Entry.Flags & 0x0200) == 0;
+            return ObjectiveInfo.Type is QuestObjectiveType.KillCreature
+                    or QuestObjectiveType.KillTargetGroups
+                    or QuestObjectiveType.Unknown15
+                    or QuestObjectiveType.KillTargetGroup
+                    or QuestObjectiveType.KillCreature2
+                && ObjectiveInfo.Entry.Count > 1u
+                && !ObjectiveInfo.HasUnknown0200();
         }
 
         /// <summary>
@@ -139,7 +137,7 @@ namespace NexusForever.WorldServer.Game.Quest
 
         private uint GetMaxValue()
         {
-            return IsDynamic() ? 1000u : Entry.Count;
+            return IsDynamic() ? 1000u : ObjectiveInfo.Entry.Count;
         }
 
         /// <summary>
@@ -148,7 +146,7 @@ namespace NexusForever.WorldServer.Game.Quest
         public void ObjectiveUpdate(uint update)
         {
             if (IsDynamic())
-                update = (uint)(((float)update / Entry.Count) * 1000f);
+                update = (uint)(((float)update / ObjectiveInfo.Entry.Count) * 1000f);
 
             Progress = Math.Min(progress + update, GetMaxValue());
         }

--- a/Source/NexusForever.WorldServer/Game/Quest/QuestObjectiveInfo.cs
+++ b/Source/NexusForever.WorldServer/Game/Quest/QuestObjectiveInfo.cs
@@ -1,0 +1,50 @@
+﻿using NexusForever.Shared.GameTable.Model;
+using NexusForever.WorldServer.Game.Quest.Static;
+
+namespace NexusForever.WorldServer.Game.Quest
+{
+    public class QuestObjectiveInfo
+    {
+        public uint Id => Entry.Id;
+        public QuestObjectiveType Type => (QuestObjectiveType)Entry.Type;
+
+        public QuestObjectiveEntry Entry { get; }
+
+        /// <summary>
+        /// Create a new <see cref="QuestObjectiveInfo"/> with supplied <see cref="QuestObjectiveEntry"/>.
+        /// </summary>
+        public QuestObjectiveInfo(QuestObjectiveEntry entry)
+        {
+            Entry = entry;
+        }
+
+        /// <summary>
+        /// Quest objective is sequential, previous quest objective must be complete.
+        /// </summary>
+        public bool IsSequential()
+        {
+            return ((QuestObjectiveFlags)Entry.Flags & QuestObjectiveFlags.Sequential) != 0;
+        }
+
+        /// <summary>
+        /// Quest objective is hidden until previous objective is complete.
+        /// </summary>
+        public bool IsHidden()
+        {
+            return ((QuestObjectiveFlags)Entry.Flags & QuestObjectiveFlags.Hidden) != 0;
+        }
+
+        /// <summary>
+        /// Quest objective is optional, doesn't need to be complete for quest to be achieved.
+        /// </summary>
+        public bool IsOptional()
+        {
+            return ((QuestObjectiveFlags)Entry.Flags & QuestObjectiveFlags.Optional) != 0;
+        }
+
+        public bool HasUnknown0200()
+        {
+            return ((QuestObjectiveFlags)Entry.Flags & QuestObjectiveFlags.Unknown0200) != 0;
+        }
+    }
+}

--- a/Source/NexusForever.WorldServer/Game/Quest/Static/QuestObjectiveFlags.cs
+++ b/Source/NexusForever.WorldServer/Game/Quest/Static/QuestObjectiveFlags.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NexusForever.WorldServer.Game.Quest.Static
+{
+    [Flags]
+    public enum QuestObjectiveFlags
+    {
+        None                = 0x0000,
+        Hidden              = 0x0008
+    }
+}

--- a/Source/NexusForever.WorldServer/Game/Quest/Static/QuestObjectiveFlags.cs
+++ b/Source/NexusForever.WorldServer/Game/Quest/Static/QuestObjectiveFlags.cs
@@ -1,15 +1,14 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace NexusForever.WorldServer.Game.Quest.Static
 {
     [Flags]
     public enum QuestObjectiveFlags
     {
-        None                = 0x0000,
-        Hidden              = 0x0008
+        None        = 0x0000,
+        Sequential  = 0x0002,
+        Hidden      = 0x0008,
+        Optional    = 0x0020,
+        Unknown0200 = 0x0200
     }
 }


### PR DESCRIPTION
Solves problem when quest is mentioned, a user doesn't accept, and is unable to get the quest ever again (specifically, if they logout after not accepting).
Delivers the quest for "Call Back" from the client.
Allows tracking of all quests the user has been offered by the client.
Automatically completes Optional Objectives when the required step is complete.