### PR TITLE
Fix: Appearance changes don't stick sometimes

### DIFF
--- a/Source/NexusForever.Database.Character/CharacterContext.cs
+++ b/Source/NexusForever.Database.Character/CharacterContext.cs
@@ -379,13 +379,11 @@ namespace NexusForever.Database.Character
 
                 entity.Property(e => e.Id)
                     .HasColumnName("id")
-                    .HasColumnType("bigint(20) unsigned")
-                    .HasDefaultValue(0);
+                    .HasColumnType("bigint(20) unsigned");
 
                 entity.Property(e => e.BoneIndex)
                     .HasColumnName("boneIndex")
-                    .HasColumnType("tinyint(4) unsigned")
-                    .HasDefaultValue(0);
+                    .HasColumnType("tinyint(4) unsigned");
 
                 entity.Property(e => e.Bone)
                     .HasColumnName("bone")

--- a/Source/NexusForever.Database.Character/Migrations/20241208062241_BoneIndexFix.Designer.cs
+++ b/Source/NexusForever.Database.Character/Migrations/20241208062241_BoneIndexFix.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NexusForever.Database.Character;
 
@@ -11,9 +12,11 @@ using NexusForever.Database.Character;
 namespace NexusForever.Database.Character.Migrations
 {
     [DbContext(typeof(CharacterContext))]
-    partial class CharacterContextModelSnapshot : ModelSnapshot
+    [Migration("20241208062241_BoneIndexFix")]
+    partial class BoneIndexFix
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Source/NexusForever.Database.Character/Migrations/20241208062241_BoneIndexFix.cs
+++ b/Source/NexusForever.Database.Character/Migrations/20241208062241_BoneIndexFix.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NexusForever.Database.Character.Migrations
+{
+    /// <inheritdoc />
+    public partial class BoneIndexFix : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<byte>(
+                name: "boneIndex",
+                table: "character_bone",
+                type: "tinyint(4) unsigned",
+                nullable: false,
+                oldClrType: typeof(byte),
+                oldType: "tinyint(4) unsigned",
+                oldDefaultValue: (byte)0);
+
+            migrationBuilder.AlterColumn<ulong>(
+                name: "id",
+                table: "character_bone",
+                type: "bigint(20) unsigned",
+                nullable: false,
+                oldClrType: typeof(ulong),
+                oldType: "bigint(20) unsigned",
+                oldDefaultValue: 0ul);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<byte>(
+                name: "boneIndex",
+                table: "character_bone",
+                type: "tinyint(4) unsigned",
+                nullable: false,
+                defaultValue: (byte)0,
+                oldClrType: typeof(byte),
+                oldType: "tinyint(4) unsigned");
+
+            migrationBuilder.AlterColumn<ulong>(
+                name: "id",
+                table: "character_bone",
+                type: "bigint(20) unsigned",
+                nullable: false,
+                defaultValue: 0ul,
+                oldClrType: typeof(ulong),
+                oldType: "bigint(20) unsigned");
+        }
+    }
+}


### PR DESCRIPTION
Fixes a bug where appearance changes don't stick sometimes, because of they're treated as "default" and not committed to the database. This PR does not include a database migration.