### PR TITLE
[Entity/Vendor] Support Credit Cost formula

### DIFF
--- a/Source/NexusForever.Game.Abstract/Entity/IItemInfo.cs
+++ b/Source/NexusForever.Game.Abstract/Entity/IItemInfo.cs
@@ -26,6 +26,18 @@ namespace NexusForever.Game.Abstract.Entity
         ushort GetDisplayId();
 
         /// <summary>
+        /// Returns the <see cref="CurrencyType"/> this <see cref="IItemInfo"/> sells for at a vendor.
+        /// </summary>
+        CurrencyType GetVendorSellCurrency(byte index);
+
+        /// <summary>
+        /// Returns the amount of <see cref="CurrencyType"/> this <see cref="IItemInfo"/> sells for at a vendor.
+        /// </summary>
+        uint GetVendorSellAmount(byte index);
+
+        uint CalculateVendorSellAmount();
+
+        /// <summary>
         /// Returns if item can be equipped into an item slot.
         /// </summary>
         bool IsEquippable();

--- a/Source/NexusForever.Game.Abstract/Entity/IItemInfo.cs
+++ b/Source/NexusForever.Game.Abstract/Entity/IItemInfo.cs
@@ -26,6 +26,16 @@ namespace NexusForever.Game.Abstract.Entity
         ushort GetDisplayId();
 
         /// <summary>
+        /// Returns the <see cref="CurrencyType"/> this <see cref="IItemInfo"/> can be purchased for at a vendor.
+        /// </summary>
+        CurrencyType GetVendorBuyCurrency(byte index);
+
+        /// <summary>
+        /// Returns the amount of <see cref="CurrencyType"/> this <see cref="IItemInfo"/> can be purchased for at a vendor.
+        /// </summary>
+        uint GetVendorBuyAmount(byte index);
+
+        /// <summary>
         /// Returns the <see cref="CurrencyType"/> this <see cref="IItemInfo"/> sells for at a vendor.
         /// </summary>
         CurrencyType GetVendorSellCurrency(byte index);

--- a/Source/NexusForever.Game.Abstract/Entity/IItemInfo.cs
+++ b/Source/NexusForever.Game.Abstract/Entity/IItemInfo.cs
@@ -35,8 +35,6 @@ namespace NexusForever.Game.Abstract.Entity
         /// </summary>
         uint GetVendorSellAmount(byte index);
 
-        uint CalculateVendorSellAmount();
-
         /// <summary>
         /// Returns if item can be equipped into an item slot.
         /// </summary>

--- a/Source/NexusForever.Game.Static/Entity/CurrencyType.cs
+++ b/Source/NexusForever.Game.Static/Entity/CurrencyType.cs
@@ -15,6 +15,7 @@
         RedEssence         = 11,
         BlueEssence        = 12,
         GreenEssence       = 13,
-        PurpleEssence      = 14
+        PurpleEssence      = 14,
+        WarCoin            = 15,
     }
 }

--- a/Source/NexusForever.Game/Entity/Item.cs
+++ b/Source/NexusForever.Game/Entity/Item.cs
@@ -324,10 +324,7 @@ namespace NexusForever.Game.Entity
         /// </summary>
         public CurrencyType GetVendorSellCurrency(byte index)
         {
-            if (Info.Entry.CurrencyTypeIdSellToVendor[index] != 0u)
-                return (CurrencyType)Info.Entry.CurrencyTypeIdSellToVendor[index];
-
-            return CurrencyType.None;
+            return Info.GetVendorSellCurrency(index);
         }
 
         /// <summary>
@@ -338,7 +335,6 @@ namespace NexusForever.Game.Entity
             if (Info.Entry.CurrencyTypeIdSellToVendor[index] != 0u)
                 return Info.Entry.CurrencyAmountSellToVendor[index];
 
-            // most items that sell for credits have their sell amount calculated and not stored in the tbl
             return CalculateVendorSellAmount();
         }
 
@@ -347,7 +343,9 @@ namespace NexusForever.Game.Entity
             // TODO: Rawaho was lazy and didn't finish this
             // GameFormulaEntry entry = GameTableManager.Instance.GameFormula.GetEntry(559);
             // uint cost = Entry.PowerLevel * entry.Dataint01;
