### PR TITLE
Social/Bugfix: Small Genesis Prime chat fixes

### DIFF
--- a/Source/NexusForever.Database.Auth/AuthContext.cs
+++ b/Source/NexusForever.Database.Auth/AuthContext.cs
@@ -894,6 +894,11 @@ namespace NexusForever.Database.Auth
                     {
                         Id   = 10002,
                         Name = "Other: BypassInstanceLimits"
+                    },
+                    new PermissionModel
+                    {
+                        Id   = 10003,
+                        Name = "Other: GMFlag"
                     });
             });
 

--- a/Source/NexusForever.Database.Auth/Migrations/20210929151553_GMFlag.Designer.cs
+++ b/Source/NexusForever.Database.Auth/Migrations/20210929151553_GMFlag.Designer.cs
@@ -2,15 +2,17 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NexusForever.Database.Auth;
 
 namespace NexusForever.Database.Auth.Migrations
 {
     [DbContext(typeof(AuthContext))]
-    partial class AuthContextModelSnapshot : ModelSnapshot
+    [Migration("20210929151553_GMFlag")]
+    partial class GMFlag
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Source/NexusForever.Database.Auth/Migrations/20210929151553_GMFlag.cs
+++ b/Source/NexusForever.Database.Auth/Migrations/20210929151553_GMFlag.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace NexusForever.Database.Auth.Migrations
+{
+    public partial class GMFlag : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.InsertData(
+                table: "permission",
+                columns: new[] { "id", "name" },
+                values: new object[] { 10003u, "Other: GMFlag" });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "permission",
+                keyColumn: "id",
+                keyValue: 10003u);
+        }
+    }
+}

--- a/Source/NexusForever.WorldServer/Game/Entity/Player.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/Player.cs
@@ -787,12 +787,14 @@ namespace NexusForever.WorldServer.Game.Entity
 
             GuildManager.OnLogin();
             ChatManager.OnLogin();
+            GlobalChatManager.Instance.JoinChatChannels(Session);
         }
 
         private void OnLogout()
         {
             GuildManager.OnLogout();
             ChatManager.OnLogout();
+            GlobalChatManager.Instance.LeaveChatChannels(Session);
         }
 
         /// <summary>

--- a/Source/NexusForever.WorldServer/Game/Entity/Player.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/Player.cs
@@ -787,14 +787,14 @@ namespace NexusForever.WorldServer.Game.Entity
 
             GuildManager.OnLogin();
             ChatManager.OnLogin();
-            GlobalChatManager.Instance.JoinChatChannels(Session);
+            GlobalChatManager.Instance.JoinChatChannels(this);
         }
 
         private void OnLogout()
         {
             GuildManager.OnLogout();
             ChatManager.OnLogout();
-            GlobalChatManager.Instance.LeaveChatChannels(Session);
+            GlobalChatManager.Instance.LeaveChatChannels(this);
         }
 
         /// <summary>

--- a/Source/NexusForever.WorldServer/Game/Guild/Circle.cs
+++ b/Source/NexusForever.WorldServer/Game/Guild/Circle.cs
@@ -1,9 +1,10 @@
 ﻿using NexusForever.Database.Character.Model;
 using NexusForever.WorldServer.Game.Guild.Static;
+using NexusForever.WorldServer.Game.Social.Static;
 
 namespace NexusForever.WorldServer.Game.Guild
 {
-    public class Circle : GuildBase
+    public class Circle : GuildChat
     {
         public override uint MaxMembers => 20u;
 
@@ -13,6 +14,7 @@ namespace NexusForever.WorldServer.Game.Guild
         public Circle(GuildModel baseModel) 
             : base(baseModel)
         {
+            InitialiseChatChannels(ChatChannelType.Society, null);
         }
 
         /// <summary>
@@ -21,6 +23,7 @@ namespace NexusForever.WorldServer.Game.Guild
         public Circle(string name, string leaderRankName, string councilRankName, string memberRankName)
             : base(GuildType.Circle, name, leaderRankName, councilRankName, memberRankName)
         {
+            InitialiseChatChannels(ChatChannelType.Society, null);
         }
     }
 }

