### PR TITLE
Player/Create: Starting Locations, Boost Support

### DIFF
--- a/Source/NexusForever.Database.Character/CharacterContext.cs
+++ b/Source/NexusForever.Database.Character/CharacterContext.cs
@@ -14,6 +14,7 @@ namespace NexusForever.Database.Character
         public DbSet<CharacterBoneModel> CharacterBone { get; set; }
         public DbSet<CharacterCostumeModel> CharacterCostume { get; set; }
         public DbSet<CharacterCostumeItemModel> CharacterCostumeItem { get; set; }
+        public DbSet<CharacterCreateModel> CharacterCreate { get; set; }
         public DbSet<CharacterCurrencyModel> CharacterCurrency { get; set; }
         public DbSet<CharacterCustomisationModel> CharacterCustomisation { get; set; }
         public DbSet<CharacterDatacubeModel> CharacterDatacube { get; set; }
@@ -453,6 +454,407 @@ namespace NexusForever.Database.Character
                     .WithMany(p => p.CostumeItem)
                     .HasForeignKey(d => new { d.Id, d.Index })
                     .HasConstraintName("FK__character_costume_item_id-index__character_costume_id-index");
+            });
+
+            modelBuilder.Entity<CharacterCreateModel>(entity =>
+            {
+                entity.ToTable("character_create");
+
+                entity.HasKey(e => new { e.Race, e.Faction, e.CreationStart })
+                    .HasName("PRIMARY");
+
+                entity.Property(e => e.Race)
+                    .HasColumnName("race")
+                    .HasColumnType("tinyint(4) unsigned")
+                    .HasDefaultValue(0);
+
+                entity.Property(e => e.Faction)
+                    .HasColumnName("faction")
+                    .HasColumnType("smallint(5) unsigned")
+                    .HasDefaultValue(0);
+
+                entity.Property(e => e.CreationStart)
+                    .HasColumnName("creationStart")
+                    .HasColumnType("tinyint(4) unsigned")
+                    .HasDefaultValue(0);
+
+                entity.Property(e => e.WorldId)
+                    .HasColumnName("worldId")
+                    .HasColumnType("int(10) unsigned")
+                    .HasDefaultValue(0);
+
+                entity.Property(e => e.X)
+                    .HasColumnName("x")
+                    .HasColumnType("float")
+                    .HasDefaultValue(0);
+
+                entity.Property(e => e.Y)
+                    .HasColumnName("y")
+                    .HasColumnType("float")
+                    .HasDefaultValue(0);
+
+                entity.Property(e => e.Z)
+                    .HasColumnName("z")
+                    .HasColumnType("float")
+                    .HasDefaultValue(0);
+
+                entity.Property(e => e.Rx)
+                    .HasColumnName("rx")
+                    .HasColumnType("float")
+                    .HasDefaultValue(0);
+
+                entity.Property(e => e.Ry)
+                    .HasColumnName("ry")
+                    .HasColumnType("float")
+                    .HasDefaultValue(0);
+
+                entity.Property(e => e.Rz)
+                    .HasColumnName("rz")
+                    .HasColumnType("float")
+                    .HasDefaultValue(0);
+
+                entity.Property(e => e.Comment)
+                    .HasColumnName("comment")
+                    .HasColumnType("varchar(200)")
+                    .HasDefaultValue("");
+
+                entity.HasData(
+                    new CharacterCreateModel
+                    {
+                        Race          = 1,
+                        Faction       = 167,
+                        CreationStart = 4,
+                        WorldId       = 3460,
+                        X             = 29.1286f,
+                        Y             = -853.8716f,
+                        Z             = -560.188f,
+                        Rx            = -2.751458f,
+                        Ry            = 0f,
+                        Rz            = 0f,
+                        Comment       = "Exile Human - Novice"
+                    },
+                    new CharacterCreateModel
+                    {
+                        Race          = 1,
+                        Faction       = 167,
+                        CreationStart = 3,
+                        WorldId       = 426,
+                        X             = 4110.71f,
+                        Y             = -658.6249f,
+                        Z             = -5145.48f,
+                        Rx            = 0.317613f,
+                        Ry            = 0f,
+                        Rz            = 0f,
+                        Comment       = "Exile Human - Veteran"
+                    },
+                    new CharacterCreateModel
+                    {
+                        Race          = 1,
+                        Faction       = 167,
+                        CreationStart = 5,
+                        WorldId       = 51,
+                        X             = 4074.34f,
+                        Y             = -797.8368f,
+                        Z             = -2399.37f,
+                        Rx            = 0f,
+                        Ry            = 0f,
+                        Rz            = 0f,
+                        Comment       = "Exile Human - Level 50"
+                    },
+                    new CharacterCreateModel
+                    {
+                        Race          = 3,
+                        Faction       = 167,
+                        CreationStart = 4,
+                        WorldId       = 3460,
+                        X             = 29.1286f,
+                        Y             = -853.8716f,
+                        Z             = -560.188f,
+                        Rx            = -2.751458f,
+                        Ry            = 0f,
+                        Rz            = 0f,
+                        Comment       = "Exile Granok - Novice"
+                    },
+                    new CharacterCreateModel
+                    {
+                        Race          = 3,
+                        Faction       = 167,
+                        CreationStart = 3,
+                        WorldId       = 426,
+                        X             = 4110.71f,
+                        Y             = -658.6249f,
+                        Z             = -5145.48f,
+                        Rx            = 0.317613f,
+                        Ry            = 0f,
+                        Rz            = 0f,
+                        Comment = "Exile Granok- Veteran"
+                    },
+                    new CharacterCreateModel
+                    {
+                        Race          = 3,
+                        Faction       = 167,
+                        CreationStart = 5,
+                        WorldId       = 51,
+                        X             = 4074.34f,
+                        Y             = -797.8368f,
+                        Z             = -2399.37f,
+                        Rx            = 0f,
+                        Ry            = 0f,
+                        Rz            = 0f,
+                        Comment       = "Exile Granok - Level 50"
+                    },
+                    new CharacterCreateModel
+                    {
+                        Race          = 4,
+                        Faction       = 167,
+                        CreationStart = 4,
+                        WorldId       = 3460,
+                        X             = 29.1286f,
+                        Y             = -853.8716f,
+                        Z             = -560.188f,
+                        Rx            = -2.751458f,
+                        Ry            = 0f,
+                        Rz            = 0f,
+                        Comment       = "Exile Aurin - Novice"
+                    },
+                    new CharacterCreateModel
+                    {
+                        Race          = 4,
+                        Faction       = 167,
+                        CreationStart = 3,
+                        WorldId       = 990,
+                        X             = -771.823f,
+                        Y             = -904.2852f,
+                        Z             = -2269.56f,
+                        Rx            = -1.1214035f,
+                        Ry            = 0f,
+                        Rz            = 0f,
+                        Comment       = "Exile Aurin - Veteran"
+                    },
+                    new CharacterCreateModel
+                    {
+                        Race          = 4,
+                        Faction       = 167,
+                        CreationStart = 5,
+                        WorldId       = 51,
+                        X             = 4074.34f,
+                        Y             = -797.8368f,
+                        Z             = -2399.37f,
+                        Rx            = 0f,
+                        Ry            = 0f,
+                        Rz            = 0f,
+                        Comment       = "Exile Aurin - Level 50"
+                    },
+                    new CharacterCreateModel
+                    {
+                        Race          = 16,
+                        Faction       = 167,
+                        CreationStart = 4,
+                        WorldId       = 3460,
+                        X             = 29.1286f,
+                        Y             = -853.8716f,
+                        Z             = -560.188f,
+                        Rx            = -2.751458f,
+                        Ry            = 0f,
+                        Rz            = 0f,
+                        Comment       = "Exile Mordesh - Novice"
+                    },
+                    new CharacterCreateModel
+                    {
+                        Race          = 16,
+                        Faction       = 167,
+                        CreationStart = 3,
+                        WorldId       = 990,
+                        X             = -771.823f,
+                        Y             = -904.2852f,
+                        Z             = -2269.56f,
+                        Rx            = -1.1214035f,
+                        Ry            = 0f,
+                        Rz            = 0f,
+                        Comment       = "Exile Mordesh - Veteran"
+                    },
+                    new CharacterCreateModel
+                    {
+                        Race          = 16,
+                        Faction       = 167,
+                        CreationStart = 5,
+                        WorldId       = 51,
+                        X             = 4074.34f,
+                        Y             = -797.8368f,
+                        Z             = -2399.37f,
+                        Rx            = 0f,
+                        Ry            = 0f,
+                        Rz            = 0f,
+                        Comment       = "Exile Mordesh - Level 50"
+                    },
+                    new CharacterCreateModel
+                    {
+                        Race          = 13,
+                        Faction       = 166,
+                        CreationStart = 4,
+                        WorldId       = 3460,
+                        X             = 29.1286f,
+                        Y             = -853.8716f,
+                        Z             = -560.188f,
+                        Rx            = -2.751458f,
+                        Ry            = 0f,
+                        Rz            = 0f,
+                        Comment       = "Dominion Chua - Novice"
+                    },
+                    new CharacterCreateModel
+                    {
+                        Race          = 13,
+                        Faction       = 166,
+                        CreationStart = 3,
+                        WorldId       = 870,
+                        X             = -8261.3984f,
+                        Y             = -995.471f,
+                        Z             = -242.3648f,
+                        Rx            = -2.215535f,
+                        Ry            = 0f,
+                        Rz            = 0f,
+                        Comment       = "Dominion Chua - Veteran"
+                    },
+                    new CharacterCreateModel
+                    {
+                        Race          = 13,
+                        Faction       = 166,
+                        CreationStart = 5,
+                        WorldId       = 22,
+                        X             = -3343.58f,
+                        Y             = -887.4646f,
+                        Z             = -536.03f,
+                        Rx            = -0.7632219f,
+                        Ry            = 0f,
+                        Rz            = 0f,
+                        Comment       = "Dominion Chua - Level 50"
+                    },
+                    new CharacterCreateModel
+                    {
+                        Race          = 5,
+                        Faction       = 166,
+                        CreationStart = 4,
+                        WorldId       = 3460,
+                        X             = 29.1286f,
+                        Y             = -853.8716f,
+                        Z             = -560.188f,
+                        Rx            = -2.751458f,
+                        Ry            = 0f,
+                        Rz            = 0f,
+                        Comment       = "Dominion Draken - Novice"
+                    },
+                    new CharacterCreateModel
+                    {
+                        Race          = 5,
+                        Faction       = 166,
+                        CreationStart = 3,
+                        WorldId       = 870,
+                        X             = -8261.3984f,
+                        Y             = -995.471f,
+                        Z             = -242.3648f,
+                        Rx            = -2.215535f,
+                        Ry            = 0f,
+                        Rz            = 0f,
+                        Comment       = "Dominion Draken - Veteran"
+                    },
+                    new CharacterCreateModel
+                    {
+                        Race          = 5,
+                        Faction       = 166,
+                        CreationStart = 5,
+                        WorldId       = 22,
+                        X             = -3343.58f,
+                        Y             = -887.4646f,
+                        Z             = -536.03f,
+                        Rx            = -0.7632219f,
+                        Ry            = 0f,
+                        Rz            = 0f,
+                        Comment       = "Dominion Draken - Level 50"
+                    },
+                    new CharacterCreateModel
+                    {
+                        Race          = 1,
+                        Faction       = 166,
+                        CreationStart = 4,
+                        WorldId       = 3460,
+                        X             = 29.1286f,
+                        Y             = -853.8716f,
+                        Z             = -560.188f,
+                        Rx            = -2.751458f,
+                        Ry            = 0f,
+                        Rz            = 0f,
+                        Comment       = "Dominion Cassian - Novice"
+                    },
+                    new CharacterCreateModel
+                    {
+                        Race          = 1,
+                        Faction       = 166,
+                        CreationStart = 3,
+                        WorldId       = 1387,
+                        X             = -3835.341f,
+                        Y             = -980.2174f,
+                        Z             = -6050.524f,
+                        Rx            = -0.456820f,
+                        Ry            = 0f,
+                        Rz            = 0f,
+                        Comment       = "Dominion Cassian - Veteran"
+                    },
+                    new CharacterCreateModel
+                    {
+                        Race          = 1,
+                        Faction       = 166,
+                        CreationStart = 5,
+                        WorldId       = 22,
+                        X             = -3343.58f,
+                        Y             = -887.4646f,
+                        Z             = -536.03f,
+                        Rx            = -0.7632219f,
+                        Ry            = 0f,
+                        Rz            = 0f,
+                        Comment       = "Dominion Cassian - Level 50"
+                    },
+                    new CharacterCreateModel
+                    {
+                        Race          = 12,
+                        Faction       = 166,
+                        CreationStart = 4,
+                        WorldId       = 3460,
+                        X             = 29.1286f,
+                        Y             = -853.8716f,
+                        Z             = -560.188f,
+                        Rx            = -2.751458f,
+                        Ry            = 0f,
+                        Rz            = 0f,
+                        Comment       = "Dominion Mechari - Novice"
+                    },
+                    new CharacterCreateModel
+                    {
+                        Race          = 12,
+                        Faction       = 166,
+                        CreationStart = 3,
+                        WorldId       = 1387,
+                        X             = -3835.341f,
+                        Y             = -980.2174f,
+                        Z             = -6050.524f,
+                        Rx            = -0.456820f,
+                        Ry            = 0f,
+                        Rz            = 0f,
+                        Comment       = "Dominion Mechari - Veteran"
+                    },
+                    new CharacterCreateModel
+                    {
+                        Race          = 12,
+                        Faction       = 166,
+                        CreationStart = 5,
+                        WorldId       = 22,
+                        X             = -3343.58f,
+                        Y             = -887.4646f,
+                        Z             = -536.03f,
+                        Rx            = -0.7632219f,
+                        Ry            = 0f,
+                        Rz            = 0f,
+                        Comment       = "Dominion Mechari - Level 50"
+                    });
             });
 
             modelBuilder.Entity<CharacterCurrencyModel>(entity =>

--- a/Source/NexusForever.Database.Character/CharacterDatabase.cs
+++ b/Source/NexusForever.Database.Character/CharacterDatabase.cs
@@ -214,5 +214,12 @@ namespace NexusForever.Database.Character
                 .Include(c => c.Members)
                 .ToList();
         }
