### PR TITLE
Who command musaji

### DIFF
--- a/Source/NexusForever.Game.Static/Entity/Class.cs
+++ b/Source/NexusForever.Game.Static/Entity/Class.cs
@@ -2,6 +2,7 @@
 {
     public enum Class : byte
     {
+        None = 0,
         Warrior      = 1,
         Engineer     = 2,
         Esper        = 3,

--- a/Source/NexusForever.Game.Static/Entity/Path.cs
+++ b/Source/NexusForever.Game.Static/Entity/Path.cs
@@ -2,9 +2,10 @@
 {
     public enum Path : byte
     {
-        Soldier,
-        Settler,
-        Scientist,
-        Explorer
+        None = 4, // The value for data that does not contain a Path byte resolves to 4. Adding it at the top to communicate it should not be changed.
+        Soldier = 0,
+        Settler = 1,
+        Scientist = 2,
+        Explorer = 3,
     }
 }

--- a/Source/NexusForever.WorldServer/Network/Message/Handler/Chat/ClientWhoRequestHandler.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Handler/Chat/ClientWhoRequestHandler.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualBasic;
+using NexusForever.Game.Abstract.Entity;
 using NexusForever.Game.Static.Entity;
 using NexusForever.Network.Message;
 using NexusForever.Network.Session;
@@ -12,45 +13,46 @@ namespace NexusForever.WorldServer.Network.Message.Handler.Chat
 {
     public class ClientWhoRequestHandler : IMessageHandler<IWorldSession, ClientWhoRequest>
     {
-
         private enum FilterStrategy
         {
             Name,
             Race,
             Class,
+            Path
         }
 
+        private IWorldSession requestingSession;
         private FilterStrategy inferredFilterStrategy;
-        public void HandleMessage(IWorldSession session, ClientWhoRequest request)
+        private readonly bool shouldSearchesIncludeThePlayerInitiatingSearch = false;
+        public void HandleMessage(IWorldSession requestingSession, ClientWhoRequest request)
         {
+            this.requestingSession = requestingSession;
             INetworkManager<IWorldSession> worldSessions = LegacyServiceProvider.Provider.GetService<INetworkManager<IWorldSession>>();
 
             var players = new List<ServerWhoResponse.WhoPlayer>();
             var currentRequestParameter = request.Parameters.Count > 0 ? request.Parameters[0] : null;
 
-            // Iterate over sessions for filtering.
-            foreach (var sessionKey in worldSessions)
+            // Iterate over sessions (connected clients) for filtering.
+            foreach (IWorldSession sessionCandidate in worldSessions)
             {
-                var sessionPlayer = sessionKey.Player;
-
                 if (currentRequestParameter == null)
                 {
-                    AddPlayerToList(players, sessionPlayer);
+                    AddPlayerToList(players, sessionCandidate);
                 }
                 else if (currentRequestParameter.Type == Game.Static.Who.WhoParameterType.Combo)
                 {
                     WhoParameterCombo comboData = currentRequestParameter.Data as WhoParameterCombo;
-                    FilterByCombo(players, sessionPlayer, comboData);
+                    FilterByCombo(players, sessionCandidate, comboData);
                 }
             }
 
-            session.EnqueueMessageEncrypted(new ServerWhoResponse
+            requestingSession.EnqueueMessageEncrypted(new ServerWhoResponse
             {
                 Players = players
             });
         }
 
-        private void FilterByCombo(List<ServerWhoResponse.WhoPlayer> players, Game.Abstract.Entity.IPlayer sessionPlayer, WhoParameterCombo comboData)
+        private void FilterByCombo(List<ServerWhoResponse.WhoPlayer> players, IWorldSession sessionCandidate, WhoParameterCombo comboData)
         {
             inferredFilterStrategy = FilterStrategy.Name;
 
@@ -58,47 +60,62 @@ namespace NexusForever.WorldServer.Network.Message.Handler.Chat
             {
                 inferredFilterStrategy = FilterStrategy.Race;
             }
-            else if (comboData.ClassId != 0)
+            else if (comboData.ClassId != Class.None)
             {
                 inferredFilterStrategy = FilterStrategy.Class;
             }
+            else if (comboData.PathId != Game.Static.Entity.Path.None)
+            {
+                inferredFilterStrategy = FilterStrategy.Path;
+            }
 
-            switch (inferredFilterStrategy) 
+            IPlayer candidatePlayer = sessionCandidate.Player;
+            switch (inferredFilterStrategy)
             {
                 case FilterStrategy.Name:
-                    FilterByName(players, sessionPlayer, comboData.SearchString, sessionPlayer.Name);
+                    FilterByName(players, sessionCandidate, comboData.SearchString, candidatePlayer.Name);
                     break;
                 case FilterStrategy.Race:
-                    FilterByArgs(players, sessionPlayer, comboData.RaceId, sessionPlayer.Race);
+                    FilterByArgs(players, sessionCandidate, comboData.RaceId, candidatePlayer.Race);
                     break;
                 case FilterStrategy.Class:
-                    FilterByArgs(players, sessionPlayer, comboData.ClassId, sessionPlayer.Class);
+                    FilterByArgs(players, sessionCandidate, comboData.ClassId, candidatePlayer.Class);
+                    break;
+                case FilterStrategy.Path:
+                    FilterByArgs(players, sessionCandidate, comboData.ClassId, candidatePlayer.Class);
                     break;
             }
         }
 
-        private void FilterByArgs<T>(List<ServerWhoResponse.WhoPlayer> players, Game.Abstract.Entity.IPlayer sessionPlayer, T filterValue, T sessionValue)
+        private void FilterByArgs<T>(List<ServerWhoResponse.WhoPlayer> players, IWorldSession sessionCandidate, T filterValue, T candidateValue)
         {
-            if (EqualityComparer<T>.Default.Equals(filterValue, sessionValue))
+            if (EqualityComparer<T>.Default.Equals(filterValue, candidateValue))
             {
-                AddPlayerToList(players, sessionPlayer);
+                AddPlayerToList(players, sessionCandidate);
             }
         }
 
-        private void FilterByName(List<ServerWhoResponse.WhoPlayer> players, Game.Abstract.Entity.IPlayer sessionPlayer, string comboSearchString, string sessionName)
+        private void FilterByName(List<ServerWhoResponse.WhoPlayer> players, IWorldSession sessionCandidate, string filterString, string candidateName)
         {
             // We want to filter in a case insensitive way
-            string lowercaseSearch = comboSearchString.ToLower();
-            string lowercaseSessionName = sessionName.ToLower();
+            string lowerFilterString = filterString.ToLower();
+            string lowerCandidateName = candidateName.ToLower();
 
-            if (lowercaseSessionName.IndexOf(lowercaseSearch) != -1)
+            if (lowerCandidateName.IndexOf(lowerFilterString) != -1)
             {
-                AddPlayerToList(players, sessionPlayer);
+                AddPlayerToList(players, sessionCandidate);
             }
         }
 
-        private static void AddPlayerToList(List<ServerWhoResponse.WhoPlayer> players, Game.Abstract.Entity.IPlayer sessionPlayer)
+        private void AddPlayerToList(List<ServerWhoResponse.WhoPlayer> players, IWorldSession sessionCandidate)
         {
+            if (requestingSession.Id == sessionCandidate.Id && (shouldSearchesIncludeThePlayerInitiatingSearch == false))
+            {
+                // This code exits early if searching party's session ID is matched with one of the filtered client session's IDs.
+                return;
+            }
+
+            IPlayer sessionPlayer = sessionCandidate.Player;
             players.Add(new()
             {
                 Name = sessionPlayer.Name,

--- a/Source/NexusForever.WorldServer/Network/Message/Handler/Chat/ClientWhoRequestHandler.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Handler/Chat/ClientWhoRequestHandler.cs
@@ -18,7 +18,8 @@ namespace NexusForever.WorldServer.Network.Message.Handler.Chat
             Name,
             Race,
             Class,
-            Path
+            Path,
+            Zone
         }
 
         private IWorldSession requestingSession;
@@ -31,26 +32,26 @@ namespace NexusForever.WorldServer.Network.Message.Handler.Chat
             this.requestingSession = requestingSession;
             INetworkManager<IWorldSession> worldSessions = LegacyServiceProvider.Provider.GetService<INetworkManager<IWorldSession>>();
 
-            var players = new List<ServerWhoResponse.WhoPlayer>();
-            var currentRequestParameter = request.Parameters.Count > 0 ? request.Parameters[0] : null;
+            List<ServerWhoResponse.WhoPlayer> whoResponsePlayerList = new List<ServerWhoResponse.WhoPlayer>();
+            WhoParameter? currentRequestParameter = request.Parameters.Count > 0 ? request.Parameters[0] : null;
 
             // Iterate over sessions (connected clients) for filtering.
             foreach (IWorldSession sessionCandidate in worldSessions)
             {
                 if (currentRequestParameter == null)
                 {
-                    AddPlayerToList(players, sessionCandidate);
+                    AddPlayerToList(whoResponsePlayerList, sessionCandidate);
                 }
                 else if (currentRequestParameter.Type == Game.Static.Who.WhoParameterType.Combo)
                 {
                     WhoParameterCombo comboData = currentRequestParameter.Data as WhoParameterCombo;
-                    FilterByCombo(players, sessionCandidate, comboData);
+                    FilterByCombo(whoResponsePlayerList, sessionCandidate, comboData);
                 }
             }
 
             requestingSession.EnqueueMessageEncrypted(new ServerWhoResponse
             {
-                Players = players
+                Players = whoResponsePlayerList
             });
         }
 
@@ -70,6 +71,10 @@ namespace NexusForever.WorldServer.Network.Message.Handler.Chat
             {
                 inferredFilterStrategy = FilterStrategy.Path;
             }
+            else if (comboData.WorldZoneId != 0)
+            {
+                inferredFilterStrategy = FilterStrategy.Zone;
+            }
 
             IPlayer candidatePlayer = sessionCandidate.Player;
             switch (inferredFilterStrategy)
@@ -85,6 +90,9 @@ namespace NexusForever.WorldServer.Network.Message.Handler.Chat
                     break;
                 case FilterStrategy.Path:
                     FilterByArgs(players, sessionCandidate, comboData.PathId, candidatePlayer.Path);
+                    break;
+                case FilterStrategy.Zone:
+                    FilterByArgs(players, sessionCandidate, comboData.WorldZoneId, candidatePlayer.Zone.Id);
                     break;
             }
         }

--- a/Source/NexusForever.WorldServer/Network/Message/Handler/Chat/ClientWhoRequestHandler.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Handler/Chat/ClientWhoRequestHandler.cs
@@ -23,7 +23,9 @@ namespace NexusForever.WorldServer.Network.Message.Handler.Chat
 
         private IWorldSession requestingSession;
         private FilterStrategy inferredFilterStrategy;
-        private readonly bool shouldSearchesIncludeThePlayerInitiatingSearch = false;
+
+        private readonly bool shouldSearchesIncludeThePlayerInitiatingSearch = true;
+        private readonly bool shouldSearchesIncludeOppositeFaction = true;
         public void HandleMessage(IWorldSession requestingSession, ClientWhoRequest request)
         {
             this.requestingSession = requestingSession;
@@ -82,7 +84,7 @@ namespace NexusForever.WorldServer.Network.Message.Handler.Chat
                     FilterByArgs(players, sessionCandidate, comboData.ClassId, candidatePlayer.Class);
                     break;
                 case FilterStrategy.Path:
-                    FilterByArgs(players, sessionCandidate, comboData.ClassId, candidatePlayer.Class);
+                    FilterByArgs(players, sessionCandidate, comboData.PathId, candidatePlayer.Path);
                     break;
             }
         }
@@ -112,6 +114,20 @@ namespace NexusForever.WorldServer.Network.Message.Handler.Chat
             if (requestingSession.Id == sessionCandidate.Id && (shouldSearchesIncludeThePlayerInitiatingSearch == false))
             {
                 // This code exits early if searching party's session ID is matched with one of the filtered client session's IDs.
+                return;
+            }
+
+            if (requestingSession.Player.Faction1 != sessionCandidate.Player.Faction1 && (shouldSearchesIncludeOppositeFaction == false))
+            {
+                // This code exits early if searching player's faction does not match the candidate player faction.
+                return;
+            }
+
+            if (requestingSession.Player.Faction2 != sessionCandidate.Player.Faction2 && (shouldSearchesIncludeOppositeFaction == false))
+            {
+                // I'm not sure what Faction2 is supposed to be. My best intuition is this might have some kind of relevance in PvP or dueling.
+                // In any case, I'm going to add this code here to cover my bases for now.
+                // This code exits early if searching player's faction does not match the candidate player faction.
                 return;
             }
 

--- a/Source/NexusForever.WorldServer/Network/Message/Handler/Chat/ClientWhoRequestHandler.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Handler/Chat/ClientWhoRequestHandler.cs
@@ -1,12 +1,13 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
-using Microsoft.VisualBasic;
 using NexusForever.Game.Abstract.Entity;
 using NexusForever.Game.Static.Entity;
+using NexusForever.Game.Static.Who;
 using NexusForever.Network.Message;
 using NexusForever.Network.Session;
 using NexusForever.Network.World.Message.Model.Who;
 using NexusForever.Network.World.Message.Model.Who.Parameter;
 using NexusForever.Shared;
+using System;
 using System.Collections.Generic;
 
 namespace NexusForever.WorldServer.Network.Message.Handler.Chat
@@ -19,7 +20,8 @@ namespace NexusForever.WorldServer.Network.Message.Handler.Chat
             Race,
             Class,
             Path,
-            Zone
+            Zone,
+            Level
         }
 
         private IWorldSession requestingSession;
@@ -42,10 +44,15 @@ namespace NexusForever.WorldServer.Network.Message.Handler.Chat
                 {
                     AddPlayerToList(whoResponsePlayerList, sessionCandidate);
                 }
-                else if (currentRequestParameter.Type == Game.Static.Who.WhoParameterType.Combo)
+                else if (currentRequestParameter.Type == WhoParameterType.Combo)
                 {
                     WhoParameterCombo comboData = currentRequestParameter.Data as WhoParameterCombo;
                     FilterByCombo(whoResponsePlayerList, sessionCandidate, comboData);
+                }
+                else if (currentRequestParameter.Type == WhoParameterType.Level)
+                {
+                    WhoParameterLevel levelData = currentRequestParameter.Data as WhoParameterLevel;
+                    FilterByLevel(whoResponsePlayerList, sessionCandidate, levelData);
                 }
             }
 
@@ -55,7 +62,17 @@ namespace NexusForever.WorldServer.Network.Message.Handler.Chat
             });
         }
 
