### PR TITLE
Plotindex fix - Decor no longer shifts around on server restart, when placed near house.

### DIFF
--- a/Source/NexusForever.Database.Character/CharacterContext.cs
+++ b/Source/NexusForever.Database.Character/CharacterContext.cs
@@ -2034,7 +2034,8 @@ namespace NexusForever.Database.Character
                 entity.Property(e => e.PlotIndex)
                     .HasColumnName("plotIndex")
                     .HasColumnType("int(10) unsigned")
-                    .HasDefaultValue(2147483647);
+                    .HasDefaultValue(2147483647)
+                    .ValueGeneratedNever();
 
                 entity.Property(e => e.Qw)
                     .HasColumnName("qw")


### PR DESCRIPTION
Decor placed near the central housing area would shift when the server restarts. This happened because any decor with plotindex 0 was instead saved with plotindex equal to int-max. On load, it would then place the decor relative to the main map, not the central housing area.

A simple .ValueGeneratedNever() in the right place fixes this.