### PR TITLE
[Entity/Vehicle] Fix vehicle attach for players mounted already when they enter range

### DIFF
--- a/Source/NexusForever.Game/Entity/Player.cs
+++ b/Source/NexusForever.Game/Entity/Player.cs
@@ -663,11 +663,33 @@ namespace NexusForever.Game.Entity
                 Session.EnqueueMessageEncrypted(worldEntity.BuildCreatePacket());
 
             if (entity is IPlayer playerEntity)
+            {
+                // Inform this player of visible player's path. This appears to be just used by the tooltip system.
                 Session.EnqueueMessageEncrypted(new ServerSetUnitPathType
                 {
                     Guid = playerEntity.Guid,
                     Path = playerEntity.Path
                 });
+
+                // Send a packet to "connect" the player to their vehicle.
+                // This is more prevalent of a problem when we use 0x08B3 after every non-player entity's ServerEntityCreate packet like live packets did.
+                if (playerEntity.VehicleGuid > 0)
+                {
+                    IVehicle vehicle = Map.GetEntity<IVehicle>(playerEntity.VehicleGuid);
+                    if (vehicle != null)
+                    {
+                        IVehiclePassenger passenger = vehicle.ToList().SingleOrDefault(p => p.Guid == playerEntity.Guid);
+                        if (passenger != null)
+                            Session.EnqueueMessageEncrypted(new ServerVehiclePassengerSet
+                            {
+                                Self = passenger.Guid,
+                                Vehicle = vehicle.Guid,
+                                SeatType = passenger.SeatType,
+                                SeatPosition = passenger.SeatPosition
+                            });
+                    }
+                }
+            }
 
             if (entity == this)
             {

--- a/Source/NexusForever.Game/Entity/Vehicle.cs
+++ b/Source/NexusForever.Game/Entity/Vehicle.cs
@@ -163,16 +163,6 @@ namespace NexusForever.Game.Entity
             {
             });
 
-            // sets vehicle guid, seat type and seat position to local self entity at client
-            // might not be correct as ServerVehiclePassengerAdd does this too, used for changing seats instead?
-            player.Session.EnqueueMessageEncrypted(new Server089B
-            {
-                Self         = passenger.Guid,
-                Vehicle      = Guid,
-                SeatType     = passenger.SeatType,
-                SeatPosition = passenger.SeatPosition
-            });
-
             EnqueueToVisible(new ServerVehiclePassengerAdd
             {
                 Self         = Guid,

--- a/Source/NexusForever.Network.World/Message/Model/ServerVehiclePassengerSet.cs
+++ b/Source/NexusForever.Network.World/Message/Model/ServerVehiclePassengerSet.cs
@@ -3,8 +3,14 @@ using NexusForever.Network.Message;
 
 namespace NexusForever.Network.World.Message.Model
 {
-    [Message(GameMessageOpcode.Server089B)]
-    public class Server089B : IWritable
+    /// <summary>
+    /// Should only be used during <see cref="GridEntity"/> AddVisible() method. It is used to "connect" an entity to their vehicle.
+    /// </summary>
+    /// <remarks>
+    /// Packets indicate this was only used when an entity and their vehicle were created at the same time, e.g. Player logs in and another Player nearby is already mounted.
+    /// </remarks>
+    [Message(GameMessageOpcode.ServerVehiclePassengerSet)]
+    public class ServerVehiclePassengerSet : IWritable
     {
         public uint Self { get; set; }
         public uint Vehicle { get; set; }

--- a/Source/NexusForever.Network/Message/GameMessageOpcode.cs
+++ b/Source/NexusForever.Network/Message/GameMessageOpcode.cs
@@ -325,7 +325,7 @@ namespace NexusForever.Network.Message
         ServerVehiclePassengerAdd       = 0x086F,
         ServerEntityCCStateSet          = 0x087F,
         ServerUnitEnteredCombat         = 0x089A,
-        Server089B                      = 0x089B, // mount related
+        ServerVehiclePassengerSet       = 0x089B,
         Server08B3                      = 0x08B3,
         ServerSetUnitPathType           = 0x08B8,
         ServerVehiclePassengerRemove    = 0x08C7,


### PR DESCRIPTION
The following issue occurs occasionally when entering world near someone who is already mounted. The packet adjustments made in this PR resolve the problem and also updates our packet flow to match live packet logs.
This is currently more prevalent on my test server, but I believe that is because I match live by sending `0x083B` after every non-Player entity's `ServerEntityCreate` packet, like live packets did.

![image](https://user-images.githubusercontent.com/32724086/236966894-a767cfef-f588-4866-98e0-a8960c7a6444.png)
