### PR TITLE
[Bug] BuybackManager Nullptr

### DIFF
--- a/Source/NexusForever.Game/Entity/BuybackManager.cs
+++ b/Source/NexusForever.Game/Entity/BuybackManager.cs
@@ -23,7 +23,7 @@ namespace NexusForever.Game.Entity
                     info.RemoveItem(buybackItem.UniqueId);
 
                     IPlayer player = PlayerManager.Instance.GetPlayer(characterId);
-                    player.Session?.EnqueueMessageEncrypted(new ServerBuybackItemRemoved
+                    player?.Session?.EnqueueMessageEncrypted(new ServerBuybackItemRemoved
                     {
                         UniqueId = buybackItem.UniqueId
                     });


### PR DESCRIPTION
Fix for a null pointer exception occuring when a buyback item expires but the selling player is no longer online.