### PR TITLE
fix: Swap behavior of AddSingletonLegacy to prevent double registrations.

### DIFF
--- a/Source/NexusForever.Shared/ServiceCollectionExtensions.cs
+++ b/Source/NexusForever.Shared/ServiceCollectionExtensions.cs
@@ -9,8 +9,8 @@ namespace NexusForever.Shared
             where TInterface : class
             where TImplementation : class, TInterface
         {
-            sc.AddSingleton<TInterface, TImplementation>();
-            sc.AddSingleton(sp => (TImplementation)sp.GetService<TInterface>());
+            sc.AddSingleton<TImplementation>();
+            sc.AddSingleton<TInterface>(sp => sp.GetService<TImplementation>());
         }
 
         public static void AddTransientFactory<TInterface, TImplementation>(this IServiceCollection sc)


### PR DESCRIPTION
The current implementation of `AddSingletonLegacy` can break when a new version of `TInterface` is regsitered, causing a cast failure.

By flipping the register/resolve here, we achieve the same behavior without this risk.