+
+        public List<CharacterCreateModel> GetCharacterCreationData()
+        {
+            using var context = new CharacterContext(config);
+
+            return context.CharacterCreate.ToList();
+        }
     }
 }

--- a/Source/NexusForever.Database.Character/Migrations/20210906140425_StartingLocations.Designer.cs
+++ b/Source/NexusForever.Database.Character/Migrations/20210906140425_StartingLocations.Designer.cs
@@ -2,15 +2,17 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NexusForever.Database.Character;
 
 namespace NexusForever.Database.Character.Migrations
 {
     [DbContext(typeof(CharacterContext))]
-    partial class CharacterContextModelSnapshot : ModelSnapshot
+    [Migration("20210906140425_StartingLocations")]
+    partial class StartingLocations
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -165,6 +167,67 @@ namespace NexusForever.Database.Character.Migrations
                         .HasName("PRIMARY");
 
                     b.ToTable("character_bone");
+                });
+
+            modelBuilder.Entity("NexusForever.Database.Character.Model.CharacterContactModel", b =>
+                {
+                    b.Property<ulong>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("bigint(20) unsigned")
+                        .HasDefaultValue(0ul)
+                        .HasColumnName("id");
+
+                    b.Property<ulong>("OwnerId")
+                        .HasColumnType("bigint(20) unsigned")
+                        .HasDefaultValue(0ul)
+                        .HasColumnName("ownerId");
+
+                    b.Property<ulong>("ContactId")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("bigint(20) unsigned")
+                        .HasDefaultValue(0ul)
+                        .HasColumnName("contactId");
+
+                    b.Property<byte>("Accepted")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("tinyint(8) unsigned")
+                        .HasDefaultValue((byte)0)
+                        .HasColumnName("accepted");
+
+                    b.Property<string>("InviteMessage")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("varchar(100)")
+                        .HasColumnName("inviteMessage")
+                        .HasDefaultValueSql("''");
+
+                    b.Property<string>("PrivateNote")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("varchar(100)")
+                        .HasColumnName("privateNote")
+                        .HasDefaultValueSql("''");
+
+                    b.Property<DateTime>("RequestTime")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("datetime")
+                        .HasColumnName("requestTime")
+                        .HasDefaultValueSql("current_timestamp()");
+
+                    b.Property<uint>("Type")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int(3) unsigned")
+                        .HasDefaultValue(0u)
+                        .HasColumnName("type");
+
+                    b.HasKey("Id", "OwnerId", "ContactId")
+                        .HasName("PRIMARY");
+
+                    b.HasIndex("Id")
+                        .IsUnique()
+                        .HasDatabaseName("contactGuid");
+
+                    b.HasIndex("OwnerId");
+
+                    b.ToTable("character_contact");
                 });
 
             modelBuilder.Entity("NexusForever.Database.Character.Model.CharacterCostumeItemModel", b =>
@@ -1005,6 +1068,12 @@ namespace NexusForever.Database.Character.Migrations
                         .HasDefaultValue((byte)0)
                         .HasColumnName("activeSpec");
 
+                    b.Property<ushort>("BindPoint")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("smallint(5) unsigned")
+                        .HasColumnName("bindPoint")
+                        .HasDefaultValueSql("'0'");
+
                     b.Property<byte>("Class")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("tinyint(3) unsigned")
@@ -1345,6 +1414,67 @@ namespace NexusForever.Database.Character.Migrations
                         .HasName("PRIMARY");
 
                     b.ToTable("character_reputation");
+                });
+
+            modelBuilder.Entity("NexusForever.Database.Character.Model.CharacterRewardTrackMilestoneModel", b =>
+                {
+                    b.Property<ulong>("Id")
+                        .HasColumnType("bigint(20) unsigned")
+                        .HasDefaultValue(0ul)
+                        .HasColumnName("id");
+
+                    b.Property<uint>("RewardTrackId")
+                        .HasColumnType("int(10) unsigned")
+                        .HasDefaultValue(0u)
+                        .HasColumnName("rewardTrackId");
+
+                    b.Property<uint>("MilestoneId")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int(10) unsigned")
+                        .HasDefaultValue(0u)
+                        .HasColumnName("milestoneId");
+
+                    b.Property<int>("Choice")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int")
+                        .HasDefaultValue(-1)
+                        .HasColumnName("choice");
+
+                    b.Property<uint>("PointsRequired")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int(10) unsigned")
+                        .HasDefaultValue(0u)
+                        .HasColumnName("pointsRequired");
+
+                    b.HasKey("Id", "RewardTrackId", "MilestoneId")
+                        .HasName("PRIMARY");
+
+                    b.ToTable("character_reward_track_milestone");
+                });
+
+            modelBuilder.Entity("NexusForever.Database.Character.Model.CharacterRewardTrackModel", b =>
+                {
+                    b.Property<ulong>("Id")
+                        .HasColumnType("bigint(20) unsigned")
+                        .HasDefaultValue(0ul)
+                        .HasColumnName("id");
+
+                    b.Property<uint>("RewardTrackId")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int(10) unsigned")
+                        .HasDefaultValue(0u)
+                        .HasColumnName("rewardTrackId");
+
+                    b.Property<uint>("Points")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int(10) unsigned")
+                        .HasDefaultValue(0u)
+                        .HasColumnName("points");
+
+                    b.HasKey("Id", "RewardTrackId")
+                        .HasName("PRIMARY");
+
+                    b.ToTable("character_reward_track");
                 });
 
             modelBuilder.Entity("NexusForever.Database.Character.Model.CharacterSpellModel", b =>
@@ -1814,6 +1944,788 @@ namespace NexusForever.Database.Character.Migrations
                     b.ToTable("item");
                 });
 