-        private void FilterByCombo(List<ServerWhoResponse.WhoPlayer> players, IWorldSession sessionCandidate, WhoParameterCombo comboData)
+        private void FilterByLevel(List<ServerWhoResponse.WhoPlayer> whoResponsePlayerList, IWorldSession sessionCandidate, WhoParameterLevel levelData)
+        {
+            IPlayer candidatePlayer = sessionCandidate.Player;
+            uint candidateLevel = candidatePlayer.Level;
+            if (candidateLevel >= levelData.BottomLevel && candidateLevel < levelData.TopLevel)
+            {
+                AddPlayerToList(whoResponsePlayerList, sessionCandidate);
+            }
+        }
+
+        private void FilterByCombo(List<ServerWhoResponse.WhoPlayer> whoResponsePlayerList, IWorldSession sessionCandidate, WhoParameterCombo comboData)
         {
             inferredFilterStrategy = FilterStrategy.Name;
 
@@ -80,32 +97,32 @@ namespace NexusForever.WorldServer.Network.Message.Handler.Chat
             switch (inferredFilterStrategy)
             {
                 case FilterStrategy.Name:
-                    FilterByName(players, sessionCandidate, comboData.SearchString, candidatePlayer.Name);
+                    FilterByName(whoResponsePlayerList, sessionCandidate, comboData.SearchString, candidatePlayer.Name);
                     break;
                 case FilterStrategy.Race:
-                    FilterByArgs(players, sessionCandidate, comboData.RaceId, candidatePlayer.Race);
+                    FilterByArgs(whoResponsePlayerList, sessionCandidate, comboData.RaceId, candidatePlayer.Race);
                     break;
                 case FilterStrategy.Class:
-                    FilterByArgs(players, sessionCandidate, comboData.ClassId, candidatePlayer.Class);
+                    FilterByArgs(whoResponsePlayerList, sessionCandidate, comboData.ClassId, candidatePlayer.Class);
                     break;
                 case FilterStrategy.Path:
-                    FilterByArgs(players, sessionCandidate, comboData.PathId, candidatePlayer.Path);
+                    FilterByArgs(whoResponsePlayerList, sessionCandidate, comboData.PathId, candidatePlayer.Path);
                     break;
                 case FilterStrategy.Zone:
-                    FilterByArgs(players, sessionCandidate, comboData.WorldZoneId, candidatePlayer.Zone.Id);
+                    FilterByArgs(whoResponsePlayerList, sessionCandidate, comboData.WorldZoneId, candidatePlayer.Zone.Id);
                     break;
             }
         }
 
