### PR TITLE
WIP [Spell/AMP] Make AMPs cast their related spell when learned

### DIFF
--- a/Source/NexusForever.Game.Abstract/Entity/ISpellManager.cs
+++ b/Source/NexusForever.Game.Abstract/Entity/ISpellManager.cs
@@ -25,6 +25,11 @@ namespace NexusForever.Game.Abstract.Entity
         void AddSpell(uint spell4BaseId, byte tier = 1);
 
         /// <summary>
+        /// Removes an existing spell (used for AMPs)
+        /// </summary>
+        void RemoveSpell(uint spell4BaseId);
+
+        /// <summary>
         /// Update existing <see cref="ICharacterSpell"/> with supplied tier. The base tier will be updated if no action set index is supplied.
         /// </summary>
         void UpdateSpell(uint spell4BaseId, byte tier, byte? actionSetIndex);

--- a/Source/NexusForever.Game.Abstract/Entity/ISpellManager.cs
+++ b/Source/NexusForever.Game.Abstract/Entity/ISpellManager.cs
@@ -66,6 +66,8 @@ namespace NexusForever.Game.Abstract.Entity
         /// </summary>
         SpecError SetActiveActionSet(byte value);
 
+        void ApplyAmps();
+
         void SendInitialPackets();
         void SendServerAbilityPoints();
     }

--- a/Source/NexusForever.Game/Entity/Player.cs
+++ b/Source/NexusForever.Game/Entity/Player.cs
@@ -559,6 +559,8 @@ namespace NexusForever.Game.Entity
             SendCharacterFlagsUpdated();
 
             base.OnAddToMap(map, guid, vector);
+            
+            SpellManager.ApplyAmps();
 
             // resummon vanity pet if it existed before teleport
             if (pendingTeleport?.VanityPetId != null)

--- a/Source/NexusForever.Game/Entity/SpellManager.cs
+++ b/Source/NexusForever.Game/Entity/SpellManager.cs
@@ -196,7 +196,7 @@ namespace NexusForever.Game.Entity
                 throw new ArgumentOutOfRangeException();
 
             if (spells.ContainsKey(spell4BaseId))
-                throw new InvalidOperationException();
+                return;
 
             IItem item = player.Inventory.SpellCreate(spellBaseInfo.Entry, ItemUpdateReason.NoReason);
 
@@ -212,6 +212,19 @@ namespace NexusForever.Game.Entity
             }
 
             spells.Add(spellBaseInfo.Entry.Id, unlockedSpell);
+        }
+
+        public void RemoveSpell(uint spell4BaseId)
+        {
+            ISpellBaseInfo spellBaseInfo = GlobalSpellManager.Instance.GetSpellBaseInfo(spell4BaseId);
+            if (spellBaseInfo == null)
+                throw new ArgumentOutOfRangeException();
+            // FIXME: The spells aren't added on load so sometimes this is not true!
+            // if (!spells.ContainsKey(spell4BaseId))
+            //     throw new InvalidOperationException();
+
+            spells.Remove(spell4BaseId);
+            player.RemoveSpellProperties(spellBaseInfo.GetSpellInfo(0).Entry.Id);
         }
 
         /// <summary>

--- a/Source/NexusForever.Game/Spell/ActionSet.cs
+++ b/Source/NexusForever.Game/Spell/ActionSet.cs
@@ -264,9 +264,7 @@ namespace NexusForever.Game.Spell
             log.Trace($"Added AMP {id} to action set {Index}.");
 
             var spellEntry = GameTableManager.Instance.Spell4.GetEntry(entry.Spell4IdAugment);
-            // Get the current player
             Player.SpellManager.AddSpell(spellEntry.Spell4BaseIdBaseSpell);
-            
             ICharacterSpell characterSpell = Player.SpellManager.GetSpell(spellEntry.Spell4BaseIdBaseSpell);
             characterSpell.Cast();
         }

--- a/Source/NexusForever.Game/Spell/ActionSet.cs
+++ b/Source/NexusForever.Game/Spell/ActionSet.cs
@@ -2,6 +2,7 @@ using NexusForever.Database.Character;
 using NexusForever.Database.Character.Model;
 using NexusForever.Game.Abstract.Entity;
 using NexusForever.Game.Abstract.Spell;
+using NexusForever.Game.Character;
 using NexusForever.Game.Static.Entity;
 using NexusForever.Game.Static.Spell;
 using NexusForever.GameTable;
@@ -35,6 +36,7 @@ namespace NexusForever.Game.Spell
         public byte Index { get; }
         public byte TierPoints { get; private set; }
         public byte AmpPoints { get; private set; }
+        public IPlayer Player { get; set; }
 
         /// <summary>
         /// Collection of <see cref="IActionSetShortcut"/> contained in the <see cref="IActionSet"/>.
@@ -56,6 +58,7 @@ namespace NexusForever.Game.Spell
         /// </summary>
         public ActionSet(byte index, IPlayer player)
         {
+            Player     = player;
             Owner      = player.CharacterId;
             Index      = index;
             TierPoints = MaxTierPoints;
@@ -259,6 +262,13 @@ namespace NexusForever.Game.Spell
             saveMask |= ActionSetSaveMask.ActionSetAmps;
 
             log.Trace($"Added AMP {id} to action set {Index}.");
+
+            var spellEntry = GameTableManager.Instance.Spell4.GetEntry(entry.Spell4IdAugment);
+            // Get the current player
+            Player.SpellManager.AddSpell(spellEntry.Spell4BaseIdBaseSpell);
+            
+            ICharacterSpell characterSpell = Player.SpellManager.GetSpell(spellEntry.Spell4BaseIdBaseSpell);
+            characterSpell.Cast();
         }
 
         /// <summary>
@@ -329,6 +339,9 @@ namespace NexusForever.Game.Spell
             }
 
             log.Trace($"Removed AMP {amp.Entry.Id} from action set {Index}.");
+            
+            var spellEntry = GameTableManager.Instance.Spell4.GetEntry(amp.Entry.Spell4IdAugment);
+            Player.SpellManager.RemoveSpell(spellEntry.Spell4BaseIdBaseSpell);
         }
 
         /// <summary>

--- a/Source/NexusForever.Game/Spell/ActionSetAmp.cs
+++ b/Source/NexusForever.Game/Spell/ActionSetAmp.cs
@@ -51,7 +51,7 @@ namespace NexusForever.Game.Spell
             {
                 Id        = actionSet.Owner,
                 SpecIndex = actionSet.Index,
-                AmpId     = (byte)Entry.Id
+                AmpId     = (ushort)Entry.Id
             };
 
             if ((saveMask & AmpSaveMask.Create) != 0)


### PR DESCRIPTION
Generally improves support for all AMPs by making them cast the linked spell when they are learned.

This greatly improves functionality for stat-related AMPs (they basically work), however it does not fix all of them.

AMPs such as ones relying on Procs will rely on that specific system being improved to properly work.