-            return 0u;
+
+            // TODO: Add calculations for Runes or other things that would increase worth amount.
+            return Info.CalculateVendorSellAmount();
         }
     }
 }

--- a/Source/NexusForever.Game/Entity/Item.cs
+++ b/Source/NexusForever.Game/Entity/Item.cs
@@ -332,20 +332,12 @@ namespace NexusForever.Game.Entity
         /// </summary>
         public uint GetVendorSellAmount(byte index)
         {
-            if (Info.Entry.CurrencyTypeIdSellToVendor[index] != 0u)
-                return Info.Entry.CurrencyAmountSellToVendor[index];
-
-            return CalculateVendorSellAmount();
-        }
-
-        private uint CalculateVendorSellAmount()
-        {
             // TODO: Rawaho was lazy and didn't finish this
             // GameFormulaEntry entry = GameTableManager.Instance.GameFormula.GetEntry(559);
             // uint cost = Entry.PowerLevel * entry.Dataint01;
 
             // TODO: Add calculations for Runes or other things that would increase worth amount.
-            return Info.CalculateVendorSellAmount();
+            return Info.GetVendorSellAmount(index);
         }
     }
 }

--- a/Source/NexusForever.Game/Entity/ItemInfo.cs
+++ b/Source/NexusForever.Game/Entity/ItemInfo.cs
@@ -17,6 +17,7 @@ namespace NexusForever.Game.Entity
         public ItemSlotEntry SlotEntry { get; }
         public ItemBudgetEntry BudgetEntry { get; }
         public ItemStatEntry StatEntry { get; }
+        public ItemQualityEntry QualityEntry { get; }
         public SecondaryItemFlags SecondaryItemFlags { get; }
 
         public float ItemPower { get; private set; }
@@ -34,6 +35,7 @@ namespace NexusForever.Game.Entity
             SlotEntry     = GameTableManager.Instance.ItemSlot.GetEntry(TypeEntry.ItemSlotId);
             BudgetEntry   = GameTableManager.Instance.ItemBudget.GetEntry(Entry.ItemBudgetId);
             StatEntry     = GameTableManager.Instance.ItemStat.GetEntry(Entry.ItemStatId);
+            QualityEntry  = GameTableManager.Instance.ItemQuality.GetEntry(Entry.ItemQualityId);
 
             // the client combines the flags from the family, category and type entries into a single value
             SecondaryItemFlags = FamilyEntry.Flags | CategoryEntry.Flags | TypeEntry.Flags;
@@ -323,6 +325,41 @@ namespace NexusForever.Game.Entity
 
             // TODO: research this...
             throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Returns the <see cref="CurrencyType"/> this <see cref="IItemInfo"/> sells for at a vendor.
+        /// </summary>
+        public CurrencyType GetVendorSellCurrency(byte index)
+        {
+            if (Entry.CurrencyTypeIdSellToVendor[index] != 0u)
+                return (CurrencyType)Entry.CurrencyTypeIdSellToVendor[index];
+
+            return CurrencyType.None;
+        }
+
+        /// <summary>
+        /// Returns the amount of <see cref="CurrencyType"/> this <see cref="IItemInfo"/> sells for at a vendor.
+        /// </summary>
+        public uint GetVendorSellAmount(byte index)
+        {
+            if (Entry.CurrencyTypeIdSellToVendor[index] != 0u)
+                return Entry.CurrencyAmountSellToVendor[index];
+
+            // most items that sell for credits have their sell amount calculated and not stored in the tbl
+            return CalculateVendorSellAmount();
+        }
+
+        public uint CalculateVendorSellAmount()
+        {
+            // TODO: Rawaho was lazy and didn't finish this
+            // GameFormulaEntry entry = GameTableManager.Instance.GameFormula.GetEntry(559);
+            // uint cost = Entry.PowerLevel * entry.Dataint01;
+
+            // Kirmmin's Temporary Sell Value (Accurate for items between PowerLevel 20 and 50)
+            float baseVal = ((((Entry.PowerLevel * Entry.PowerLevel) * Entry.ItemQualityId) * TypeEntry.VendorMultiplier) * CategoryEntry.VendorMultiplier);
+            float moddedValue = MathF.Floor(baseVal * 1.125f);
+            return (uint)(moddedValue > 0f ? moddedValue : 1u);
         }
 
         /// <summary>