-        private void FilterByArgs<T>(List<ServerWhoResponse.WhoPlayer> players, IWorldSession sessionCandidate, T filterValue, T candidateValue)
+        private void FilterByArgs<T>(List<ServerWhoResponse.WhoPlayer> whoResponsePlayerList, IWorldSession sessionCandidate, T filterValue, T candidateValue)
         {
             if (EqualityComparer<T>.Default.Equals(filterValue, candidateValue))
             {
-                AddPlayerToList(players, sessionCandidate);
+                AddPlayerToList(whoResponsePlayerList, sessionCandidate);
             }
         }
 
-        private void FilterByName(List<ServerWhoResponse.WhoPlayer> players, IWorldSession sessionCandidate, string filterString, string candidateName)
+        private void FilterByName(List<ServerWhoResponse.WhoPlayer> whoResponsePlayerList, IWorldSession sessionCandidate, string filterString, string candidateName)
         {
             // We want to filter in a case insensitive way
             string lowerFilterString = filterString.ToLower();
@@ -113,11 +130,11 @@ namespace NexusForever.WorldServer.Network.Message.Handler.Chat
 
             if (lowerCandidateName.IndexOf(lowerFilterString) != -1)
             {
-                AddPlayerToList(players, sessionCandidate);
+                AddPlayerToList(whoResponsePlayerList, sessionCandidate);
             }
         }
 
