### PR TITLE
Change ToEulerDegrees into ToEuler (Radians)

### DIFF
--- a/Source/NexusForever.Game/Guild/CommunityOperations.cs
+++ b/Source/NexusForever.Game/Guild/CommunityOperations.cs
@@ -53,7 +53,7 @@ namespace NexusForever.Game.Guild
 
                         IMapLock mapLock = MapLockManager.Instance.GetResidenceLock(Residence);
 
-                        player.Rotation = entrance.Rotation.ToEulerDegrees();
+                        player.Rotation = entrance.Rotation.ToEuler();
                         player.TeleportTo(entrance.Entry, entrance.Position, mapLock);
                     }
                     else
@@ -64,7 +64,7 @@ namespace NexusForever.Game.Guild
                         // otherwise they will be moved to the new instance during the unload
                         if (residence.Map != player.Map)
                         {
-                            player.Rotation = entrance.Rotation.ToEulerDegrees();
+                            player.Rotation = entrance.Rotation.ToEuler();
                             player.TeleportTo(entrance.Entry, entrance.Position, mapLock);
                         }
 

--- a/Source/NexusForever.Game/Map/Instance/ResidenceInstancedMap.cs
+++ b/Source/NexusForever.Game/Map/Instance/ResidenceInstancedMap.cs
@@ -66,7 +66,7 @@ namespace NexusForever.Game.Map.Instance
 
             IResidenceEntrance entrance = globalResidenceManager.GetResidenceEntrance(residence.PropertyInfoId);
             mapPosition.Position = entrance.Position;
-            player.Rotation = entrance.Rotation.ToEulerDegrees();
+            player.Rotation = entrance.Rotation.ToEuler();
         }
 
         protected override IResidenceMapInstance CreateInstance(IPlayer player, IMapLock mapLock)

--- a/Source/NexusForever.Game/Matching/MatchingDataManager.cs
+++ b/Source/NexusForever.Game/Matching/MatchingDataManager.cs
@@ -98,7 +98,7 @@ namespace NexusForever.Game.Matching
                     MapId    = mapEntranceModel.MapId,
                     Team     = mapEntranceModel.Team,
                     Position = new Vector3(entry.Position0, entry.Position1, entry.Position2),
-                    Rotation = quaternion.ToEulerDegrees(),
+                    Rotation = quaternion.ToEuler(),
                 });
             }
 

--- a/Source/NexusForever.Game/Spell/SpellEffectHandler.cs
+++ b/Source/NexusForever.Game/Spell/SpellEffectHandler.cs
@@ -152,7 +152,7 @@ namespace NexusForever.Game.Spell
                 return;
 
             var rotation = new Quaternion(worldLocation.Facing0, worldLocation.Facing0, worldLocation.Facing2, worldLocation.Facing3);
-            player.Rotation = rotation.ToEulerDegrees();
+            player.Rotation = rotation.ToEuler();
             player.TeleportTo((ushort)worldLocation.WorldId, worldLocation.Position0, worldLocation.Position1, worldLocation.Position2);
         }
 

--- a/Source/NexusForever.WorldServer/Command/Handler/HouseCommandCategory.cs
+++ b/Source/NexusForever.WorldServer/Command/Handler/HouseCommandCategory.cs
@@ -87,7 +87,7 @@ namespace NexusForever.WorldServer.Command.Handler
             IMapLock mapLock = MapLockManager.Instance.GetResidenceLock(residence.Parent ?? residence);
 
             IResidenceEntrance entrance = GlobalResidenceManager.Instance.GetResidenceEntrance(residence.PropertyInfoId);
-            target.Rotation = entrance.Rotation.ToEulerDegrees();
+            target.Rotation = entrance.Rotation.ToEuler();
             target.TeleportTo(entrance.Entry, entrance.Position, mapLock);
         }
     }