--- a/Source/NexusForever.Game/Entity/ItemInfo.cs
+++ b/Source/NexusForever.Game/Entity/ItemInfo.cs
@@ -23,6 +23,9 @@ namespace NexusForever.Game.Entity
         public float ItemPower { get; private set; }
         public ImmutableDictionary<Property, float> Properties { get; private set; }
 
+        private CurrencyType[] vendorBuyCurrency = new CurrencyType[2];
+        private uint[] vendorBuyAmount = new uint[2];
+
         private CurrencyType[] vendorSellCurrency = new CurrencyType[2];
         private uint[] vendorSellAmount = new uint[2];
 
@@ -45,6 +48,7 @@ namespace NexusForever.Game.Entity
 
             CalculateProperties();
 
+            CalculateVendorBuyAmount();
             CalculateVendorSellAmount();
         }
 
@@ -330,6 +334,44 @@ namespace NexusForever.Game.Entity
 
             // TODO: research this...
             throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Returns the <see cref="CurrencyType"/> this <see cref="IItemInfo"/> can be purchased for at a vendor.
+        /// </summary>
+        public CurrencyType GetVendorBuyCurrency(byte index)
+        {
+            return vendorBuyCurrency[index];
+        }
+
+        /// <summary>
+        /// Returns the amount of <see cref="CurrencyType"/> this <see cref="IItemInfo"/> can be purchased for at a vendor.
+        /// </summary>
+        public uint GetVendorBuyAmount(byte index)
+        {
+            return vendorBuyAmount[index];
+        }
+
+        private void CalculateVendorBuyAmount()
+        {
+            if (Entry.CurrencyTypeId[0] != CurrencyType.None
+               || Entry.CurrencyTypeId[1] != CurrencyType.None)
+            {
+                // explicit purchase price
+                vendorBuyCurrency = Entry.CurrencyTypeId;
+                vendorBuyAmount   = Entry.CurrencyAmount;
+
+                if ((Entry.Flags & ItemFlags.Unknown200) != 0)
+                    vendorBuyCurrency[0] = CurrencyType.WarCoin;
+            }
+            else
+            {
+                vendorBuyCurrency[0] = CurrencyType.Credits;
+                vendorBuyCurrency[1] = CurrencyType.Credits;
+
+                // calculated purchase price
+                vendorBuyAmount[0] = (uint)MathF.Floor(CalculateVendorAmount());
+            }
         }
 
         /// <summary>

--- a/Source/NexusForever.GameTable/GameTableManager.cs
+++ b/Source/NexusForever.GameTable/GameTableManager.cs
@@ -289,7 +289,10 @@ namespace NexusForever.GameTable
         public GameTable<ItemImbuementEntry> ItemImbuement { get; private set; }
         public GameTable<ItemImbuementRewardEntry> ItemImbuementReward { get; private set; }
         public GameTable<ItemProficiencyEntry> ItemProficiency { get; private set; }
+
+        [GameData]
         public GameTable<ItemQualityEntry> ItemQuality { get; private set; }
+
         public GameTable<ItemRandomStatEntry> ItemRandomStat { get; private set; }
         public GameTable<ItemRandomStatGroupEntry> ItemRandomStatGroup { get; private set; }
         public GameTable<ItemRuneInstanceEntry> ItemRuneInstance { get; private set; }

--- a/Source/NexusForever.GameTable/Model/Item2Entry.cs
+++ b/Source/NexusForever.GameTable/Model/Item2Entry.cs
@@ -1,3 +1,4 @@
+using NexusForever.Game.Static.Entity;
 using NexusForever.GameTable.Static;
 
 namespace NexusForever.GameTable.Model
@@ -43,7 +44,7 @@ namespace NexusForever.GameTable.Model
         [GameTableFieldArray(2)]
         public uint[] CurrencyAmount;
         [GameTableFieldArray(2)]
-        public uint[] CurrencyTypeIdSellToVendor;
+        public CurrencyType[] CurrencyTypeIdSellToVendor;
         [GameTableFieldArray(2)]
         public uint[] CurrencyAmountSellToVendor;
         public uint ItemColorSetId;