--- a/Source/NexusForever.WorldServer/Game/Guild/WarParty.cs
+++ b/Source/NexusForever.WorldServer/Game/Guild/WarParty.cs
@@ -1,9 +1,10 @@
 ﻿using NexusForever.Database.Character.Model;
 using NexusForever.WorldServer.Game.Guild.Static;
+using NexusForever.WorldServer.Game.Social.Static;
 
 namespace NexusForever.WorldServer.Game.Guild
 {
-    public class WarParty : GuildBase
+    public class WarParty : GuildChat
     {
         public override uint MaxMembers => 30u;
 
@@ -13,6 +14,7 @@ namespace NexusForever.WorldServer.Game.Guild
         public WarParty(GuildModel baseModel) 
             : base(baseModel)
         {
+            InitialiseChatChannels(ChatChannelType.WarParty, ChatChannelType.WarPartyOfficer);
         }
 
         /// <summary>
@@ -21,6 +23,7 @@ namespace NexusForever.WorldServer.Game.Guild
         public WarParty(string name, string leaderRankName, string councilRankName, string memberRankName)
             : base(GuildType.WarParty, name, leaderRankName, councilRankName, memberRankName)
         {
+            InitialiseChatChannels(ChatChannelType.WarParty, ChatChannelType.WarPartyOfficer);
         }
     }
 }

--- a/Source/NexusForever.WorldServer/Game/RBAC/Static/Permission.cs
+++ b/Source/NexusForever.WorldServer/Game/RBAC/Static/Permission.cs
@@ -172,6 +172,7 @@
         // non command permissions
         InstantLogout               = 10000,
         Signature                   = 10001,
-        BypassInstanceLimits        = 10002
+        BypassInstanceLimits        = 10002,
+        GMFlag                      = 10003
     }
 }

--- a/Source/NexusForever.WorldServer/Game/Social/ChatChannel.cs
+++ b/Source/NexusForever.WorldServer/Game/Social/ChatChannel.cs
@@ -74,7 +74,12 @@ namespace NexusForever.WorldServer.Game.Social
         {
             return Type == ChatChannelType.Guild
                 || Type == ChatChannelType.GuildOfficer
-                || Type == ChatChannelType.Community;
+                || Type == ChatChannelType.Community
+                || Type == ChatChannelType.Society
+                || Type == ChatChannelType.WarParty
+                || Type == ChatChannelType.WarPartyOfficer
+                || Type == ChatChannelType.Nexus
+                || Type == ChatChannelType.Trade;
         }
 
         /// <summary>
@@ -377,7 +382,7 @@ namespace NexusForever.WorldServer.Game.Social
                 Type      = Type,
                 ChannelId = Id,
                 Names     = members.Values
-                    .Where(m => !m.PendingDelete)
+                    .Where(m => !m.PendingDelete && m.IsOnline)
                     .Select(m => CharacterManager.Instance.GetCharacterInfo(m.CharacterId).Name)
                     .ToList(),
                 Flags     = members.Values
@@ -648,13 +653,16 @@ namespace NexusForever.WorldServer.Game.Social
         /// <remarks>
         /// <see cref="CanBroadcast(Player, string)"/> should be invoked before invoking this method.
         /// </remarks>
-        public void Broadcast(IWritable message)
+        public void Broadcast(IWritable message, Player except = null)
         {
             foreach (ChatChannelMember member in members.Values
                 .Where(m => m.IsOnline && !m.PendingDelete))
             {
                 Player player = CharacterManager.Instance.GetPlayer(member.CharacterId);
-                player?.Session?.EnqueueMessageEncrypted(message);
+                if (player != except)
+                {
+                    player?.Session?.EnqueueMessageEncrypted(message);
+                }
             }
         }
 

