### PR TITLE
Option to generate map and table files on WorldServer build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@
 ##
 ## Get latest from https://github.com/github/gitignore/blob/master/VisualStudio.gitignore
 
+# NexusForever generated files
+tbl/
+map/
+
 # User-specific files
 *.suo
 *.user

--- a/Source/NexusForever.MapGenerator/ExtractionManager.cs
+++ b/Source/NexusForever.MapGenerator/ExtractionManager.cs
@@ -18,15 +18,19 @@ namespace NexusForever.MapGenerator
             "en-GB.bin"
         };
 
+        private string outputDir;
+
         private ExtractionManager()
         {
         }
 
-        public void Initialise()
+        public void Initialise(string outputDir)
         {
             log.Info("Extracting GameTables...");
 
-            Directory.CreateDirectory("tbl");
+            this.outputDir = Path.Combine(outputDir, "tbl");
+
+            Directory.CreateDirectory(this.outputDir);
 
             ExtractGameTables();
             ExtractLanguageFiles();
@@ -63,7 +67,7 @@ namespace NexusForever.MapGenerator
         /// </summary>
         private void ExtractFile(Archive archive, IArchiveFileEntry fileEntry)
         {
-            string filePath = Path.Combine("tbl", fileEntry.FileName);
+            string filePath = Path.Combine(outputDir, fileEntry.FileName);
 
             using (Stream archiveStream = archive.OpenFileStream(fileEntry))
             using (FileStream fileStream = File.OpenWrite(filePath))

--- a/Source/NexusForever.MapGenerator/GenerationManager.cs
+++ b/Source/NexusForever.MapGenerator/GenerationManager.cs
@@ -19,16 +19,19 @@ namespace NexusForever.MapGenerator
     public sealed class GenerationManager : Singleton<GenerationManager>
     {
         private static readonly ILogger log = LogManager.GetCurrentClassLogger();
+        private string outputDir;
 
         private GenerationManager()
         {
         }
 
-        public void Initialise()
+        public void Initialise(string outputDir)
         {
             log.Info("Generatring base map files...");
 
-            Directory.CreateDirectory("map");
+            this.outputDir = Path.Combine(outputDir, "map");
+
+            Directory.CreateDirectory(this.outputDir);
         }
 
         /// <summary>
@@ -50,8 +53,7 @@ namespace NexusForever.MapGenerator
             foreach (WorldEntry entry in GameTableManager.Instance.World.Entries
                 .Where(e => e.AssetPath != string.Empty)
                 .GroupBy(e => e.AssetPath)
-                .Select(g => g.First())
-                .ToArray())
+                .Select(g => g.First()))
             {
                 if (singleThread)
                     ProcessWorld(entry);
@@ -105,7 +107,7 @@ namespace NexusForever.MapGenerator
 
             // Path.ChangeExtension(mapFile.Asset, "nfmap")
             // ChangeExtension doesn't behave correctly on linux
-            string filePath = Path.Combine("map", $"{mapFile.Asset}.nfmap");
+            string filePath = Path.Combine(outputDir, $"{mapFile.Asset}.nfmap");
 
             using (FileStream stream = File.Create(filePath))
             using (var writer = new BinaryWriter(stream))

--- a/Source/NexusForever.MapGenerator/MapGenerator.cs
+++ b/Source/NexusForever.MapGenerator/MapGenerator.cs
@@ -26,7 +26,6 @@ namespace NexusForever.MapGenerator
             parserResult.WithParsed(ParameterOk);
 
             log.Info("Finished!");
-            Console.ReadLine();
         }
 
         private static void ParameterOk(Parameters parameters)
@@ -41,14 +40,20 @@ namespace NexusForever.MapGenerator
                 return;
             }
 
+            if ((parameters.Extract || parameters.Generate) && !string.IsNullOrEmpty(parameters.OutputDir))
+            {
+                if (!Directory.Exists(parameters.OutputDir))
+                    throw new DirectoryNotFoundException(parameters.OutputDir);
+            }
+
             ArchiveManager.Instance.Initialise(parameters.PatchPath);
             GameTableManager.Instance.Initialise();
 
             if (parameters.Extract)
-                ExtractionManager.Instance.Initialise();
+                ExtractionManager.Instance.Initialise(parameters.OutputDir);
             if (parameters.Generate)
             {
-                GenerationManager.Instance.Initialise();
+                GenerationManager.Instance.Initialise(parameters.OutputDir);
 
                 var start = DateTime.UtcNow;
                 if (parameters.WorldId.HasValue)

--- a/Source/NexusForever.MapGenerator/Parameters.cs
+++ b/Source/NexusForever.MapGenerator/Parameters.cs
@@ -16,6 +16,10 @@ namespace NexusForever.MapGenerator
             HelpText = "Generate base map files (.nfmap) from the area files.")]
         public bool Generate { get; set; }
 
