### PR TITLE
[Inventory/Item] Fix IsEquippable incorrect return

### DIFF
--- a/Source/NexusForever.WorldServer/Game/Entity/ItemInfo.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/ItemInfo.cs
@@ -30,7 +30,7 @@ namespace NexusForever.WorldServer.Game.Entity
         /// </summary>
         public bool IsEquippable()
         {
-            return SlotEntry != null && SlotEntry?.EquippedSlotFlags != 0u;
+            return SlotEntry != null && SlotEntry.EquippedSlotFlags != 0u;
         }
 
         /// <summary>

--- a/Source/NexusForever.WorldServer/Game/Entity/ItemInfo.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/ItemInfo.cs
@@ -30,7 +30,7 @@ namespace NexusForever.WorldServer.Game.Entity
         /// </summary>
         public bool IsEquippable()
         {
-            return SlotEntry?.EquippedSlotFlags != 0u;
+            return SlotEntry != null && SlotEntry?.EquippedSlotFlags != 0u;
         }
 
         /// <summary>


### PR DESCRIPTION
If SlotEntry was empty, I was getting "true" returns. This was most prevalent when creating a Veteran character, it would try to put the Protostar Rucksack lootbag in an equipped slot, even without a SlotEntry. 

Solution I chose was to update `IsEquppable` with a non-null check.