### PR TITLE
Added pet renaming

### DIFF
--- a/Source/NexusForever.Game.Abstract/Entity/IPetCustomisationManager.cs
+++ b/Source/NexusForever.Game.Abstract/Entity/IPetCustomisationManager.cs
@@ -11,6 +11,11 @@ namespace NexusForever.Game.Abstract.Entity
         void UnlockFlair(ushort id);
 
         /// <summary>
+        /// Renames the pet name for <see cref="PetType"/> and object id.
+        /// </summary>
+        void RenamePet(PetType type, uint objectId, String name);
+
+        /// <summary>
         /// Add or update equipped pet flair at supplied index for <see cref="PetType"/> and object id.
         /// </summary>
         void AddCustomisation(PetType type, uint objectId, ushort index, ushort flairId);

--- a/Source/NexusForever.Game.Static/TextFilter/UserText.cs
+++ b/Source/NexusForever.Game.Static/TextFilter/UserText.cs
@@ -7,6 +7,7 @@
     {
         [UserText(UserTextFlags.NoStartEndSpace | UserTextFlags.Unknown4 | UserTextFlags.Unknown100 | UserTextFlags.RequireSpace, 31u, 5u)]
         CharacterName                = 0,
+        [UserText(UserTextFlags.NoConsecutiveSpace | UserTextFlags.NoStartEndSpace | UserTextFlags.Unknown4 | UserTextFlags.Unknown20, 17u, 3u)]
         ScientistScanbotName         = 1,
         [UserText(UserTextFlags.NoConsecutiveSpace | UserTextFlags.NoStartEndSpace | UserTextFlags.Unknown20, 30u, 3u)]
         GuildName                    = 2,

--- a/Source/NexusForever.Network.World/Message/Model/ClientPetRename.cs
+++ b/Source/NexusForever.Network.World/Message/Model/ClientPetRename.cs
@@ -1,0 +1,20 @@
+﻿using NexusForever.Game.Static.Entity;
+using NexusForever.Network.Message;
+
+namespace NexusForever.Network.World.Message.Model
+{
+    [Message(GameMessageOpcode.ClientPetRename)]
+    public class ClientPetRename : IReadable
+    {
+        public PetType PetType { get; private set; }
+        public uint PetObjectId { get; private set; }
+        public String Name { get; private set; }
+
+        public void Read(GamePacketReader reader)
+        {
+            PetType = reader.ReadEnum<PetType>(2u);
+            PetObjectId = reader.ReadUInt();
+            Name = reader.ReadWideString();
+        }
+    }
+}

--- a/Source/NexusForever.Network/Message/GameMessageOpcode.cs
+++ b/Source/NexusForever.Network/Message/GameMessageOpcode.cs
@@ -272,6 +272,7 @@ namespace NexusForever.Network.Message
         ServerPathUnlockResult          = 0x06BE,
         ServerPathCurrentEpisode        = 0x06BF,
         Server068B                      = 0x068B, // pet customization something
+        ClientPetRename                 = 0x068C,
         ServerUnlockPetFlair            = 0x068D,
         ServerChangePetStance           = 0x068F,
         ServerPublicEventStart          = 0x0700,

--- a/Source/NexusForever.WorldServer/Network/Message/Handler/PetHandler.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Handler/PetHandler.cs
@@ -30,5 +30,13 @@ namespace NexusForever.WorldServer.Network.Message.Handler
                 petcustomisation.FlairSlotIndex,
                 petcustomisation.FlairId);
         }
+
+        [MessageHandler(GameMessageOpcode.ClientPetRename)]
+        public static void HandlePetRename(IWorldSession session, ClientPetRename petRename)
+        {
+            session.Player.PetCustomisationManager.RenamePet(petRename.PetType,
+               petRename.PetObjectId,
+               petRename.Name);
+        }
     }
 }


### PR DESCRIPTION
Added support for renaming the pets.


Since testing might be a bit tricky since the scanbot logic is still missing you can use the attached patch file to allow deploying the scan bot of a scientist and rename it.


[scan_bot_deploy.patch](https://github.com/NexusForever/NexusForever/files/12346582/scan_bot_deploy.patch)
