### PR TITLE
[Scripts/Core] Add SC for Spells to fix casting

### DIFF
--- a/Source/NexusForever.Script/Template/Collection/ServiceCollectionExtensions.cs
+++ b/Source/NexusForever.Script/Template/Collection/ServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@
 using NexusForever.Game.Abstract.Entity;
 using NexusForever.Game.Abstract.Map;
 using NexusForever.Game.Abstract.Quest;
+using NexusForever.Game.Abstract.Spell;
 
 namespace NexusForever.Script.Template.Collection
 {
@@ -15,6 +16,7 @@ namespace NexusForever.Script.Template.Collection
             sc.AddTransient<IOwnedScriptCollection<INonPlayer>, OwnedScriptCollection<INonPlayer>>();
             sc.AddTransient<IOwnedScriptCollection<IPlayer>, OwnedScriptCollection<IPlayer>>();
             sc.AddTransient<IOwnedScriptCollection<IQuest>, OwnedScriptCollection<IQuest>>();
+            sc.AddTransient<IOwnedScriptCollection<ISpell>, OwnedScriptCollection<ISpell>>();
         }
     }
 }


### PR DESCRIPTION
Casting could not begin because `ISpell` was not available in the script collection.