### PR TITLE
Place-from-vendor plotindex fix

### DIFF
--- a/Source/NexusForever.Game/Map/Instance/ResidenceMapInstance.cs
+++ b/Source/NexusForever.Game/Map/Instance/ResidenceMapInstance.cs
@@ -355,6 +355,7 @@ namespace NexusForever.Game.Map.Instance
 
             IDecor decor = residence.DecorCreate(entry);
             decor.Type = update.DecorType;
+            decor.PlotIndex = update.PlotIndex;
 
             if (update.ColourShiftId != decor.ColourShiftId)
             {


### PR DESCRIPTION
Should fix https://github.com/NexusForever/NexusForever/issues/218; the PlotIndex wasn't assigned to the decor when the client placed decor directly from vendor.