### PR TITLE
Addition of server command to allow changing client's entity send update interval

### DIFF
--- a/Source/NexusForever.Game/Entity/Player.cs
+++ b/Source/NexusForever.Game/Entity/Player.cs
@@ -634,7 +634,7 @@ namespace NexusForever.Game.Entity
 
             ResidenceManager.SendHousingBasics();
             Session.EnqueueMessageEncrypted(new ServerHousingNeighbors());
-            Session.EnqueueMessageEncrypted(new ServerInstanceSettings() { Unknown3 = 69 });
+            Session.EnqueueMessageEncrypted(new ServerInstanceSettings() { ClientEntityMaxSendUpdateInterval = 125 });
 
             SetControl(this);
 

--- a/Source/NexusForever.Game/Entity/Player.cs
+++ b/Source/NexusForever.Game/Entity/Player.cs
@@ -634,7 +634,7 @@ namespace NexusForever.Game.Entity
 
             ResidenceManager.SendHousingBasics();
             Session.EnqueueMessageEncrypted(new ServerHousingNeighbors());
-            Session.EnqueueMessageEncrypted(new ServerInstanceSettings() { ClientEntityMaxSendUpdateInterval = 125 });
+            Session.EnqueueMessageEncrypted(new ServerInstanceSettings() { ClientEntitySendUpdateInterval = 125 });
 
             SetControl(this);
 

--- a/Source/NexusForever.Network.World/Message/Model/ServerEntityUpdateInterval.cs
+++ b/Source/NexusForever.Network.World/Message/Model/ServerEntityUpdateInterval.cs
@@ -2,6 +2,9 @@
 
 namespace NexusForever.Network.World.Message.Model
 {
+    // Message is used to change the interval at which the client sends entity updates.
+    // This can be sent at any time but will get overwritten by the ServiceInstanceSettings message.
+
     [Message(GameMessageOpcode.ServerClientEntityUpdateInterval)]
     public class ServerClientEntityUpdateInterval : IWritable
     {

--- a/Source/NexusForever.Network.World/Message/Model/ServerEntityUpdateInterval.cs
+++ b/Source/NexusForever.Network.World/Message/Model/ServerEntityUpdateInterval.cs
@@ -5,7 +5,7 @@ namespace NexusForever.Network.World.Message.Model
     [Message(GameMessageOpcode.ServerClientEntityUpdateInterval)]
     public class ServerClientEntityUpdateInterval : IWritable
     {
-        public uint ClientEntityMaxSendUpdateInterval { get; set; }
+        public uint ClientEntitySendUpdateInterval { get; set; }
         // Interval is specified in milliseconds.
         // Client will bound the value received between 25 and 1000 ms.
         // Captured data show that the server would periodically change the interval between 125 and 126 ms
@@ -13,7 +13,7 @@ namespace NexusForever.Network.World.Message.Model
 
         public void Write(GamePacketWriter writer)
         {
-            writer.Write(ClientEntityMaxSendUpdateInterval);
+            writer.Write(ClientEntitySendUpdateInterval);
         }
     }
 }

--- a/Source/NexusForever.Network.World/Message/Model/ServerEntityUpdateInterval.cs
+++ b/Source/NexusForever.Network.World/Message/Model/ServerEntityUpdateInterval.cs
@@ -1,0 +1,19 @@
+﻿using NexusForever.Network.Message;
+
+namespace NexusForever.Network.World.Message.Model
+{
+    [Message(GameMessageOpcode.ServerClientEntityUpdateInterval)]
+    public class ServerClientEntityUpdateInterval : IWritable
+    {
+        public uint ClientEntityMaxSendUpdateInterval { get; set; }
+        // Interval is specified in milliseconds.
+        // Client will bound the value received between 25 and 1000 ms.
+        // Captured data show that the server would periodically change the interval between 125 and 126 ms
+        // but the reasoning for this is unclear.
+
+        public void Write(GamePacketWriter writer)
+        {
+            writer.Write(ClientEntityMaxSendUpdateInterval);
+        }
+    }
+}

--- a/Source/NexusForever.Network.World/Message/Model/ServerInstanceSettings.cs
+++ b/Source/NexusForever.Network.World/Message/Model/ServerInstanceSettings.cs
@@ -12,14 +12,14 @@ namespace NexusForever.Network.World.Message.Model
         // 0x04 = TransmatTeleport
         // 0x08 = HoloCryptTeleport
         public byte Flags { get; set; }
-        public uint ClientEntityMaxSendUpdateInterval { get; set; }
+        public uint ClientEntitySendUpdateInterval { get; set; }
 
         public void Write(GamePacketWriter writer)
         {
             writer.Write(Difficulty, 2u);
             writer.Write(PrimeLevel);
             writer.Write(Flags);
-            writer.Write(ClientEntityMaxSendUpdateInterval);
+            writer.Write(ClientEntitySendUpdateInterval);
         }
     }
 }

--- a/Source/NexusForever.Network.World/Message/Model/ServerInstanceSettings.cs
+++ b/Source/NexusForever.Network.World/Message/Model/ServerInstanceSettings.cs
@@ -12,14 +12,14 @@ namespace NexusForever.Network.World.Message.Model
         // 0x04 = TransmatTeleport
         // 0x08 = HoloCryptTeleport
         public byte Flags { get; set; }
-        public uint Unknown3 { get; set; }
+        public uint ClientEntityMaxSendUpdateInterval { get; set; }
 
         public void Write(GamePacketWriter writer)
         {
             writer.Write(Difficulty, 2u);
             writer.Write(PrimeLevel);
             writer.Write(Flags);
-            writer.Write(Unknown3);
+            writer.Write(ClientEntityMaxSendUpdateInterval);
         }
     }
 }

--- a/Source/NexusForever.Network/Message/GameMessageOpcode.cs
+++ b/Source/NexusForever.Network/Message/GameMessageOpcode.cs
@@ -7,6 +7,7 @@ namespace NexusForever.Network.Message
         ServerHello                     = 0x0003,
         ServerMaxCharacterLevelAchieved = 0x0036,
         ServerPlayerEnteredWorld        = 0x0061,
+        ServerClientEntityUpdateInterval = 0x0070,
         ServerAuthEncrypted             = 0x0076,
         ServerLogoutUpdate              = 0x0092,
         ClientActivateUnitCast          = 0x0097, // not sure about the name - almost the same as 0x00B3, but also initiates 0x07FD


### PR DESCRIPTION
Figured out what the unknown parameter in server message 0xF1 (ServerInstanceSettings) does. It sets the client's maximum send update interval for the player's unit. This same parameter can be changed at any time by sending server message 0x70 (ServerClientEntityUpdateInterval).

Based on captures, the server would always set this parameter as 125 or 126ms and would periodically change it but it is not clear why.