### PR TITLE
Fix incorrect filename generation on Linux for map files

### DIFF
--- a/Source/NexusForever.MapGenerator/GenerationManager.cs
+++ b/Source/NexusForever.MapGenerator/GenerationManager.cs
@@ -69,7 +69,7 @@ namespace NexusForever.MapGenerator
         /// </summary>
         private void ProcessWorld(WorldEntry entry, byte? gridX = null, byte? gridY = null)
         {
-            var mapFile = new WritableMapFile(Path.GetFileName(entry.AssetPath.Replace('\\', '/')));
+            var mapFile = new WritableMapFile(Path.GetFileName(entry.AssetPath.Replace('\\', Path.DirectorySeparatorChar)));
 
             log.Info($"Processing {mapFile.Asset}...");
 

--- a/Source/NexusForever.MapGenerator/GenerationManager.cs
+++ b/Source/NexusForever.MapGenerator/GenerationManager.cs
@@ -69,7 +69,7 @@ namespace NexusForever.MapGenerator
         /// </summary>
         private void ProcessWorld(WorldEntry entry, byte? gridX = null, byte? gridY = null)
         {
-            var mapFile = new WritableMapFile(Path.GetFileName(entry.AssetPath));
+            var mapFile = new WritableMapFile(Path.GetFileName(entry.AssetPath.Replace('\\', '/')));
 
             log.Info($"Processing {mapFile.Asset}...");
 


### PR DESCRIPTION
### Problem:

When generating map files on Linux, the filenames are incorrectly generated as `Map\<Filename>`. This is due to platform-specific path delimiters being used in the filename retrieval.

![Screenshot_2024-08-28_09-49-35](https://github.com/user-attachments/assets/e26b991f-5799-4681-8ae5-862ba0ed2a8b)

### Workaround:

This pull request introduces a fix for getting the filename on Linux.

### Testing:

While the changes have been thoroughly tested on Linux, additional testing on Windows is recommended to verify that the fix does not introduce unintended side effects on that platform.