--- a/Source/NexusForever.WorldServer/Game/Social/GlobalChatManager.cs
+++ b/Source/NexusForever.WorldServer/Game/Social/GlobalChatManager.cs
@@ -316,26 +316,26 @@ namespace NexusForever.WorldServer.Game.Social
         }
 
         /// <summary>
-        /// Add the <see cref="WorldSession"/> to the chat channels sessions list for appropriate chat channels.
+        /// Add the <see cref="Player"/> to the chat channels sessions list for appropriate chat channels.
         /// </summary>
         /// <param name="session"></param>
-        public void JoinChatChannels(WorldSession session)
+        public void JoinChatChannels(Player player)
         {
             foreach (var channelType in defaultChannelTypes)
             {
-                GetChatChannel(channelType, 1).Join(session.Player, null);
+                GetChatChannel(channelType, 1).Join(player, null);
             }
         }
 
         /// <summary>
-        /// Remove the <see cref="WorldSession"/> from the chat channels sessions list for appropriate chat channels.
+        /// Remove the <see cref="Player"/> from the chat channels sessions list for appropriate chat channels.
         /// </summary>
         /// <param name="session"></param>
-        public void LeaveChatChannels(WorldSession session)
+        public void LeaveChatChannels(Player player)
         {
             foreach (var channelType in defaultChannelTypes)
             {
-                GetChatChannel(channelType, 1).Leave(session.Player.CharacterId);
+                GetChatChannel(channelType, 1).Leave(player.CharacterId);
             }
         }
 

--- a/Source/NexusForever.WorldServer/Game/Social/GlobalChatManager.cs
+++ b/Source/NexusForever.WorldServer/Game/Social/GlobalChatManager.cs
@@ -40,6 +40,12 @@ namespace NexusForever.WorldServer.Game.Social
         private readonly Dictionary<ChatChannelType, Dictionary<string, ulong>> chatChannelNames = new();
         private readonly Dictionary<ChatChannelType, Dictionary<ulong, List<ulong>>> characterChatChannels = new();
 
+        private readonly List<ChatChannelType> defaultChannelTypes = new List<ChatChannelType>
+        {
+            ChatChannelType.Nexus,
+            ChatChannelType.Trade,
+        };
+
         private readonly UpdateTimer saveTimer = new(60d);
 
         private GlobalChatManager()
@@ -72,6 +78,11 @@ namespace NexusForever.WorldServer.Game.Social
 
                 chatChannels[chatChannel.Type].Add(chatChannel.Id, chatChannel);
                 chatChannelNames[chatChannel.Type].Add(chatChannel.Name, chatChannel.Id);
+            }
+
+            foreach (var channelType in defaultChannelTypes)
+            {
+                CreateChatChannel(channelType, 1, channelType.ToString());
             }
         }
 
@@ -289,17 +300,43 @@ namespace NexusForever.WorldServer.Game.Social
             session.EnqueueMessageEncrypted(new ServerChatAccept
             {
                 Name = session.Player.Name,
-                Guid = session.Player.Guid
+                Guid = session.Player.Guid,
+                GM = session.AccountRbacManager.HasPermission(RBAC.Static.Permission.GMFlag)
             });
         }
 
