### PR TITLE
Customisation/Fix: Handle duplicate primary customisations

### DIFF
--- a/Source/NexusForever.Game/Customisation/CustomisationInfoCollection.cs
+++ b/Source/NexusForever.Game/Customisation/CustomisationInfoCollection.cs
@@ -52,7 +52,7 @@ namespace NexusForever.Game.Customisation
                 return null;
 
             // find customisation that only has primary label and value
-            return customisationInfos.SingleOrDefault(e => e.Label[1] == 0 && e.Value[1] == 0);
+            return customisationInfos.FirstOrDefault(e => e.Label[1] == 0 && e.Value[1] == 0);
         }
 
         private IEnumerable<ICustomisationInfo> GetSecondaryCustomisations(uint label, uint value, IList<(uint Label, uint Value)> customisations)


### PR DESCRIPTION
Creating a female character with the first haircut option would always throw the same exception. This is due to there being multiple primary customisation entries for female characters with the first haircut selected.

This PR selects the first entry that matches the condition, rather than throwing if more than one entry is found.