### PR TITLE
[Entity/CostumeManager] Prevent double-setting costume index

### DIFF
--- a/Source/NexusForever.WorldServer/Game/Entity/CostumeManager.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/CostumeManager.cs
@@ -163,7 +163,8 @@ namespace NexusForever.WorldServer.Game.Entity
                 costumes.Add(costume.Index, costume);
             }
 
-            SetCostume((sbyte)costumeSave.Index, costume);
+            if (costumeSave.Index == player.CostumeIndex)
+                player.Inventory.VisualUpdate(costume);
 
             SendCostume(costume);
             SendCostumeSaveResult(CostumeSaveResult.Saved, costumeSave.Index, costumeSave.MannequinIndex);


### PR DESCRIPTION
Addresses: https://github.com/NexusForever/NexusForever/issues/104

The client calls `Save` and then `Set` in the case of editing a non-equipped costume. This caused a double `Set` which would error out and cause the client and server state to be desync'd.