### PR TITLE
[Player/Fix] Fixed packet to no longer emit from target.

### DIFF
--- a/Source/NexusForever.WorldServer/Game/Entity/Player.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/Player.cs
@@ -665,8 +665,12 @@ namespace NexusForever.WorldServer.Game.Entity
             base.AddVisible(entity);
             Session.EnqueueMessageEncrypted(((WorldEntity)entity).BuildCreatePacket());
 
-            if (entity is Player player)
-                player.PathManager.SendSetUnitPathTypePacket();
+            if (entity is Player playerEntity)
+                Session.EnqueueMessageEncrypted(new ServerSetUnitPathType
+                {
+                    Guid = playerEntity.Guid,
+                    Path = playerEntity.Path
+                });
 
             if (entity == this)
             {


### PR DESCRIPTION
This was necessary because if the target emitted the packet too early, the requesting client would forget about it.