--- a/Source/NexusForever.GameTable/Model/Item2Entry.cs
+++ b/Source/NexusForever.GameTable/Model/Item2Entry.cs
@@ -40,7 +40,7 @@ namespace NexusForever.GameTable.Model
         public uint BindFlags;
         public uint BuyFromVendorStackCount;
         [GameTableFieldArray(2)]
-        public uint[] CurrencyTypeId;
+        public CurrencyType[] CurrencyTypeId;
         [GameTableFieldArray(2)]
         public uint[] CurrencyAmount;
         [GameTableFieldArray(2)]

--- a/Source/NexusForever.GameTable/Static/ItemFlags.cs
+++ b/Source/NexusForever.GameTable/Static/ItemFlags.cs
@@ -6,6 +6,7 @@
         None            = 0x00000000,
         DestroyOnLogout = 0x00000040,
         DestroyOnZone   = 0x00000080,
+        Unknown200      = 0x00000200, // seems to relate to items that sell for WarCoins
         Depreciated     = 0x00004000,
         PlayerVsPlayer  = 0x00008000
     }

--- a/Source/NexusForever.WorldServer/Network/Message/Handler/VendorHandler.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Handler/VendorHandler.cs
@@ -96,7 +96,7 @@ namespace NexusForever.WorldServer.Network.Message.Handler
 
             // TODO Calculate values appropriately.
             // clientPurchaseMod was confirmed by in-game vendor values. Need to find GameTable it's associated with.
-            ulong amount = (ulong)Math.Ceiling(info.GetVendorSellAmount(0) * costMultiplier);
+            ulong amount = (ulong)Math.Ceiling(info.GetVendorBuyAmount(0) * costMultiplier);
             currencyChanges.Add((CurrencyType.Credits, amount));
 
             foreach ((CurrencyType currencyTypeId, ulong currencyAmount) in currencyChanges)

--- a/Source/NexusForever.WorldServer/Network/Message/Handler/VendorHandler.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Handler/VendorHandler.cs
@@ -1,5 +1,7 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 using NexusForever.Database.World.Model;
+using NexusForever.Game;
 using NexusForever.Game.Abstract.Entity;
 using NexusForever.Game.Entity;
 using NexusForever.Game.Static.Entity;
@@ -7,23 +9,22 @@ using NexusForever.GameTable;
 using NexusForever.GameTable.Model;
 using NexusForever.Network.Message;
 using NexusForever.Network.World.Message.Model;