+            modelBuilder.Entity("NexusForever.Database.Character.Model.PropertyBaseModel", b =>
+                {
+                    b.Property<uint>("Type")
+                        .HasColumnType("int unsigned")
+                        .HasColumnName("type")
+                        .HasDefaultValueSql("'0'");
+
+                    b.Property<uint>("Subtype")
+                        .HasColumnType("int unsigned")
+                        .HasColumnName("subtype")
+                        .HasDefaultValueSql("'0'");
+
+                    b.Property<uint>("Property")
+                        .HasColumnType("int unsigned")
+                        .HasColumnName("property")
+                        .HasDefaultValueSql("'0'");
+
+                    b.Property<ushort>("ModType")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("smallint unsigned")
+                        .HasColumnName("modType")
+                        .HasDefaultValueSql("'0'");
+
+                    b.Property<string>("Note")
+                        .IsRequired()
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("varchar(100)")
+                        .HasColumnName("note")
+                        .HasDefaultValueSql("''");
+
+                    b.Property<float>("Value")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("float")
+                        .HasColumnName("value")
+                        .HasDefaultValueSql("'0'");
+
+                    b.HasKey("Type", "Subtype", "Property")
+                        .HasName("PRIMARY");
+
+                    b.ToTable("property_base");
+
+                    b.HasData(
+                        new
+                        {
+                            Type = 0u,
+                            Subtype = 0u,
+                            Property = 0u,
+                            ModType = (ushort)0,
+                            Note = "Player - Base Strength",
+                            Value = 0f
+                        },
+                        new
+                        {
+                            Type = 0u,
+                            Subtype = 0u,
+                            Property = 1u,
+                            ModType = (ushort)0,
+                            Note = "Player - Base Dexterity",
+                            Value = 0f
+                        },
+                        new
+                        {
+                            Type = 0u,
+                            Subtype = 0u,
+                            Property = 2u,
+                            ModType = (ushort)0,
+                            Note = "Player - Base Technology",
+                            Value = 0f
+                        },
+                        new
+                        {
+                            Type = 0u,
+                            Subtype = 0u,
+                            Property = 3u,
+                            ModType = (ushort)0,
+                            Note = "Player - Base Magic",
+                            Value = 0f
+                        },
+                        new
+                        {
+                            Type = 0u,
+                            Subtype = 0u,
+                            Property = 4u,
+                            ModType = (ushort)0,
+                            Note = "Player - Base Wisdom",
+                            Value = 0f
+                        },
+                        new
+                        {
+                            Type = 0u,
+                            Subtype = 0u,
+                            Property = 7u,
+                            ModType = (ushort)1,
+                            Note = "Player - Base HP per Level",
+                            Value = 200f
+                        },
+                        new
+                        {
+                            Type = 0u,
+                            Subtype = 0u,
+                            Property = 9u,
+                            ModType = (ushort)0,
+                            Note = "Player - Base Endurance",
+                            Value = 500f
+                        },
+                        new
+                        {
+                            Type = 0u,
+                            Subtype = 0u,
+                            Property = 16u,
+                            ModType = (ushort)0,
+                            Note = "Player - Base Endurance Regen",
+                            Value = 0.0225f
+                        },
+                        new
+                        {
+                            Type = 0u,
+                            Subtype = 0u,
+                            Property = 35u,
+                            ModType = (ushort)1,
+                            Note = "Player - Base Assault Rating per Level",
+                            Value = 18f
+                        },
+                        new
+                        {
+                            Type = 0u,
+                            Subtype = 0u,
+                            Property = 36u,
+                            ModType = (ushort)1,
+                            Note = "Player - Base Support Rating per Level",
+                            Value = 18f
+                        },
+                        new
+                        {
+                            Type = 0u,
+                            Subtype = 0u,
+                            Property = 38u,
+                            ModType = (ushort)0,
+                            Note = "Player - Base Dash Energy",
+                            Value = 200f
+                        },
+                        new
+                        {
+                            Type = 0u,
+                            Subtype = 0u,
+                            Property = 39u,
+                            ModType = (ushort)0,
+                            Note = "Player - Base Dash Energy Regen",
+                            Value = 0.045f
+                        },
+                        new
+                        {
+                            Type = 0u,
+                            Subtype = 0u,
+                            Property = 41u,
+                            ModType = (ushort)0,
+                            Note = "Player - Shield Capacity Base",
+                            Value = 0f
+                        },
+                        new
+                        {
+                            Type = 0u,
+                            Subtype = 0u,
+                            Property = 100u,
+                            ModType = (ushort)0,
+                            Note = "Player - Base Movement Speed",
+                            Value = 1f
+                        },
+                        new
+                        {
+                            Type = 0u,
+                            Subtype = 0u,
+                            Property = 101u,
+                            ModType = (ushort)0,
+                            Note = "Player - Base Avoid Chance",
+                            Value = 0.05f
+                        },
+                        new
+                        {
+                            Type = 0u,
+                            Subtype = 0u,
+                            Property = 102u,
+                            ModType = (ushort)0,
+                            Note = "Player - Base Crit Chance",
+                            Value = 0.05f
+                        },
+                        new
+                        {
+                            Type = 0u,
+                            Subtype = 0u,
+                            Property = 107u,
+                            ModType = (ushort)0,
+                            Note = "Player - Base Focus Recovery In Combat",
+                            Value = 0f
+                        },
+                        new
+                        {
+                            Type = 0u,
+                            Subtype = 0u,
+                            Property = 108u,
+                            ModType = (ushort)0,
+                            Note = "Player - Base Focus Recovery Out of Combat",
+                            Value = 0f
+                        },
+                        new
+                        {
+                            Type = 0u,
+                            Subtype = 0u,
+                            Property = 112u,
+                            ModType = (ushort)0,
+                            Note = "Player - Base Multi-Hit Amount",
+                            Value = 0.3f
+                        },
+                        new
+                        {
+                            Type = 0u,
+                            Subtype = 0u,
+                            Property = 130u,
+                            ModType = (ushort)0,
+                            Note = "Player - Base Gravity Multiplier",
+                            Value = 0.8f
+                        },
+                        new
+                        {
+                            Type = 0u,
+                            Subtype = 0u,
+                            Property = 150u,
+                            ModType = (ushort)0,
+                            Note = "Player - Base Damage Taken Offset - Physical",
+                            Value = 1f
+                        },
+                        new
+                        {
+                            Type = 0u,
+                            Subtype = 0u,
+                            Property = 151u,
+                            ModType = (ushort)0,
+                            Note = "Player - Base Damage Taken Offset - Tech",
+                            Value = 1f
+                        },
+                        new
+                        {
+                            Type = 0u,
+                            Subtype = 0u,
+                            Property = 152u,
+                            ModType = (ushort)0,
+                            Note = "Player - Base Damage Taken Offset - Magic",
+                            Value = 1f
+                        },
+                        new
+                        {
+                            Type = 0u,
+                            Subtype = 0u,
+                            Property = 154u,
+                            ModType = (ushort)0,
+                            Note = "Player - Base Mutli-Hit Chance",
+                            Value = 0.05f
+                        },
+                        new
+                        {
+                            Type = 0u,
+                            Subtype = 0u,
+                            Property = 155u,
+                            ModType = (ushort)0,
+                            Note = "Player - Base Damage Reflect Amount",
+                            Value = 0.05f
+                        },
+                        new
+                        {
+                            Type = 0u,
+                            Subtype = 0u,
+                            Property = 191u,
+                            ModType = (ushort)0,
+                            Note = "Player - Base Mount Movement Speed",
+                            Value = 1f
+                        },
+                        new
+                        {
+                            Type = 0u,
+                            Subtype = 0u,
+                            Property = 195u,
+                            ModType = (ushort)0,
+                            Note = "Player - Base Glance Amount",
+                            Value = 0.3f
+                        },
+                        new
+                        {
+                            Type = 1u,
+                            Subtype = 1u,
+                            Property = 10u,
+                            ModType = (ushort)2,
+                            Note = "Class - Warrior - Base Kinetic Energy Cap",
+                            Value = 1000f
+                        },
+                        new
+                        {
+                            Type = 0u,
+                            Subtype = 0u,
+                            Property = 17u,
+                            ModType = (ushort)2,
+                            Note = "Class - Warrior - Base Kinetic Energy Regen",
+                            Value = 1f
+                        },
+                        new
+                        {
+                            Type = 1u,
+                            Subtype = 2u,
+                            Property = 10u,
+                            ModType = (ushort)2,
+                            Note = "Class - Engineer - Base Volatile Energy Cap",
+                            Value = 100f
+                        },
+                        new
+                        {
+                            Type = 1u,
+                            Subtype = 3u,
+                            Property = 10u,
+                            ModType = (ushort)2,
+                            Note = "Class - Esper - Base Psi Point Cap",
+                            Value = 5f
+                        },
+                        new
+                        {
+                            Type = 1u,
+                            Subtype = 4u,
+                            Property = 10u,
+                            ModType = (ushort)2,
+                            Note = "Class - Medic - Base Medic Core Cap",
+                            Value = 4f
+                        },
+                        new
+                        {
+                            Type = 1u,
+                            Subtype = 5u,
+                            Property = 12u,
+                            ModType = (ushort)2,
+                            Note = "Class - Stalker - Base Suit Power Cap",
+                            Value = 100f
+                        },
+                        new
+                        {
+                            Type = 1u,
+                            Subtype = 5u,
+                            Property = 19u,
+                            ModType = (ushort)2,
+                            Note = "Class - Stalker - Base Suit Power Regeneration Rate",
+                            Value = 0.035f
+                        },
+                        new
+                        {
+                            Type = 1u,
+                            Subtype = 7u,
+                            Property = 13u,
+                            ModType = (ushort)2,
+                            Note = "Class - Spellslinger - Base Spell Power Cap",
+                            Value = 100f
+                        },
+                        new
+                        {
+                            Type = 1u,
+                            Subtype = 4u,
+                            Property = 5u,
+                            ModType = (ushort)2,
+                            Note = "Class - Medic - Base Focus Pool",
+                            Value = 1000f
+                        },
+                        new
+                        {
+                            Type = 1u,
+                            Subtype = 7u,
+                            Property = 5u,
+                            ModType = (ushort)2,
+                            Note = "Class - Spellslinger - Base Focus Pool",
+                            Value = 1000f
+                        },
+                        new
+                        {
+                            Type = 1u,
+                            Subtype = 3u,
+                            Property = 5u,
+                            ModType = (ushort)2,
+                            Note = "Class - Esper - Base Focus Pool",
+                            Value = 1000f
+                        },
+                        new
+                        {
+                            Type = 1u,
+                            Subtype = 4u,
+                            Property = 107u,
+                            ModType = (ushort)2,
+                            Note = "Class - Medic - Base Focus Recovery Rate In Combat",
+                            Value = 0.005f
+                        },
+                        new
+                        {
+                            Type = 1u,
+                            Subtype = 7u,
+                            Property = 107u,
+                            ModType = (ushort)2,
+                            Note = "Class - Spellslinger - Focus Recovery Rate In Combat",
+                            Value = 0.005f
+                        },
+                        new
+                        {
+                            Type = 1u,
+                            Subtype = 3u,
+                            Property = 107u,
+                            ModType = (ushort)2,
+                            Note = "Class - Esper - Focus Recovery Rate In Combat",
+                            Value = 0.005f
+                        },
+                        new
+                        {
+                            Type = 1u,
+                            Subtype = 4u,
+                            Property = 108u,
+                            ModType = (ushort)2,
+                            Note = "Class - Medic - Base Focus Recovery Rate Out of Combat",
+                            Value = 0.02f
+                        },
+                        new
+                        {
+                            Type = 1u,
+                            Subtype = 7u,
+                            Property = 108u,
+                            ModType = (ushort)2,
+                            Note = "Class - Spellslinger - Focus Recovery Rate Out of Combat",
+                            Value = 0.02f
+                        },
+                        new
+                        {
+                            Type = 1u,
+                            Subtype = 3u,
+                            Property = 108u,
+                            ModType = (ushort)2,
+                            Note = "Class - Esper - Focus Recovery Rate Out of Combat",
+                            Value = 0.02f
+                        },
+                        new
+                        {
+                            Type = 2u,
+                            Subtype = 1u,
+                            Property = 7u,
+                            ModType = (ushort)1,
+                            Note = "Item - Chest - HP per Eff. Level",
+                            Value = 75f
+                        },
+                        new
+                        {
+                            Type = 2u,
+                            Subtype = 2u,
+                            Property = 7u,
+                            ModType = (ushort)1,
+                            Note = "Item - Legs - HP per Eff. Level",
+                            Value = 75f
+                        },
+                        new
+                        {
+                            Type = 2u,
+                            Subtype = 3u,
+                            Property = 7u,
+                            ModType = (ushort)1,
+                            Note = "Item - Head - HP per Eff. Level",
+                            Value = 45f
+                        },
+                        new
+                        {
+                            Type = 2u,
+                            Subtype = 4u,
+                            Property = 7u,
+                            ModType = (ushort)1,
+                            Note = "Item - Shoulder - HP per Eff. Level",
+                            Value = 60f
+                        },
+                        new
+                        {
+                            Type = 2u,
+                            Subtype = 5u,
+                            Property = 7u,
+                            ModType = (ushort)1,
+                            Note = "Item - Feet - HP per Eff. Level",
+                            Value = 45f
+                        },
+                        new
+                        {
+                            Type = 2u,
+                            Subtype = 6u,
+                            Property = 7u,
+                            ModType = (ushort)1,
+                            Note = "Item - Hands - HP per Eff. Level",
+                            Value = 45f
+                        },
+                        new
+                        {
+                            Type = 2u,
+                            Subtype = 1u,
+                            Property = 35u,
+                            ModType = (ushort)1,
+                            Note = "Item - Chest - Attack Power per Eff. Level",
+                            Value = 4.5f
+                        },
+                        new
+                        {
+                            Type = 2u,
+                            Subtype = 2u,
+                            Property = 35u,
+                            ModType = (ushort)1,
+                            Note = "Item - Legs - Attack Power per Eff. Level",
+                            Value = 4.5f
+                        },
+                        new
+                        {
+                            Type = 2u,
+                            Subtype = 3u,
+                            Property = 35u,
+                            ModType = (ushort)1,
+                            Note = "Item - Head - Attack Power per Eff. Level",
+                            Value = 2.7f
+                        },
+                        new
+                        {
+                            Type = 2u,
+                            Subtype = 4u,
+                            Property = 35u,
+                            ModType = (ushort)1,
+                            Note = "Item - Shoulder - Attack Power per Eff. Level",
+                            Value = 3.6f
+                        },
+                        new
+                        {
+                            Type = 2u,
+                            Subtype = 5u,
+                            Property = 35u,
+                            ModType = (ushort)1,
+                            Note = "Item - Feet - Attack Power per Eff. Level",
+                            Value = 2.7f
+                        },
+                        new
+                        {
+                            Type = 2u,
+                            Subtype = 6u,
+                            Property = 35u,
+                            ModType = (ushort)1,
+                            Note = "Item - Hands - Attack Power per Eff. Level",
+                            Value = 2.7f
+                        },
+                        new
+                        {
+                            Type = 2u,
+                            Subtype = 7u,
+                            Property = 35u,
+                            ModType = (ushort)1,
+                            Note = "Item - Tool - Attack Power per Eff. Level",
+                            Value = 3.6f
+                        },
+                        new
+                        {
+                            Type = 2u,
+                            Subtype = 20u,
+                            Property = 35u,
+                            ModType = (ushort)1,
+                            Note = "Item - Weapon - Attack Power per Eff. Level",
+                            Value = 83.53f
+                        },
+                        new
+                        {
+                            Type = 2u,
+                            Subtype = 58u,
+                            Property = 35u,
+                            ModType = (ushort)1,
+                            Note = "Item - Support System - Attack Power per Eff. Level",
+                            Value = 3.6f
+                        },
+                        new
+                        {
+                            Type = 2u,
+                            Subtype = 59u,
+                            Property = 35u,
+                            ModType = (ushort)1,
+                            Note = "Item - Augment - Attack Power per Eff. Level",
+                            Value = 3.6f
+                        },
+                        new
+                        {
+                            Type = 2u,
+                            Subtype = 60u,
+                            Property = 35u,
+                            ModType = (ushort)1,
+                            Note = "Item - Implant - Attack Power per Eff. Level",
+                            Value = 3.6f
+                        },
+                        new
+                        {
+                            Type = 2u,
+                            Subtype = 1u,
+                            Property = 36u,
+                            ModType = (ushort)1,
+                            Note = "Item - Chest - Support Power per Eff. Level",
+                            Value = 4.5f
+                        },
+                        new
+                        {
+                            Type = 2u,
+                            Subtype = 2u,
+                            Property = 36u,
+                            ModType = (ushort)1,
+                            Note = "Item - Legs - Support Power per Eff. Level",
+                            Value = 4.5f
+                        },
+                        new
+                        {
+                            Type = 2u,
+                            Subtype = 3u,
+                            Property = 36u,
+                            ModType = (ushort)1,
+                            Note = "Item - Head - Support Power per Eff. Level",
+                            Value = 2.7f
+                        },
+                        new
+                        {
+                            Type = 2u,
+                            Subtype = 4u,
+                            Property = 36u,
+                            ModType = (ushort)1,
+                            Note = "Item - Shoulder - Support Power per Eff. Level",
+                            Value = 3.6f
+                        },
+                        new
+                        {
+                            Type = 2u,
+                            Subtype = 5u,
+                            Property = 36u,
+                            ModType = (ushort)1,
+                            Note = "Item - Feet - Support Power per Eff. Level",
+                            Value = 2.7f
+                        },
+                        new
+                        {
+                            Type = 2u,
+                            Subtype = 6u,
+                            Property = 36u,
+                            ModType = (ushort)1,
+                            Note = "Item - Hands - Support Power per Eff. Level",
+                            Value = 2.7f
+                        },
+                        new
+                        {
+                            Type = 2u,
+                            Subtype = 7u,
+                            Property = 36u,
+                            ModType = (ushort)1,
+                            Note = "Item - Tool - Support Power per Eff. Level",
+                            Value = 3.6f
+                        },
+                        new
+                        {
+                            Type = 2u,
+                            Subtype = 20u,
+                            Property = 36u,
+                            ModType = (ushort)1,
+                            Note = "Item - Weapon - Support Power per Eff. Level",
+                            Value = 83.53f
+                        },
+                        new
+                        {
+                            Type = 2u,
+                            Subtype = 58u,
+                            Property = 36u,
+                            ModType = (ushort)1,
+                            Note = "Item - Support System - Support Power per Eff. Level",
+                            Value = 3.6f
+                        },
+                        new
+                        {
+                            Type = 2u,
+                            Subtype = 59u,
+                            Property = 36u,
+                            ModType = (ushort)1,
+                            Note = "Item - Augment - Support Power per Eff. Level",
+                            Value = 3.6f
+                        },
+                        new
+                        {
+                            Type = 2u,
+                            Subtype = 60u,
+                            Property = 36u,
+                            ModType = (ushort)1,
+                            Note = "Item - Implant - Support Power per Eff. Level",
+                            Value = 3.6f
+                        },
+                        new
+                        {
+                            Type = 2u,
+                            Subtype = 43u,
+                            Property = 41u,
+                            ModType = (ushort)1,
+                            Note = "Item - Shield - Shield Capacity per Eff. Level",
+                            Value = 225f
+                        },
+                        new
+                        {
+                            Type = 2u,
+                            Subtype = 1u,
+                            Property = 42u,
+                            ModType = (ushort)1,
+                            Note = "Item - Chest - Armor per Eff. Level",
+                            Value = 25f
+                        },
+                        new
+                        {
+                            Type = 2u,
+                            Subtype = 2u,
+                            Property = 42u,
+                            ModType = (ushort)1,
+                            Note = "Item - Legs - Armor per Eff. Level",
+                            Value = 25f
+                        },
+                        new
+                        {
+                            Type = 2u,
+                            Subtype = 3u,
+                            Property = 42u,
+                            ModType = (ushort)1,
+                            Note = "Item - Head - Armor per Eff. Level",
+                            Value = 15f
+                        },
+                        new
+                        {
+                            Type = 2u,
+                            Subtype = 4u,
+                            Property = 42u,
+                            ModType = (ushort)1,
+                            Note = "Item - Shoulder - Armor per Eff. Level",
+                            Value = 20f
+                        },
+                        new
+                        {
+                            Type = 2u,
+                            Subtype = 5u,
+                            Property = 42u,
+                            ModType = (ushort)1,
+                            Note = "Item - Feet - Armor per Eff. Level",
+                            Value = 15f
+                        },
+                        new
+                        {
+                            Type = 2u,
+                            Subtype = 6u,
+                            Property = 42u,
+                            ModType = (ushort)1,
+                            Note = "Item - Hands - Armor per Eff. Level",
+                            Value = 15f
+                        },
+                        new
+                        {
+                            Type = 2u,
+                            Subtype = 43u,
+                            Property = 175u,
+                            ModType = (ushort)0,
+                            Note = "Item - Shield - Base Shield Mitigation Percent",
+                            Value = 0.625f
+                        },
+                        new
+                        {
+                            Type = 2u,
+                            Subtype = 43u,
+                            Property = 176u,
+                            ModType = (ushort)0,
+                            Note = "Item - Shield - Base Shield Regen Percent",
+                            Value = 0.15f
+                        },
+                        new
+                        {
+                            Type = 2u,
+                            Subtype = 43u,
+                            Property = 178u,
+                            ModType = (ushort)0,
+                            Note = "Item - Shield - Base Shield Reboot Rate (ms)",
+                            Value = 5130f
+                        });
+                });
+
             modelBuilder.Entity("NexusForever.Database.Character.Model.ResidenceDecor", b =>
                 {
                     b.Property<ulong>("Id")
@@ -2119,6 +3031,18 @@ namespace NexusForever.Database.Character.Migrations
                     b.Navigation("Character");
                 });
 