--- a/Source/NexusForever.WorldServer/Command/Handler/TeleportCommandCategory.cs
+++ b/Source/NexusForever.WorldServer/Command/Handler/TeleportCommandCategory.cs
@@ -57,7 +57,7 @@ namespace NexusForever.WorldServer.Command.Handler
             }
 
             var rotation = new Quaternion(entry.Facing0, entry.Facing1, entry.Facing2, entry.Facing3);
-            target.Rotation = rotation.ToEulerDegrees();
+            target.Rotation = rotation.ToEuler();
             target.TeleportTo((ushort)entry.WorldId, entry.Position0, entry.Position1, entry.Position2);
         }
 

--- a/Source/NexusForever.WorldServer/Network/Message/Handler/Housing/ClientHousingCommunityPlacementHandler.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Handler/Housing/ClientHousingCommunityPlacementHandler.cs
@@ -58,7 +58,7 @@ namespace NexusForever.WorldServer.Network.Message.Handler.Housing
 
                 IMapLock mapLock = MapLockManager.Instance.GetResidenceLock(community.Residence);
 
-                session.Player.Rotation = entrance.Rotation.ToEulerDegrees();
+                session.Player.Rotation = entrance.Rotation.ToEuler();
                 session.Player.TeleportTo(entrance.Entry, entrance.Position, mapLock);
             }
             else
@@ -69,7 +69,7 @@ namespace NexusForever.WorldServer.Network.Message.Handler.Housing
                 // otherwise they will be moved to the new instance during the unload
                 if (residence.Map != session.Player.Map)
                 {
-                    session.Player.Rotation = entrance.Rotation.ToEulerDegrees();
+                    session.Player.Rotation = entrance.Rotation.ToEuler();
                     session.Player.TeleportTo(entrance.Entry, entrance.Position, mapLock);
                 }
 

--- a/Source/NexusForever.WorldServer/Network/Message/Handler/Housing/ClientHousingCommunityRemovalHandler.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Handler/Housing/ClientHousingCommunityRemovalHandler.cs
@@ -60,7 +60,7 @@ namespace NexusForever.WorldServer.Network.Message.Handler.Housing
             // shouldn't need to check for existing instance
             // individual residence instances are unloaded when transfered to a community
             // if for some reason the instance is still unloading the residence will be initalised again after
-            session.Player.Rotation = entrance.Rotation.ToEulerDegrees();
+            session.Player.Rotation = entrance.Rotation.ToEuler();
             session.Player.TeleportTo(entrance.Entry, entrance.Position, mapLock);
         }
     }

--- a/Source/NexusForever.WorldServer/Network/Message/Handler/Housing/ClientHousingReturnHandler.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Handler/Housing/ClientHousingReturnHandler.cs
@@ -38,7 +38,7 @@ namespace NexusForever.WorldServer.Network.Message.Handler.Housing
 
             // return player to correct residence instance
             IResidenceEntrance entrance = globalResidenceManager.GetResidenceEntrance(residence.PropertyInfoId);
-            session.Player.Rotation = entrance.Rotation.ToEulerDegrees();
+            session.Player.Rotation = entrance.Rotation.ToEuler();
             session.Player.TeleportTo(new MapPosition
             {
                 Info = new MapInfo

--- a/Source/NexusForever.WorldServer/Network/Message/Handler/Housing/ClientHousingVisitHandler.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Handler/Housing/ClientHousingVisitHandler.cs
@@ -80,7 +80,7 @@ namespace NexusForever.WorldServer.Network.Message.Handler.Housing
 
             // teleport player to correct residence instance
             IResidenceEntrance entrance = globalResidenceManager.GetResidenceEntrance(residence.PropertyInfoId);
-            session.Player.Rotation = entrance.Rotation.ToEulerDegrees();
+            session.Player.Rotation = entrance.Rotation.ToEuler();
             session.Player.TeleportTo(new MapPosition
             {
                 Info = new MapInfo


### PR DESCRIPTION
Each entity rotation seems to require radians, not degrees. This PR leaves Quaternion.ToEulerDegrees intact, but entirely unused.