+using NexusForever.Network.World.Message.Static;
 
 namespace NexusForever.WorldServer.Network.Message.Handler
 {
     public static class VendorHandler
-    {   
+    {
+        private static float clientPurchaseMod = 0.14966f;
+
         public static void HandleClientVendor(IWorldSession session, ClientEntityInteract vendor)
         {
             var vendorEntity = session.Player.Map.GetEntity<INonPlayer>(vendor.Guid);
             if (vendorEntity == null)
-            {
-                return;
-            }
+                throw new InvalidOperationException();
 
             if (vendorEntity.VendorInfo == null)
-            {
-                return;
-            }
+                throw new InvalidOperationException();
 
             session.Player.SelectedVendorInfo = vendorEntity.VendorInfo;
             var serverVendor = new ServerVendorItemsUpdated
@@ -76,6 +77,10 @@ namespace NexusForever.WorldServer.Network.Message.Handler
             Item2Entry itemEntry = GameTableManager.Instance.Item.GetEntry(vendorItem.ItemId);
             float costMultiplier = vendorInfo.BuyPriceMultiplier * vendorPurchase.VendorItemQty;
 
+            IItemInfo info = ItemManager.Instance.GetItemInfo(itemEntry.Id);
+            if (info == null)
+                return;
+
             // do all sanity checks before modifying currency
             var currencyChanges = new List<(CurrencyType CurrencyTypeId, ulong CurrencyAmount)>();
             for (int i = 0; i < itemEntry.CurrencyTypeId.Length; i++)
@@ -90,7 +95,12 @@ namespace NexusForever.WorldServer.Network.Message.Handler
 
                 currencyChanges.Add((currencyId, currencyAmount));
             }
-            
+
+            // TODO Calculate values appropriately.
+            // clientPurchaseMod was confirmed by in-game vendor values. Need to find GameTable it's associated with.
+            ulong amount = (ulong)Math.Ceiling((info.GetVendorSellAmount(0) * costMultiplier) / clientPurchaseMod);
+            currencyChanges.Add((CurrencyType.Credits, amount));
+
             foreach ((CurrencyType currencyTypeId, ulong currencyAmount) in currencyChanges)
                 session.Player.CurrencyManager.CurrencySubtractAmount(currencyTypeId, currencyAmount);
 
@@ -104,7 +114,11 @@ namespace NexusForever.WorldServer.Network.Message.Handler
             if (vendorInfo == null)
                 return;
 
-            IItemInfo info = session.Player.Inventory.GetItem(vendorSell.ItemLocation).Info;
+            IItem item = session.Player.Inventory.GetItem(vendorSell.ItemLocation);
+            if (item == null)
+                return;
+
+            IItemInfo info = item.Info;
             if (info == null)
                 return;
 
@@ -123,12 +137,13 @@ namespace NexusForever.WorldServer.Network.Message.Handler
             }
 
             // TODO Insert calculation for cost here
+            currencyChange.Add((CurrencyType.Credits, (ulong)(item.GetVendorSellAmount(0) * costMultiplier)));
 
             foreach ((CurrencyType currencyTypeId, ulong currencyAmount) in currencyChange)
                 session.Player.CurrencyManager.CurrencyAddAmount(currencyTypeId, currencyAmount);
 
             // TODO Figure out why this is showing "You deleted [item]"
-            IItem soldItem = session.Player.Inventory.ItemDelete(vendorSell.ItemLocation);
+            IItem soldItem = session.Player.Inventory.ItemDelete(vendorSell.ItemLocation, ItemUpdateReason.Vendor);
             BuybackManager.Instance.AddItem(session.Player, soldItem, vendorSell.Quantity, currencyChange);
         }
 
@@ -140,6 +155,11 @@ namespace NexusForever.WorldServer.Network.Message.Handler
                 return;
 
             //TODO Ensure player has room in inventory
+            if (session.Player.Inventory.GetInventorySlotsRemaining(InventoryLocation.Inventory) < 1)
+            {
+                session.Player.SendGenericError(GenericError.ItemInventoryFull);
+                return;
+            }
 
             // do all sanity checks before modifying currency
             foreach ((CurrencyType currencyTypeId, ulong currencyAmount) in buybackItem.CurrencyChange)

--- a/Source/NexusForever.WorldServer/Network/Message/Handler/VendorHandler.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Handler/VendorHandler.cs
@@ -15,8 +15,6 @@ namespace NexusForever.WorldServer.Network.Message.Handler
 {
     public static class VendorHandler
     {
-        private static float clientPurchaseMod = 0.14966f;
-
         public static void HandleClientVendor(IWorldSession session, ClientEntityInteract vendor)
         {
             var vendorEntity = session.Player.Map.GetEntity<INonPlayer>(vendor.Guid);
@@ -98,7 +96,7 @@ namespace NexusForever.WorldServer.Network.Message.Handler
 
             // TODO Calculate values appropriately.
             // clientPurchaseMod was confirmed by in-game vendor values. Need to find GameTable it's associated with.
-            ulong amount = (ulong)Math.Ceiling((info.GetVendorSellAmount(0) * costMultiplier) / clientPurchaseMod);
+            ulong amount = (ulong)Math.Ceiling(info.GetVendorSellAmount(0) * costMultiplier);
             currencyChanges.Add((CurrencyType.Credits, amount));
 
             foreach ((CurrencyType currencyTypeId, ulong currencyAmount) in currencyChanges)


### PR DESCRIPTION
The formula that I derived was determined by taking values as seen in game. I was unable to discover the formula in the client, but said I would push this as a PR as it gives a good baseline value to work with.
```
((((PowerLevel * PowerLevel) * ItemQualityId) * Type.VendorMultiplier) * Category.VendorMultiplier) * 1.125
```
The value always rounded down. It's worth mentioning that this value worked for items regardless of PowerLevel. Initially, I thought this would only work on Items between 20 and 50 PowerLevel, but finding the ItemCategory's VendorMultiplier was the missing piece that made this formula always work.

On top of this, Vendors sell items for `the above value / 0.14966`. I could not find any related GameTables to figure out how either multiplier was determined.