### PR TITLE
Costume slot 1 fix - It can now save properly, even after the first save.

### DIFF
--- a/Source/NexusForever.Database.Character/CharacterContext.cs
+++ b/Source/NexusForever.Database.Character/CharacterContext.cs
@@ -447,7 +447,8 @@ namespace NexusForever.Database.Character
                 entity.Property(e => e.Index)
                     .HasColumnName("index")
                     .HasColumnType("tinyint(3) unsigned")
-                    .HasDefaultValue(0);
+                    .HasDefaultValue(0)
+                    .ValueGeneratedNever();
 
                 entity.Property(e => e.Slot)
                     .HasColumnName("slot")


### PR DESCRIPTION
When a character had anything in costume slot 1, any changes to it would fail to save properly, probably for the same reason that plotindex 0 caused issues with decor. The exact mechanism of this failure is unknown to me, but a .ValueGeneratedNever() on character_costume_item.index fixes this issue.