+            modelBuilder.Entity("NexusForever.Database.Character.Model.CharacterContactModel", b =>
+                {
+                    b.HasOne("NexusForever.Database.Character.Model.CharacterModel", "Character")
+                        .WithMany("Contact")
+                        .HasForeignKey("OwnerId")
+                        .HasConstraintName("FK__character_contact_id__character_id")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Character");
+                });
+
             modelBuilder.Entity("NexusForever.Database.Character.Model.CharacterCostumeItemModel", b =>
                 {
                     b.HasOne("NexusForever.Database.Character.Model.CharacterCostumeModel", "Costume")
@@ -2302,6 +3226,30 @@ namespace NexusForever.Database.Character.Migrations
                         .WithMany("Reputation")
                         .HasForeignKey("Id")
                         .HasConstraintName("FK__character_reputation_id__character_id")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Character");
+                });
+
+            modelBuilder.Entity("NexusForever.Database.Character.Model.CharacterRewardTrackMilestoneModel", b =>
+                {
+                    b.HasOne("NexusForever.Database.Character.Model.CharacterRewardTrackModel", "RewardTrack")
+                        .WithMany("Milestone")
+                        .HasForeignKey("Id", "RewardTrackId")
+                        .HasConstraintName("FK__character_reward_track_milestone_id-rewardTrackId__character_reward_track_id-rewardTrackId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("RewardTrack");
+                });
+
+            modelBuilder.Entity("NexusForever.Database.Character.Model.CharacterRewardTrackModel", b =>
+                {
+                    b.HasOne("NexusForever.Database.Character.Model.CharacterModel", "Character")
+                        .WithMany("RewardTrack")
+                        .HasForeignKey("Id")
+                        .HasConstraintName("FK__character_reward_track_id__character_id")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
@@ -2504,6 +3452,8 @@ namespace NexusForever.Database.Character.Migrations
 
                     b.Navigation("CharacterTitle");
 
+                    b.Navigation("Contact");
+
                     b.Navigation("Costume");
 
                     b.Navigation("Currency");
@@ -2532,6 +3482,8 @@ namespace NexusForever.Database.Character.Migrations
 
                     b.Navigation("Residence");
 
+                    b.Navigation("RewardTrack");
+
                     b.Navigation("Spell");
 
                     b.Navigation("Stat");
@@ -2544,6 +3496,11 @@ namespace NexusForever.Database.Character.Migrations
             modelBuilder.Entity("NexusForever.Database.Character.Model.CharacterQuestModel", b =>
                 {
                     b.Navigation("QuestObjective");
+                });
+
+            modelBuilder.Entity("NexusForever.Database.Character.Model.CharacterRewardTrackModel", b =>
+                {
+                    b.Navigation("Milestone");
                 });
 
             modelBuilder.Entity("NexusForever.Database.Character.Model.ChatChannelModel", b =>

--- a/Source/NexusForever.Database.Character/Migrations/20210906140425_StartingLocations.cs
+++ b/Source/NexusForever.Database.Character/Migrations/20210906140425_StartingLocations.cs
@@ -1,0 +1,112 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace NexusForever.Database.Character.Migrations
+{
+    public partial class StartingLocations : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "character_create",
+                columns: table => new
+                {
+                    race = table.Column<byte>(type: "tinyint(4) unsigned", nullable: false, defaultValue: (byte)0),
+                    creationStart = table.Column<byte>(type: "tinyint(4) unsigned", nullable: false, defaultValue: (byte)0),
+                    faction = table.Column<ushort>(type: "smallint(5) unsigned", nullable: false, defaultValue: (ushort)0),
+                    worldId = table.Column<uint>(type: "int(10) unsigned", nullable: false, defaultValue: 0u),
+                    x = table.Column<float>(type: "float", nullable: false, defaultValue: 0f),
+                    y = table.Column<float>(type: "float", nullable: false, defaultValue: 0f),
+                    z = table.Column<float>(type: "float", nullable: false, defaultValue: 0f),
+                    rx = table.Column<float>(type: "float", nullable: false, defaultValue: 0f),
+                    ry = table.Column<float>(type: "float", nullable: false, defaultValue: 0f),
+                    rz = table.Column<float>(type: "float", nullable: false, defaultValue: 0f),
+                    comment = table.Column<string>(type: "varchar(200)", nullable: true, defaultValue: "")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PRIMARY", x => new { x.race, x.faction, x.creationStart });
+                });
+
+            migrationBuilder.InsertData(
+                table: "character_create",
+                columns: new[] { "creationStart", "faction", "race", "comment", "rx", "worldId", "x", "y", "z" },
+                values: new object[,]
+                {
+                    { (byte)4, (ushort)167, (byte)1, "Exile Human - Novice", -2.751458f, 3460u, 29.1286f, -853.8716f, -560.188f },
+                    { (byte)4, (ushort)166, (byte)12, "Dominion Mechari - Novice", -2.751458f, 3460u, 29.1286f, -853.8716f, -560.188f },
+                    { (byte)5, (ushort)166, (byte)1, "Dominion Cassian - Level 50", -0.7632219f, 22u, -3343.58f, -887.4646f, -536.03f },
+                    { (byte)3, (ushort)166, (byte)1, "Dominion Cassian - Veteran", -0.45682f, 1387u, -3835.341f, -980.2174f, -6050.524f },
+                    { (byte)4, (ushort)166, (byte)1, "Dominion Cassian - Novice", -2.751458f, 3460u, 29.1286f, -853.8716f, -560.188f },
+                    { (byte)5, (ushort)166, (byte)5, "Dominion Draken - Level 50", -0.7632219f, 22u, -3343.58f, -887.4646f, -536.03f },
+                    { (byte)3, (ushort)166, (byte)5, "Dominion Draken - Veteran", -2.215535f, 870u, -8261.398f, -995.471f, -242.3648f },
+                    { (byte)4, (ushort)166, (byte)5, "Dominion Draken - Novice", -2.751458f, 3460u, 29.1286f, -853.8716f, -560.188f },
+                    { (byte)5, (ushort)166, (byte)13, "Dominion Chua - Level 50", -0.7632219f, 22u, -3343.58f, -887.4646f, -536.03f },
+                    { (byte)3, (ushort)166, (byte)13, "Dominion Chua - Veteran", -2.215535f, 870u, -8261.398f, -995.471f, -242.3648f },
+                    { (byte)4, (ushort)166, (byte)13, "Dominion Chua - Novice", -2.751458f, 3460u, 29.1286f, -853.8716f, -560.188f }
+                });
+
+            migrationBuilder.InsertData(
+                table: "character_create",
+                columns: new[] { "creationStart", "faction", "race", "comment", "worldId", "x", "y", "z" },
+                values: new object[] { (byte)5, (ushort)167, (byte)16, "Exile Mordesh - Level 50", 51u, 4074.34f, -797.8368f, -2399.37f });
+
+            migrationBuilder.InsertData(
+                table: "character_create",
+                columns: new[] { "creationStart", "faction", "race", "comment", "rx", "worldId", "x", "y", "z" },
+                values: new object[,]
+                {
+                    { (byte)3, (ushort)167, (byte)16, "Exile Mordesh - Veteran", -1.1214035f, 990u, -771.823f, -904.2852f, -2269.56f },
+                    { (byte)4, (ushort)167, (byte)16, "Exile Mordesh - Novice", -2.751458f, 3460u, 29.1286f, -853.8716f, -560.188f }
+                });
+
+            migrationBuilder.InsertData(
+                table: "character_create",
+                columns: new[] { "creationStart", "faction", "race", "comment", "worldId", "x", "y", "z" },
+                values: new object[] { (byte)5, (ushort)167, (byte)4, "Exile Aurin - Level 50", 51u, 4074.34f, -797.8368f, -2399.37f });
+
+            migrationBuilder.InsertData(
+                table: "character_create",
+                columns: new[] { "creationStart", "faction", "race", "comment", "rx", "worldId", "x", "y", "z" },
+                values: new object[,]
+                {
+                    { (byte)3, (ushort)167, (byte)4, "Exile Aurin - Veteran", -1.1214035f, 990u, -771.823f, -904.2852f, -2269.56f },
+                    { (byte)4, (ushort)167, (byte)4, "Exile Aurin - Novice", -2.751458f, 3460u, 29.1286f, -853.8716f, -560.188f }
+                });
+
+            migrationBuilder.InsertData(
+                table: "character_create",
+                columns: new[] { "creationStart", "faction", "race", "comment", "worldId", "x", "y", "z" },
+                values: new object[] { (byte)5, (ushort)167, (byte)3, "Exile Granok - Level 50", 51u, 4074.34f, -797.8368f, -2399.37f });
+
+            migrationBuilder.InsertData(
+                table: "character_create",
+                columns: new[] { "creationStart", "faction", "race", "comment", "rx", "worldId", "x", "y", "z" },
+                values: new object[,]
+                {
+                    { (byte)3, (ushort)167, (byte)3, "Exile Granok- Veteran", 0.317613f, 426u, 4110.71f, -658.6249f, -5145.48f },
+                    { (byte)4, (ushort)167, (byte)3, "Exile Granok - Novice", -2.751458f, 3460u, 29.1286f, -853.8716f, -560.188f }
+                });
+
+            migrationBuilder.InsertData(
+                table: "character_create",
+                columns: new[] { "creationStart", "faction", "race", "comment", "worldId", "x", "y", "z" },
+                values: new object[] { (byte)5, (ushort)167, (byte)1, "Exile Human - Level 50", 51u, 4074.34f, -797.8368f, -2399.37f });
+
+            migrationBuilder.InsertData(
+                table: "character_create",
+                columns: new[] { "creationStart", "faction", "race", "comment", "rx", "worldId", "x", "y", "z" },
+                values: new object[,]
+                {
+                    { (byte)3, (ushort)167, (byte)1, "Exile Human - Veteran", 0.317613f, 426u, 4110.71f, -658.6249f, -5145.48f },
+                    { (byte)3, (ushort)166, (byte)12, "Dominion Mechari - Veteran", -0.45682f, 1387u, -3835.341f, -980.2174f, -6050.524f },
+                    { (byte)5, (ushort)166, (byte)12, "Dominion Mechari - Level 50", -0.7632219f, 22u, -3343.58f, -887.4646f, -536.03f }
+                });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "character_create");
+        }
+    }
+}