-        private void AddPlayerToList(List<ServerWhoResponse.WhoPlayer> players, IWorldSession sessionCandidate)
+        private void AddPlayerToList(List<ServerWhoResponse.WhoPlayer> whoResponsePlayerList, IWorldSession sessionCandidate)
         {
             if (requestingSession.Id == sessionCandidate.Id && (shouldSearchesIncludeThePlayerInitiatingSearch == false))
             {
@@ -140,7 +157,7 @@ namespace NexusForever.WorldServer.Network.Message.Handler.Chat
             }
 
             IPlayer sessionPlayer = sessionCandidate.Player;
-            players.Add(new()
+            whoResponsePlayerList.Add(new()
             {
                 Name = sessionPlayer.Name,
                 Level = sessionPlayer.Level,

--- a/Source/NexusForever.WorldServer/Network/Message/Handler/Chat/ClientWhoRequestHandler.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Handler/Chat/ClientWhoRequestHandler.cs
@@ -1,31 +1,114 @@
-﻿using System.Collections.Generic;
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualBasic;
+using NexusForever.Game.Static.Entity;
 using NexusForever.Network.Message;
+using NexusForever.Network.Session;
 using NexusForever.Network.World.Message.Model.Who;
+using NexusForever.Network.World.Message.Model.Who.Parameter;
+using NexusForever.Shared;
+using System.Collections.Generic;
 
 namespace NexusForever.WorldServer.Network.Message.Handler.Chat
 {
     public class ClientWhoRequestHandler : IMessageHandler<IWorldSession, ClientWhoRequest>
     {
+
+        private enum FilterStrategy
+        {
+            Name,
+            Race,
+            Class,
+        }
+
+        private FilterStrategy inferredFilterStrategy;
         public void HandleMessage(IWorldSession session, ClientWhoRequest request)
         {
-            var players = new List<ServerWhoResponse.WhoPlayer>
+            INetworkManager<IWorldSession> worldSessions = LegacyServiceProvider.Provider.GetService<INetworkManager<IWorldSession>>();
+
+            var players = new List<ServerWhoResponse.WhoPlayer>();
+            var currentRequestParameter = request.Parameters.Count > 0 ? request.Parameters[0] : null;
+
+            // Iterate over sessions for filtering.
+            foreach (var sessionKey in worldSessions)
             {
-                new()
+                var sessionPlayer = sessionKey.Player;
+
+                if (currentRequestParameter == null)
                 {
-                    Name    = session.Player.Name,
-                    Level   = session.Player.Level,
-                    Race    = session.Player.Race,
-                    Class   = session.Player.Class,
-                    Path    = session.Player.Path,
-                    Faction = session.Player.Faction1,
-                    Sex     = session.Player.Sex,
-                    Zone    = session.Player.Zone.Id
+                    AddPlayerToList(players, sessionPlayer);
                 }
-            };
+                else if (currentRequestParameter.Type == Game.Static.Who.WhoParameterType.Combo)
+                {
+                    WhoParameterCombo comboData = currentRequestParameter.Data as WhoParameterCombo;
+                    FilterByCombo(players, sessionPlayer, comboData);
+                }
+            }
 
             session.EnqueueMessageEncrypted(new ServerWhoResponse
             {
                 Players = players
+            });
+        }
+
+        private void FilterByCombo(List<ServerWhoResponse.WhoPlayer> players, Game.Abstract.Entity.IPlayer sessionPlayer, WhoParameterCombo comboData)
+        {
+            inferredFilterStrategy = FilterStrategy.Name;
+
+            if (comboData.RaceId != Race.None)
+            {
+                inferredFilterStrategy = FilterStrategy.Race;
+            }
+            else if (comboData.ClassId != 0)
+            {
+                inferredFilterStrategy = FilterStrategy.Class;
+            }
+
+            switch (inferredFilterStrategy) 
+            {
+                case FilterStrategy.Name:
+                    FilterByName(players, sessionPlayer, comboData.SearchString, sessionPlayer.Name);
+                    break;
+                case FilterStrategy.Race:
+                    FilterByArgs(players, sessionPlayer, comboData.RaceId, sessionPlayer.Race);
+                    break;
+                case FilterStrategy.Class:
+                    FilterByArgs(players, sessionPlayer, comboData.ClassId, sessionPlayer.Class);
+                    break;
+            }
+        }
+
+        private void FilterByArgs<T>(List<ServerWhoResponse.WhoPlayer> players, Game.Abstract.Entity.IPlayer sessionPlayer, T filterValue, T sessionValue)
+        {
+            if (EqualityComparer<T>.Default.Equals(filterValue, sessionValue))
+            {
+                AddPlayerToList(players, sessionPlayer);
+            }
+        }
+
+        private void FilterByName(List<ServerWhoResponse.WhoPlayer> players, Game.Abstract.Entity.IPlayer sessionPlayer, string comboSearchString, string sessionName)
+        {
+            // We want to filter in a case insensitive way
+            string lowercaseSearch = comboSearchString.ToLower();
+            string lowercaseSessionName = sessionName.ToLower();
+
+            if (lowercaseSessionName.IndexOf(lowercaseSearch) != -1)
+            {
+                AddPlayerToList(players, sessionPlayer);
+            }
+        }
+
+        private static void AddPlayerToList(List<ServerWhoResponse.WhoPlayer> players, Game.Abstract.Entity.IPlayer sessionPlayer)
+        {
+            players.Add(new()
+            {
+                Name = sessionPlayer.Name,
+                Level = sessionPlayer.Level,
+                Race = sessionPlayer.Race,
+                Class = sessionPlayer.Class,
+                Path = sessionPlayer.Path,
+                Faction = sessionPlayer.Faction1,
+                Sex = sessionPlayer.Sex,
+                Zone = sessionPlayer.Zone.Id
             });
         }
     }


### PR DESCRIPTION
This PR implements /who command functionality. The following commands are supported by this PR:

/who {level:int}
/who {level:int-level:int}
/who {zone:string}
/who {path:string}
/who {class:string}
/who {race:string}

/who {name:string}
/who {substring_name:string}

Where each entry has the type I placed after ":"

There are a couple of unknowns right now in regards to this implementation. I was not sure whether or not cross faction /who requests were supported in the original Wildstar. I added some code to test cross faction /who requests and a variable that toggles the ability to request these on or off. I imagine reviewers will want us to move in a single direction, so I expect this to be replaced with a hard coded support for one of the options.

I also was not sure if the requestor's name / player should show up in the who response. I followed the same protocol as I described above for factions and created a boolean toggle to turn the functionality on or off.

Additionally, during testing I was only ever able to trigger enum reads for "Combo" and "Level". That leaves 7 / 9 of the expected enum types that Krakal outlined unsupported. In order to implement support for these WhoParameter types, I will need more detailed documentation for how to trigger these enum types.

As such this PR only aims to implement 2/9 possible enum types, Level and Combo.

Tested this across multiple zones and level ranges for a collection of players on both the same faction and differing factions.