### PR TITLE
Add loot system enum types to Game.Static

### DIFF
--- a/Source/NexusForever.Game.Static/Loot/LootConditionType.cs
+++ b/Source/NexusForever.Game.Static/Loot/LootConditionType.cs
@@ -1,0 +1,18 @@
+namespace NexusForever.Game.Static.Loot
+{
+    /// <summary>
+    /// Condition types for conditional loot group evaluation.
+    /// </summary>
+    public enum LootConditionType
+    {
+        None                 = 0,
+        IsClass              = 1,
+        IsRace               = 2,
+        IsLevel              = 3,
+        IsLessThanLevel      = 4,
+        IsMoreThanLevel      = 5,
+        QuestIsComplete      = 6,
+        QuestNotComplete     = 7,
+        QuestObjectiveActive = 8
+    }
+}

--- a/Source/NexusForever.Game.Static/Loot/LootEntityType.cs
+++ b/Source/NexusForever.Game.Static/Loot/LootEntityType.cs
@@ -1,0 +1,11 @@
+namespace NexusForever.Game.Static.Loot
+{
+    /// <summary>
+    /// Determines the source entity type for a loot drop.
+    /// </summary>
+    public enum LootEntityType
+    {
+        Creature,
+        Item
+    }
+}

--- a/Source/NexusForever.Game.Static/Loot/LooterType.cs
+++ b/Source/NexusForever.Game.Static/Loot/LooterType.cs
@@ -1,0 +1,13 @@
+namespace NexusForever.Game.Static.Loot
+{
+    /// <summary>
+    /// Determines the loot distribution mode based on group type.
+    /// </summary>
+    public enum LooterType
+    {
+        Player,
+        Group,
+        Raid,
+        Guild
+    }
+}


### PR DESCRIPTION
## Summary

Adds three new enums to `NexusForever.Game.Static/Loot/` that are prerequisites for loot system implementation:

- **`LootEntityType`** — Distinguishes creature vs item loot sources. Used by the loot manager to route drops through the correct lookup table (entity_loot vs item_loot).
- **`LooterType`** — Player/Group/Raid/Guild distribution modes. Determines loot visibility and distribution rules per loot instance.
- **`LootConditionType`** — 9 condition types for conditional loot group evaluation (class, race, level range, quest completion/objective state). Used by loot groups to filter drops based on player state.

### Why these values

All values are derived from client data tables (specifically the loot group condition system visible in quest reward filtering and creature loot tables). `LootItemType` and `LootRollAction` already exist in Game.Static with identical values — verified, no changes needed.

### What this enables

These types are the static foundation for a full loot system: loot tables, drop generation, conditional filtering, and group loot distribution. No runtime code depends on these yet — this is purely additive.

## Test plan

- [x] `dotnet build` on `NexusForever.Game.Static` — 0 errors, 0 warnings
- [x] Full solution build — 0 errors (7 pre-existing warnings, none from new files)
- [x] Verified enum values match client data table expectations
- [x] Verified no duplicate values within any enum