### PR TITLE
Corrected TargetGroupId passed to Quest.ObjectiveUpdate in RewardKill

### DIFF
--- a/Source/NexusForever.Game/Entity/UnitEntity.cs
+++ b/Source/NexusForever.Game/Entity/UnitEntity.cs
@@ -436,8 +436,12 @@ namespace NexusForever.Game.Entity
         {
             player.QuestManager.ObjectiveUpdate(QuestObjectiveType.KillCreature, CreatureId, 1u);
             player.QuestManager.ObjectiveUpdate(QuestObjectiveType.KillCreature2, CreatureId, 1u);
-            player.QuestManager.ObjectiveUpdate(QuestObjectiveType.KillTargetGroup, CreatureId, 1u);
-            player.QuestManager.ObjectiveUpdate(QuestObjectiveType.KillTargetGroups, CreatureId, 1u);
+
+            foreach (uint targetGroupId in AssetManager.Instance.GetTargetGroupsForCreatureId(CreatureId))
+            {
+                player.QuestManager.ObjectiveUpdate(QuestObjectiveType.KillTargetGroup, targetGroupId, 1u);
+                player.QuestManager.ObjectiveUpdate(QuestObjectiveType.KillTargetGroups, targetGroupId, 1u);
+            }
 
             // TODO: Reward XP
             // TODO: Reward Loot


### PR DESCRIPTION
* RewardKiller was passing CreatureId instead of TargetGroupId in UnitEntity.RewardKiller.
* Correction applied using GameTable data.