### PR TITLE
fix console.html case in apphost link

### DIFF
--- a/Source/NexusForever.Aspire.AppHost/Program.cs
+++ b/Source/NexusForever.Aspire.AppHost/Program.cs
@@ -72,7 +72,7 @@ internal class Program
                         continue;
 
                     url.DisplayText = "Web Console";
-                    url.Url = new UriBuilder(url.Url) { Path = "Console.html" }.ToString();
+                    url.Url = new UriBuilder(url.Url) { Path = "console.html" }.ToString();
                 }
             }
         });


### PR DESCRIPTION
very quick patch to move this to lower case. this was fixed in the docs as well!