--- a/Source/NexusForever.Database.Character/Model/CharacterCreateModel.cs
+++ b/Source/NexusForever.Database.Character/Model/CharacterCreateModel.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.Generic;
+
+namespace NexusForever.Database.Character.Model
+{
+    public class CharacterCreateModel
+    {
+        public byte Race { get; set; }
+        public byte CreationStart { get; set; }
+        public ushort Faction { get; set; }
+        public uint WorldId { get; set; }
+        public float X { get; set; }
+        public float Y { get; set; }
+        public float Z { get; set; }
+        public float Rx { get; set; }
+        public float Ry { get; set; }
+        public float Rz { get; set; }
+        public string Comment { get; set; }
+    }
+}

--- a/Source/NexusForever.WorldServer/Game/Entity/Location.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/Location.cs
@@ -1,0 +1,22 @@
+﻿using NexusForever.Shared.GameTable.Model;
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using System.Text;
+
+namespace NexusForever.WorldServer.Game.Entity
+{
+    public class Location
+    {
+        public WorldEntry World { get; private set; }
+        public Vector3 Position { get; private set; }
+        public Vector3 Rotation { get; private set; }
+
+        public Location(WorldEntry world, Vector3 position, Vector3 rotation)
+        {
+            World    = world;
+            Position = position;
+            Rotation = rotation;
+        }
+    }
+}