+        [Option('o', "output",
+            HelpText = "The base directory where output files will be created.", Default = "")]
+        public string OutputDir { get; set; }
+
         [Option("debug")]
         public bool Debug { get; set; }
 

--- a/Source/NexusForever.WorldServer/ExtractGameTableFiles.targets
+++ b/Source/NexusForever.WorldServer/ExtractGameTableFiles.targets
@@ -1,0 +1,10 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="ExtractGameTableFiles" AfterTargets="AfterBuild">
+    <Message Text="Extracting game table files." Importance="High" />
+
+    <!-- Extract the Game Table files into the NexusForever.WorldServer build directory -->
+    <Exec Command='dotnet run --project ../NexusForever.MapGenerator -- --e --i "$(WsInstallDir)\Patch" --o $(MSBuildThisFileDirectory)$(OutDir)'/>
+
+    <Message Text="Done extracting game table files!" Importance="High" />
+  </Target>
+</Project>

--- a/Source/NexusForever.WorldServer/GenerateBaseMapFiles.targets
+++ b/Source/NexusForever.WorldServer/GenerateBaseMapFiles.targets
@@ -1,0 +1,10 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="GenerateBaseMapFiles" AfterTargets="AfterBuild">
+    <Message Text="Generating base map files. This can take several minutes." Importance="High" />
+
+      <!-- Generate the Base Map files in the NexusForever.WorldServer build directory -->
+      <Exec Command='dotnet run --project ../NexusForever.MapGenerator -- --g --i "$(WsInstallDir)\Patch" --o $(MSBuildThisFileDirectory)$(OutDir)'/>
+
+      <Message Text="Done generating base map files!" Importance="High" />
+  </Target>
+</Project>

--- a/Source/NexusForever.WorldServer/NexusForever.WorldServer.csproj
+++ b/Source/NexusForever.WorldServer/NexusForever.WorldServer.csproj
@@ -30,6 +30,12 @@
     <ProjectReference Include="..\NexusForever.Shared\NexusForever.Shared.csproj" />
   </ItemGroup>
 
+  <Import Project="./ExtractGameTableFiles.targets"
+    Condition="$(ExtractGameTables) == 'true'" />
+
+  <Import Project="./GenerateBaseMapFiles.targets"
+    Condition="$(GenerateMapFiles) == 'true'" />
+
   <ItemGroup>
     <None Update="WorldServer.example.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>


### PR DESCRIPTION
This adds msbuild parameters to the WorldServer project which allow a user to extract game table files, as well as generate base map files.

Example command which generates both the /tbl and /map folders, populated in the WorldServer's build output directory:
`dotnet build /p:"WsInstallDir=H:\Wildstar\;ExtractGameTables=true;GenerateMapFiles=true"`

I ended up adding an option to the MapGenerator to allow us to specify the output directory. I could have created then moved the files, but an output directory seemed like a reasonable addition.

I noticed that the server installation guide is on @Rawaho fork, so I didn't update the docs in this PR.

This is just a qol update to help simplify first-time setup for local development.