-        private void SendChatAccept(WorldSession session, string targetName)
+        private void SendChatAccept(WorldSession session, Player target)
         {
             session.EnqueueMessageEncrypted(new ServerChatAccept
             {
-                Name = targetName,
-                Guid = session.Player.Guid
+                Name = target.Name,
+                Guid = target.Guid,
+                GM = target.Session.AccountRbacManager.HasPermission(RBAC.Static.Permission.GMFlag)
             });
+        }
+
+        /// <summary>
+        /// Add the <see cref="WorldSession"/> to the chat channels sessions list for appropriate chat channels.
+        /// </summary>
+        /// <param name="session"></param>
+        public void JoinChatChannels(WorldSession session)
+        {
+            foreach (var channelType in defaultChannelTypes)
+            {
+                GetChatChannel(channelType, 1).Join(session.Player, null);
+            }
+        }
+
+        /// <summary>
+        /// Remove the <see cref="WorldSession"/> from the chat channels sessions list for appropriate chat channels.
+        /// </summary>
+        /// <param name="session"></param>
+        public void LeaveChatChannels(WorldSession session)
+        {
+            foreach (var channelType in defaultChannelTypes)
+            {
+                GetChatChannel(channelType, 1).Leave(session.Player.CharacterId);
+            }
         }
 
         [ChatChannelHandler(ChatChannelType.Say)]
@@ -313,7 +350,8 @@ namespace NexusForever.WorldServer.Game.Social
                 FromName = session.Player.Name,
                 Text     = chat.Message,
                 Formats  = ParseChatLinks(session, chat.Formats).ToList(),
-                Guid     = session.Player.Guid
+                Guid     = session.Player.Guid,
+                GM       = session.AccountRbacManager.HasPermission(RBAC.Static.Permission.GMFlag)
             };
 
             session.Player.Map.Search(
@@ -334,6 +372,8 @@ namespace NexusForever.WorldServer.Game.Social
         [ChatChannelHandler(ChatChannelType.Community)]
         [ChatChannelHandler(ChatChannelType.GuildOfficer)]
         [ChatChannelHandler(ChatChannelType.WarPartyOfficer)]
+        [ChatChannelHandler(ChatChannelType.Nexus)]
+        [ChatChannelHandler(ChatChannelType.Trade)]
         [ChatChannelHandler(ChatChannelType.Custom)]
         private void HandleChannelChat(WorldSession session, ClientChat chat)
         {
@@ -361,10 +401,12 @@ namespace NexusForever.WorldServer.Game.Social
                 FromName = session.Player.Name,
                 Text     = chat.Message,
                 Formats  = ParseChatLinks(session, chat.Formats).ToList(),
-                Guid     = session.Player.Guid
+                Guid     = session.Player.Guid,
+                GM       = session.AccountRbacManager.HasPermission(RBAC.Static.Permission.GMFlag)
             };
 
-            channel.Broadcast(builder.Build());
+            channel.Broadcast(builder.Build(), session.Player);
+            SendChatAccept(session);
         }
 
         /// <summary>
@@ -400,6 +442,7 @@ namespace NexusForever.WorldServer.Game.Social
                 return;
             }
 
+            // target player message
             var builder = new ChatMessageBuilder
             {
                 Type         = ChatChannelType.Whisper,
@@ -407,11 +450,14 @@ namespace NexusForever.WorldServer.Game.Social
                 FromName     = session.Player.Name,
                 Text         = whisper.Message,
                 Formats      = ParseChatLinks(session, whisper.Formats).ToList(),
-                CrossFaction = session.Player.Faction1 != target.Faction1
+                CrossFaction = session.Player.Faction1 != target.Faction1,
+                FromCharacterId = session.Player.CharacterId,
+                FromCharacterRealmId = WorldServer.RealmId,
+                GM           = session.AccountRbacManager.HasPermission(RBAC.Static.Permission.GMFlag)
             };
             target.Session.EnqueueMessageEncrypted(builder.Build());
 
-            SendChatAccept(session, target.Name);
+            SendChatAccept(session, target);
         }
 
         /// <summary>


### PR DESCRIPTION
**Changes**

- Remove chat duplication bug from GuildBase chats and custom channels.
- Added Nexus and Trade chat (easily extended to cover German/French versions too, if desired?
- Added GM Flag as an RBAC permission.
- /chlist now only lists online members.
- SendChatAccept is now slightly cleaner for whisper messages and uses the target's guid, the same way it already uses the target's name and now also uses the target's GM flag permission.

**Known issues to be investigated/resolved**

None, I tested every situation I could think of.