--- a/Source/NexusForever.WorldServer/Game/Static/CharacterCreationStart.cs
+++ b/Source/NexusForever.WorldServer/Game/Static/CharacterCreationStart.cs
@@ -1,0 +1,13 @@
+﻿namespace NexusForever.WorldServer.Game.Entity.Static
+{
+    public enum CharacterCreationStart
+    {
+        Arkship     = 0,
+        Demo01      = 1,
+        Demo02      = 2,
+        Nexus       = 3,
+        PreTutorial = 4,
+        Level50     = 5,
+        CostumeOnly = 99
+    }
+}

--- a/Source/NexusForever.WorldServer/Network/Message/Handler/CharacterHandler.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Handler/CharacterHandler.cs
@@ -4,6 +4,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Numerics;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
+using NexusForever.Shared;
 using NexusForever.Database.Character;
 using NexusForever.Database.Character.Model;
 using NexusForever.Shared.Cryptography;
@@ -20,6 +21,7 @@ using NexusForever.WorldServer.Game.Entity;
 using NexusForever.WorldServer.Game.Entity.Static;
 using NexusForever.WorldServer.Game.Housing;
 using NexusForever.WorldServer.Game.Map;
+using NexusForever.WorldServer.Game.Reputation.Static;
 using NexusForever.WorldServer.Game.RBAC.Static;
 using NexusForever.WorldServer.Game.Spell;
 using NexusForever.WorldServer.Game.Spell.Static;
@@ -155,7 +157,9 @@ namespace NexusForever.WorldServer.Network.Message.Handler
                     RealmId                        = WorldServer.RealmId,
                     // no longer used as replaced by entitlements but retail server still used to send this
                     AdditionalCount                = characterCount,
-                    AdditionalAllowedCharCreations = (uint)Math.Max(0, (int)(characterSlots - characterCount))
+                    AdditionalAllowedCharCreations = (uint)Math.Max(0, (int)(characterSlots - characterCount)),
+                    // Free Level 50 needs(?) support. It appears to have just been a custom flag on the account that was consume when used up.
+                    // FreeLevel50 = true
                 };
 
                 foreach (CharacterModel character in characters.Where(c => c.DeleteTime == null))
@@ -274,8 +278,11 @@ namespace NexusForever.WorldServer.Network.Message.Handler
                     Sex        = (byte)creationEntry.Sex,
                     Class      = (byte)creationEntry.ClassId,
                     FactionId  = (ushort)creationEntry.FactionId,
-                    ActivePath = characterCreate.Path
+                    ActivePath = characterCreate.Path,
+                    TotalXp    = creationEntry.Xp
                 };
+
+                uint startingLevel = GameTableManager.Instance.XpPerLevel.Entries.First(l => l.MinXpForLevel >= creationEntry.Xp).Id;
 
                 for (Path path = Path.Soldier; path <= Path.Explorer; path++)
                 {
@@ -319,11 +326,14 @@ namespace NexusForever.WorldServer.Network.Message.Handler
                     });
                 }
 
-                //TODO: handle starting locations per race
-                character.LocationX = -7683.809f;
-                character.LocationY = -942.5914f;
-                character.LocationZ = -666.6343f;
-                character.WorldId = 870;
+                Location startingLocation = AssetManager.Instance.GetStartingLocation((Race)creationEntry.RaceId, (Faction)creationEntry.FactionId, (CharacterCreationStart)creationEntry.CharacterCreationStartEnum);
+                if (startingLocation == null)
+                    throw new ArgumentNullException(nameof(startingLocation));
+
+                character.LocationX = startingLocation.Position.X;
+                character.LocationY = startingLocation.Position.Y;
+                character.LocationZ = startingLocation.Position.Z;
+                character.WorldId = (ushort)startingLocation.World.Id;
 
                 character.ActiveSpec = 0;
 
@@ -372,12 +382,6 @@ namespace NexusForever.WorldServer.Network.Message.Handler
                 character.Stat.Add(new CharacterStatModel
                 {
                     Id    = character.Id,
-                    Stat  = (byte)Stat.Shield,
-                    Value = 450
-                });
-                character.Stat.Add(new CharacterStatModel
-                {
-                    Id    = character.Id,
                     Stat  = (byte)Stat.Dash,
                     Value = 200
                 });
@@ -385,13 +389,19 @@ namespace NexusForever.WorldServer.Network.Message.Handler
                 {
                     Id    = character.Id,
                     Stat  = (byte)Stat.Level,
-                    Value = 1
+                    Value = startingLevel
                 });
                 character.Stat.Add(new CharacterStatModel
                 {
                     Id    = character.Id,
                     Stat  = (byte)Stat.StandState,
                     Value = 3
+                });
+                character.Stat.Add(new CharacterStatModel
+                {
+                    Id = character.Id,
+                    Stat = (byte)Stat.Sheathed,
+                    Value = 1
                 });
 
                 // TODO: actually error check this
@@ -404,6 +414,10 @@ namespace NexusForever.WorldServer.Network.Message.Handler
                    () =>
                {
                    session.Characters.Add(character);
+
+                   if ((CharacterCreationStart)creationEntry.CharacterCreationStartEnum == CharacterCreationStart.Level50)
+                       session.AccountCurrencyManager.CurrencySubtractAmount(Game.Account.Static.AccountCurrencyType.MaxLevelToken, 1u);
+
                    session.EnqueueMessageEncrypted(new ServerCharacterCreate
                    {
                        CharacterId = character.Id,


### PR DESCRIPTION
- All locations were pulled from live logs
- Modifiable locations to support custom starting locations
- Boost is supported but tokens are disabled, still, due to needing bag support

Note: We need to store rotations against the character so it will spawn facing the right direction, but I will put that in a separate PR.

Thanks to @ahoiahoi for providing the original implementation of this that I referenced when updating this to latest version of NF.