### PR TITLE
[feat] Add Docker Compose stack for full server deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.gitattributes
+.gitignore
+**/bin/
+**/obj/
+Obsolete/
+LICENSE
+*.md

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Copy to `.env` in this directory — Docker Compose reads it automatically for ${VAR} substitution.
+# https://docs.docker.com/compose/environment-variables/set-environment-variables/
+
+# WildStar 16042 client directory (asset extraction / MapGenerator).
+# Same idea as ~/NCSOFT/WildStar in https://www.emulator.ws/installation/server-guide/asset-extraction/game-tables.md
+WILDSTAR_DIR=
+
+# Optional compose overrides (examples):
+# NEXUS_DB_PORT=3307
+# NEXUS_WORLD_HTTP_PORT=5000

--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@
 
 # WildStar 16042 client directory (asset extraction / MapGenerator).
 # Same idea as ~/NCSOFT/WildStar in https://www.emulator.ws/installation/server-guide/asset-extraction/game-tables.md
+# example for windows: WILDSTAR_DIR=C:\Program Files (x86)\NCSOFT\WildStar
 WILDSTAR_DIR=
 
 # Optional compose overrides (examples):

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,17 @@
 *.tbl
 *.nfmap
 
+# Distribution directories
+dist/
+
+# World DB SQL dumps (clone NexusForever.WorldDatabase here)
+docker/config
+docker/game-data
+docker/world-database
+
+# Docker Compose local env (copy from .env.example)
+.env
+
 # User-specific files
 *.suo
 *.user

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,150 @@
+# Docker Overview
+
+This document describes all Dockerfiles, the Compose file, and the `docker/` support folder.
+
+---
+
+## Dockerfiles
+
+### `Dockerfile`
+
+**Purpose:** Generic multi-project server image builder. Used for every game server service in Compose.
+
+Accepts two build arguments:
+
+| Argument | Default | Description |
+|---|---|---|
+| `PROJECT` | `NexusForever.AuthServer` | The `Source/` project to publish |
+| `RUNTIME_IMAGE` | `mcr.microsoft.com/dotnet/aspnet:10.0` | Base runtime image for the final stage |
+
+**Build stages:**
+1. `build` — restores and builds the full `NexusForever.slnx` solution in Release, then publishes the specified `PROJECT` to `/app/publish`.
+2. `final` — copies the published output into the chosen `RUNTIME_IMAGE`. The entry-point dynamically resolves `$ASSEMBLY` so any project name works.
+
+**Used by Compose services:** `auth`, `sts`, `character-api`, `world`, `chat`, `group`.
+
+Use `RUNTIME_IMAGE=mcr.microsoft.com/dotnet/aspnet:10.0` for projects that expose HTTP (WorldServer, CharacterAPI) and `mcr.microsoft.com/dotnet/runtime:10.0` for all others to keep images smaller.
+
+---
+
+### `Dockerfile.Artifacts`
+
+**Purpose:** Builds all five server release artifacts in a single image and optionally exports them to the host.
+
+**Artifacts produced:**
+
+| Folder | Target RID | Deployment |
+|---|---|---|
+| `AuthServer/` | `linux-x64` | Framework-dependent |
+| `StsServer/` | `linux-x64` | Framework-dependent |
+| `WorldServer/` | `linux-x64` | Framework-dependent |
+| `MapGenerator/` | `linux-x64` | Framework-dependent |
+| `ClientConnector/` | `win-x64` | Framework-dependent |
+
+**Build stages:**
+1. `build` — restores the solution and publishes each project separately.
+2. `final` — Alpine image with all artifacts under `/artifacts/`. Used by the `build-artifacts` Compose service, which copies them to `./dist/` via a bind-mount.
+3. `export` — scratch target for standalone use; `--output` writes folders directly to the host without a running container.
+
+**Usage:**
+```bash
+# Via Compose (copies to ./dist/)
+docker compose --profile tools run --rm build-artifacts
+
+# Standalone (direct export)
+docker build -f Dockerfile.Artifacts --target export --output ./dist/artifacts .
+```
+
+---
+
+### `Dockerfile.Launcher`
+
+**Purpose:** Cross-compiles the [NexusForever.Launcher](https://github.com/NexusForever/NexusForever.Launcher) WPF application into a self-contained `win-x64` single-file executable from a Linux SDK container (no Windows Docker daemon required).
+
+**Build stages:**
+1. `build` — installs `git`, clones the Launcher repository at `HEAD --depth 1`, and publishes a self-contained single-file `win-x64` binary to `/artifacts/`.
+2. `final` — copies `/artifacts/` so the Compose `launcher` service can copy them to the host via a bind-mount volume.
+
+**Usage:**
+```bash
+# Via Compose (copies to ./dist/Launcher/)
+docker compose --profile tools run --rm launcher
+
+# Standalone
+docker build -f Dockerfile.Launcher --output ./dist/Launcher .
+```
+
+The output is the player-side launcher — it runs on the player's Windows machine and connects to a live NexusForever server.
+
+---
+
+## `docker-compose.yml`
+
+The Compose file orchestrates the full NexusForever server stack. It follows the sequence from the [official server guide](https://www.emulator.ws/installation/server-guide).
+
+**Network:** All services share a bridge network `nf_net` (`172.26.240.0/24`). MariaDB has a fixed IP (`172.26.240.10`) to avoid Docker DNS and IPv6 resolution issues.
+
+**Optional `.env` file** (copy from `.env.example`): Overrides port bindings, credentials, and the `WILDSTAR_DIR` path used by extraction tooling.
+
+### Service groups
+
+#### Infrastructure (always up)
+
+| Service | Image | Purpose |
+|---|---|---|
+| `mariadb` | `mariadb:11.4` | Primary database. Bootstrapped by `docker/init-db/01-databases.sql` on first run. Data persisted in `mariadb_data` named volume. |
+| `rabbitmq` | `rabbitmq:3.13-management` | Message broker between WorldServer, ChatServer, and GroupServer. Management UI on port `15672`. |
+
+#### One-shot setup (run once, then exit)
+
+| Service | Depends on | Purpose |
+|---|---|---|
+| `init` | `mariadb` healthy | Generates `docker/config/*.json` from example files and clones/pins the world database repo. Runs `docker/init.sh`. |
+| `migrate` | `init` complete | Runs EF Core database migrations via `docker/migrate/migrate.sh` using the .NET SDK image. |
+| `world-import` | `migrate` complete | Imports world database SQL files into `nexus_forever_world` via `docker/import.sh`. |
+| `check-assets` | `world-import` complete | Verifies that `docker/game-data/tbl/` and `docker/game-data/map/` contain extracted game files before allowing game servers to start. |
+
+#### Game servers (default profile)
+
+| Service | Port(s) | Purpose |
+|---|---|---|
+| `character-api` | `4000` | HTTP REST API for character data (`NexusForever.API.Character`). |
+| `auth` | `23115` | Authentication server. Also runs an internal `socat` relay on `24000` → `world:24000` for client compatibility. |
+| `sts` | `6600` | STS (Secure Token Service) server. |
+| `group` | — | Group server; communicates via RabbitMQ. |
+
+#### Game servers (`--profile game`)
+
+| Service | Port(s) | Purpose |
+|---|---|---|
+| `world` | `24000` (game), `5000` (HTTP) | World game server. Requires extracted `tbl/` and `map/` assets. HTTP port is used for the web account-management console. |
+| `chat` | — | Chat server. Requires extracted `tbl/` assets. |
+
+Start the game-profile services with:
+```bash
+docker compose --profile game up -d
+```
+
+#### Tools (`--profile tools`)
+
+| Service | Purpose |
+|---|---|
+| `extractor` | Runs `NexusForever.MapGenerator` against a WildStar 16042 `Patch` directory to extract `.tbl`/`.bin` game tables and `.nfmap` map files into `docker/game-data/`. Requires `WILDSTAR_DIR` to be set. |
+| `build-artifacts` | Builds all five server artifacts via `Dockerfile.Artifacts` and copies them to `./dist/`. |
+| `launcher` | Builds the player-side launcher via `Dockerfile.Launcher` and copies it to `./dist/Launcher/`. |
+
+---
+
+## `docker/` Folder
+
+Supporting files consumed by Compose services and setup scripts. See [docker/README.md](docker/README.md) for full details.
+
+| Path | Description |
+|---|---|
+| `init.sh` | One-shot setup: generates configs, clones world DB |
+| `import.sh` | Imports world SQL files into MariaDB |
+| `migrate/migrate.sh` | Runs EF Core migrations |
+| `init-db/01-databases.sql` | MariaDB bootstrap SQL (databases + user) |
+| `config/` | Generated server JSON configs (gitignored) |
+| `game-data/` | Extracted game assets — `tbl/`, `map/`, `cache/` (gitignored) |
+| `world-database/` | Cloned world database SQL repo (gitignored) |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+# syntax=docker/dockerfile:1
+
+# Build steps follow the official NexusForever server guide (Linux / .NET 10 SDK):
+# https://www.emulator.ws/installation/server-guide
+# https://www.emulator.ws/installation/server-guide/server-building/linux.md
+#
+# Final stage: use aspnet for NexusForever.WorldServer and NexusForever.API.Character;
+# use runtime for smaller images for Auth, STS, Chat, or Group servers.
+ARG RUNTIME_IMAGE=mcr.microsoft.com/dotnet/aspnet:10.0
+
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+ARG PROJECT=NexusForever.AuthServer
+WORKDIR /src/Source
+
+COPY Source/ .
+
+# Official guide: restore and build the solution from NexusForever.slnx in Release.
+RUN dotnet restore NexusForever.slnx
+
+RUN dotnet build NexusForever.slnx --configuration Release --no-restore --verbosity minimal
+
+RUN dotnet publish "${PROJECT}/${PROJECT}.csproj" \
+    --configuration Release \
+    --output /app/publish \
+    --no-build \
+    --verbosity minimal
+
+FROM ${RUNTIME_IMAGE} AS final
+ARG PROJECT=NexusForever.AuthServer
+
+WORKDIR /app
+COPY --from=build --chown=app:app /app/publish .
+
+ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
+ENV ASSEMBLY=${PROJECT}.dll
+
+USER app
+
+ENTRYPOINT ["sh", "-c", "exec dotnet /app/$ASSEMBLY"]

--- a/Dockerfile.Artifacts
+++ b/Dockerfile.Artifacts
@@ -1,0 +1,79 @@
+# syntax=docker/dockerfile:1
+#
+# Builds all five release artifacts as folders:
+#   AuthServer/
+#   ClientConnector/
+#   MapGenerator/
+#   StsServer/
+#   WorldServer/
+#
+# Usage (standalone — exports folders directly to ./dist/artifacts/):
+#   docker build -f Dockerfile.Artifacts --target export --output ./dist/artifacts .
+#
+# Or via docker-compose (copies folders to ./dist/artifacts/ on the host):
+#   docker compose --profile tools run --rm build-artifacts
+
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src/Source
+
+COPY Source/ .
+
+RUN dotnet restore NexusForever.slnx
+
+# ── AuthServer (linux-x64, framework-dependent) ───────────────────────────────
+RUN dotnet publish NexusForever.AuthServer/NexusForever.AuthServer.csproj \
+    --configuration Release \
+    --runtime linux-x64 \
+    --self-contained false \
+    --output /publish/AuthServer \
+    --verbosity minimal
+
+# ── StsServer (linux-x64, framework-dependent) ────────────────────────────────
+RUN dotnet publish NexusForever.StsServer/NexusForever.StsServer.csproj \
+    --configuration Release \
+    --runtime linux-x64 \
+    --self-contained false \
+    --output /publish/StsServer \
+    --verbosity minimal
+
+# ── WorldServer (linux-x64, framework-dependent) ──────────────────────────────
+RUN dotnet publish NexusForever.WorldServer/NexusForever.WorldServer.csproj \
+    --configuration Release \
+    --runtime linux-x64 \
+    --self-contained false \
+    --output /publish/WorldServer \
+    --verbosity minimal
+
+# ── MapGenerator (linux-x64, framework-dependent) ─────────────────────────────
+RUN dotnet publish NexusForever.MapGenerator/NexusForever.MapGenerator.csproj \
+    --configuration Release \
+    --runtime linux-x64 \
+    --self-contained false \
+    --output /publish/MapGenerator \
+    --verbosity minimal
+
+# ── ClientConnector (win-x64, framework-dependent) ────────────────────────────
+RUN dotnet publish NexusForever.ClientConnector/NexusForever.ClientConnector.csproj \
+    --configuration Release \
+    --runtime win-x64 \
+    --self-contained false \
+    --output /publish/ClientConnector \
+    --verbosity minimal
+
+# ── Final stage (compose): alpine with all folders under /artifacts ──────────
+FROM alpine:3 AS final
+COPY --from=build /publish/AuthServer      /artifacts/AuthServer
+COPY --from=build /publish/StsServer       /artifacts/StsServer
+COPY --from=build /publish/WorldServer     /artifacts/WorldServer
+COPY --from=build /publish/MapGenerator    /artifacts/MapGenerator
+COPY --from=build /publish/ClientConnector /artifacts/ClientConnector
+
+# ── Export target (standalone): bare folders, no shell needed ─────────────────
+# docker build -f Dockerfile.Artifacts --target export --output ./dist/artifacts .
+FROM scratch AS export
+COPY --from=build /publish/AuthServer      /AuthServer
+COPY --from=build /publish/StsServer       /StsServer
+COPY --from=build /publish/WorldServer     /WorldServer
+COPY --from=build /publish/MapGenerator    /MapGenerator
+COPY --from=build /publish/ClientConnector /ClientConnector
+

--- a/Dockerfile.Launcher
+++ b/Dockerfile.Launcher
@@ -1,0 +1,45 @@
+# syntax=docker/dockerfile:1
+#
+# Builds NexusForever.Launcher as a self-contained Windows x64 executable.
+#
+# The Launcher is a WPF GUI application maintained in a separate repository:
+#   https://github.com/NexusForever/NexusForever.Launcher
+#
+# It runs on the *player's* Windows machine to connect to a NexusForever server.
+# This Dockerfile cross-compiles from a Linux SDK image (no Windows daemon needed).
+#
+# Usage (standalone):
+#   docker build -f Dockerfile.Launcher --output ./dist/Launcher .
+#
+# Or via docker-compose (see the `launcher` service in docker-compose.yml):
+#   docker compose --profile tools run --rm launcher
+# Artifacts are written to ./dist/Launcher/ on the host.
+
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+
+# git is needed to clone the Launcher repository.
+RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+RUN git clone --depth 1 https://github.com/NexusForever/NexusForever.Launcher.git launcher
+
+WORKDIR /src/launcher
+
+# Publish self-contained win-x64 WPF app.
+# WPF (net*-windows TFM) cross-compiles fine from the Linux SDK when targeting win-x64.
+RUN dotnet publish NexusForever.Launcher/NexusForever.Launcher.csproj \
+    --configuration Release \
+    --runtime win-x64 \
+    --self-contained true \
+    -p:PublishSingleFile=true \
+    -p:IncludeNativeLibrariesForSelfExtract=true \
+    -p:EnableWindowsTargeting=true \
+    --output /artifacts \
+    --verbosity minimal
+
+# ── Final stage ────────────────────────────────────────────────────────────────
+# Artifacts live at /artifacts.  The compose service copies them to the host via
+# a bind-mounted volume at /output.
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS final
+COPY --from=build /artifacts /artifacts
+WORKDIR /artifacts

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,430 @@
+# Docker stack aligned with the official server guide:
+# https://www.emulator.ws/installation/server-guide
+#
+# Same sequence as the guide (do these on the host before expecting World/Chat to run):
+#   1) Source — this repository (server-cloning).
+#   2) World DB repo — https://www.emulator.ws/installation/server-guide/world-database-cloning
+#      Clone into docker/world-database/ then ./docker/init.sh (after migrate).
+#   3) Build — Dockerfile follows server-building/linux.md (NexusForever.slnx, Release).
+#   4) Asset extraction — WildStar 16042 required; use NexusForever.MapGenerator per
+#      https://www.emulator.ws/installation/server-guide/asset-extraction.md
+#      (game-tables.md → tbl/*.tbl + *.bin; base-maps.md → map/*.nfmap).
+#      Copy into docker/game-data/tbl and docker/game-data/map OR run docker/extract-from-client.sh sync.
+#   5) Install — docker/config/*.json (like copying *.example.json in server-install-guide-linux.md);
+#      migrate service runs dotnet-ef same as that guide (paths use NexusForever.WorldServer — see migrate.sh).
+#      MariaDB user/password and RabbitMQ user match the Linux guide defaults.
+#   6) Accounts — https://www.emulator.ws/installation/server-guide/account-creation.md
+#      Web console: WorldServer HTTP port (default 5000) when world service is up:
+#      docker compose --profile game up -d
+#
+# Networking: MariaDB is reachable at 172.26.240.10 on the compose network (fixed IPv4 avoids Docker DNS/IPv6 issues).
+# Host publishes MariaDB on port 3306 by default; if that is already in use, set e.g. NEXUS_DB_PORT=3307.
+#
+# Locally built image names use pull_policy: never (see nexusforever-*:local tags).
+#
+# Optional `.env` beside this file (copy from `.env.example`): Docker Compose loads it for ${...}
+# substitution. Define client Patch path for extraction tooling:
+#   WILDSTAR_DIR=/absolute/path/to/WildStar
+# (`extract-from-client.sh` and docs reference this variable.)
+
+name: nexusforever
+
+networks:
+  nf_net:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.26.240.0/24
+
+services:
+  mariadb:
+    image: mariadb:11.4
+    restart: unless-stopped
+    networks:
+      nf_net:
+        ipv4_address: 172.26.240.10
+    environment:
+      MARIADB_ROOT_PASSWORD: ${NEXUS_MARIADB_ROOT_PASSWORD:-nexusforeverRoot}
+    volumes:
+      - mariadb_data:/var/lib/mysql
+      - ./docker/init-db:/docker-entrypoint-initdb.d:ro
+    ports:
+      - "${NEXUS_DB_PORT:-3306}:3306"
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 45s
+
+  rabbitmq:
+    image: rabbitmq:3.13-management
+    restart: unless-stopped
+    networks:
+      - nf_net
+    environment:
+      RABBITMQ_DEFAULT_USER: nexusforever
+      RABBITMQ_DEFAULT_PASS: nexusforever
+    ports:
+      - "${NEXUS_RABBIT_PORT:-5672}:5672"
+      - "${NEXUS_RABBIT_UI_PORT:-15672}:15672"
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "-q", "ping"]
+      interval: 15s
+      timeout: 10s
+      retries: 6
+      start_period: 45s
+
+  init:
+    image: nexusforever-init:local
+    build:
+      context: .
+      dockerfile_inline: |
+        FROM debian:bookworm-slim
+        RUN apt-get update -qq && apt-get install -y -qq --no-install-recommends \
+            git mariadb-client ca-certificates jq > /dev/null 2>&1 && rm -rf /var/lib/apt/lists/*
+    pull_policy: never
+    restart: "no"
+    networks:
+      - nf_net
+    depends_on:
+      mariadb:
+        condition: service_healthy
+    environment:
+      DB_HOST: "172.26.240.10"
+      DB_PORT: "3306"
+      DB_USER: nexusforever
+      DB_PASS: nexusforever
+      RABBIT_HOST: rabbitmq
+      REALM_ID: "1"
+      CHAR_API_HOST: "http://0.0.0.0:4000"
+      WORLD_DB_REPO: ${WORLD_DB_REPO:-https://github.com/NexusForever/NexusForever.WorldDatabase.git}
+      # Last commit whose tables are fully covered by EF migrations.
+      # Set WORLD_DB_REVISION=HEAD in .env to use the latest world database.
+      WORLD_DB_REVISION: ${WORLD_DB_REVISION:-342cb2e}
+    volumes:
+      - ./Source:/repo/Source:ro
+      - ./docker:/repo/docker
+    entrypoint: ["/bin/bash", "/repo/docker/init.sh"]
+
+  migrate:
+    image: mcr.microsoft.com/dotnet/sdk:10.0
+    restart: "no"
+    networks:
+      - nf_net
+    depends_on:
+      mariadb:
+        condition: service_healthy
+      init:
+        condition: service_completed_successfully
+    environment:
+      # Host/client Patch path per asset-extraction.md — available inside compose project; migrations ignore it.
+      WILDSTAR_DIR: ${WILDSTAR_DIR:-C:\Program Files (x86)\NCSOFT\WildStar}/Patch
+    volumes:
+      - ./Source:/src/Source
+      - ./docker/config:/migrate-config:ro
+      - ./docker/migrate/migrate.sh:/migrate.sh:ro
+    entrypoint: ["/bin/bash", "/migrate.sh"]
+
+  world-import:
+    image: nexusforever-init:local
+    pull_policy: never
+    restart: "no"
+    networks:
+      - nf_net
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+    environment:
+      DB_HOST: "172.26.240.10"
+      DB_PORT: "3306"
+      DB_USER: nexusforever
+      DB_PASS: nexusforever
+      NO_IMPORT: "false"
+    volumes:
+      - ./docker:/repo/docker
+    entrypoint: ["/bin/bash", "/repo/docker/import.sh"]
+
+  extractor:
+    profiles:
+      - tools
+    image: mcr.microsoft.com/dotnet/sdk:10.0
+    restart: "no"
+    networks:
+      - nf_net
+    depends_on:
+      init:
+        condition: service_completed_successfully
+    environment:
+      WILDSTAR_DIR: ${WILDSTAR_DIR:-C:\Program Files (x86)\NCSOFT\WildStar}/Patch
+    volumes:
+      - ./Source:/src/Source
+      - ./docker/game-data:/game-data
+      - ${WILDSTAR_DIR:-.}/Patch:/wildstar/patch:ro
+    working_dir: /src/Source
+    entrypoint: ["/bin/bash", "-c"]
+    command: 
+      - |
+        set -e
+        echo "=== NexusForever MapGenerator ==="
+        echo "Patch directory contents:"
+        ls -lh /wildstar/patch
+
+        echo ""
+        echo "Building MapGenerator..."
+        cd /src/Source/NexusForever.MapGenerator
+        dotnet build -c Release
+        
+        echo ""
+        cd /src/Source/NexusForever.MapGenerator/bin/Release/net10.0
+        echo "Running: dotnet NexusForever.MapGenerator.dll --extract --patchPath /wildstar/patch"
+        dotnet NexusForever.MapGenerator.dll --extract --patchPath /wildstar/patch
+        
+
+        echo ""
+        cd /src/Source/NexusForever.MapGenerator/bin/Release/net10.0
+        echo "Running: dotnet NexusForever.MapGenerator.dll --generate --patchPath /wildstar/patch"
+        dotnet NexusForever.MapGenerator.dll --generate --patchPath /wildstar/patch
+
+        echo ""
+        echo "Copying tbl files to /game-data/tbl/ ..."
+        mkdir -p /game-data/tbl
+        cp -v tbl/* /game-data/tbl/
+
+        echo ""
+        echo "Copying nfmap files to /game-data/map/ ..."
+        mkdir -p /game-data/map
+        cp -v map/* /game-data/map/
+        echo "Done."
+
+  # Runs after world-import and verifies that tbl/map game-data files exist before
+  # the game servers try to start.  Run `docker compose --profile tools run --rm extractor`
+  # (with WILDSTAR_DIR set) to populate docker/game-data/tbl and docker/game-data/map.
+  check-assets:
+    image: nexusforever-init:local
+    pull_policy: never
+    restart: "no"
+    networks:
+      - nf_net
+    depends_on:
+      world-import:
+        condition: service_completed_successfully
+    volumes:
+      - ./docker/game-data/tbl:/check/tbl:ro
+      - ./docker/game-data/map:/check/map:ro
+    entrypoint: ["/bin/bash", "-c"]
+    command:
+      - |
+        tbl_count=$$(find /check/tbl -maxdepth 1 -name '*.tbl' 2>/dev/null | wc -l)
+        map_count=$$(find /check/map -maxdepth 1 -name '*.nfmap' 2>/dev/null | wc -l)
+        ok=true
+        if [ "$$tbl_count" -eq 0 ]; then
+          echo "ERROR: No .tbl files found in docker/game-data/tbl/"
+          ok=false
+        else
+          echo "  tbl: $$tbl_count file(s) found"
+        fi
+        if [ "$$map_count" -eq 0 ]; then
+          echo "ERROR: No .nfmap files found in docker/game-data/map/"
+          ok=false
+        else
+          echo "  map: $$map_count file(s) found"
+        fi
+        if [ "$$ok" = false ]; then
+          echo ""
+          echo "Run the extractor first:"
+          echo "  WILDSTAR_DIR=/path/to/WildStar docker compose --profile tools run --rm extractor"
+          exit 1
+        fi
+        echo "Asset check passed."
+
+  build-artifacts:
+    profiles:
+      - tools
+    build:
+      context: .
+      dockerfile: Dockerfile.Artifacts
+      target: final
+    image: nexusforever-artifacts:local
+    pull_policy: never
+    # Copies all five zip files to ./dist/artifacts/ on the host.
+    volumes:
+      - ./dist:/output
+    entrypoint: ["/bin/sh", "-c", "cp -rv /artifacts/. /output/ && echo 'Done. Artifacts are in ./dist/artifacts/'"]
+
+  launcher:
+    profiles:
+      - tools
+    build:
+      context: .
+      dockerfile: Dockerfile.Launcher
+    image: nexusforever-launcher:local
+    pull_policy: never
+    # Copies the published win-x64 artifacts to ./dist/Launcher/ on the host.
+    volumes:
+      - ./dist/Launcher:/output
+    entrypoint: ["/bin/sh", "-c", "cp -rv /artifacts/. /output/ && echo 'Done. Artifacts are in ./dist/Launcher/'"]
+
+  character-api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        PROJECT: NexusForever.API.Character
+        RUNTIME_IMAGE: mcr.microsoft.com/dotnet/aspnet:10.0
+    image: nexusforever-character-api:local
+    pull_policy: never
+    restart: unless-stopped
+    networks:
+      - nf_net
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+      mariadb:
+        condition: service_healthy
+    ports:
+      - "${NEXUS_CHARACTER_API_PORT:-4000}:4000"
+    volumes:
+      - ./docker/config/CharacterAPI.json:/app/CharacterAPI.json:ro
+
+  auth:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        PROJECT: NexusForever.AuthServer
+        RUNTIME_IMAGE: mcr.microsoft.com/dotnet/runtime:10.0
+    image: nexusforever-auth:local
+    pull_policy: never
+    user: root
+    restart: unless-stopped
+    networks:
+      - nf_net
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+      mariadb:
+        condition: service_healthy
+    ports:
+      - "${NEXUS_AUTH_PORT:-23115}:23115"
+    volumes:
+      - ./docker/config/AuthServer.json:/app/AuthServer.json:ro
+    # socat relays 127.0.0.1:24000 → world:24000 inside this container so that
+    # ServerManager.PingHostAsync() succeeds when server.host = '127.0.0.1'.
+    # The WildStar game client also connects to 127.0.0.1:24000 via the published port.
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        apt-get update -qq && apt-get install -y -qq socat > /dev/null 2>&1
+        socat TCP-LISTEN:24000,fork,reuseaddr TCP:world:24000 &
+        exec dotnet /app/$$ASSEMBLY
+
+  sts:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        PROJECT: NexusForever.StsServer
+        RUNTIME_IMAGE: mcr.microsoft.com/dotnet/runtime:10.0
+    image: nexusforever-sts:local
+    pull_policy: never
+    restart: unless-stopped
+    networks:
+      - nf_net
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+      mariadb:
+        condition: service_healthy
+    ports:
+      - "${NEXUS_STS_PORT:-6600}:6600"
+    volumes:
+      - ./docker/config/StsServer.json:/app/StsServer.json:ro
+
+  world:
+    profiles:
+      - game
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        PROJECT: NexusForever.WorldServer
+        RUNTIME_IMAGE: mcr.microsoft.com/dotnet/aspnet:10.0
+    image: nexusforever-world:local
+    pull_policy: never
+    restart: unless-stopped
+    networks:
+      - nf_net
+    depends_on:
+      check-assets:
+        condition: service_completed_successfully
+      mariadb:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
+    ports:
+      - "${NEXUS_WORLD_GAME_PORT:-24000}:24000"
+      - "${NEXUS_WORLD_HTTP_PORT:-5000}:5000"
+    environment:
+      # Ensures Kestrel binds on all interfaces inside the container (localhost-only breaks host access).
+      ASPNETCORE_URLS: http://0.0.0.0:5000
+    volumes:
+      - ./docker/config/WorldServer.json:/app/WorldServer.json:ro
+      - ./docker/game-data/tbl:/app/tbl:ro
+      - ./docker/game-data/cache:/app/cache
+      - ./docker/game-data/map:/app/map:ro
+
+  chat:
+    profiles:
+      - game
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        PROJECT: NexusForever.Server.ChatServer
+        RUNTIME_IMAGE: mcr.microsoft.com/dotnet/runtime:10.0
+    image: nexusforever-chat:local
+    pull_policy: never
+    restart: unless-stopped
+    networks:
+      - nf_net
+    depends_on:
+      check-assets:
+        condition: service_completed_successfully
+      mariadb:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
+      character-api:
+        condition: service_started
+    volumes:
+      - ./docker/config/ChatServer.json:/app/ChatServer.json:ro
+      - ./docker/game-data/tbl:/app/tbl:ro
+      - ./docker/game-data/cache:/app/cache
+
+  group:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        PROJECT: NexusForever.Server.GroupServer
+        RUNTIME_IMAGE: mcr.microsoft.com/dotnet/runtime:10.0
+    image: nexusforever-group:local
+    pull_policy: never
+    restart: unless-stopped
+    networks:
+      - nf_net
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+      mariadb:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
+      character-api:
+        condition: service_started
+    volumes:
+      - ./docker/config/GroupServer.json:/app/GroupServer.json:ro
+
+volumes:
+  mariadb_data:

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,219 @@
+# docker/ — Support Files Reference
+
+This folder contains scripts, bootstrap SQL, server configuration, and runtime game data consumed by the Docker Compose stack. Several subdirectories and files are **generated at runtime** by the scripts and are excluded from version control via `.gitignore`.
+
+---
+
+## Directory Layout
+
+```
+docker/
+├── init.sh                  # One-shot setup script (config generation + world DB clone)
+├── import.sh                # World SQL import script
+├── config/                  # !! GENERATED — gitignored !!
+│   ├── AuthServer.json
+│   ├── CharacterAPI.json
+│   ├── ChatServer.json
+│   ├── GroupServer.json
+│   ├── StsServer.json
+│   └── WorldServer.json
+├── game-data/               # !! GENERATED — gitignored !!
+│   ├── tbl/                 # Extracted game tables (*.tbl, *.bin)
+│   ├── map/                 # Extracted map files (*.nfmap)
+│   └── cache/               # Runtime cache written by WorldServer / ChatServer
+├── init-db/
+│   └── 01-databases.sql     # MariaDB bootstrap SQL (run once on container first start)
+├── migrate/
+│   └── migrate.sh           # EF Core migration runner
+└── world-database/          # !! GENERATED — gitignored !!
+                             # Cloned NexusForever.WorldDatabase SQL repo
+```
+
+---
+
+## Scripts
+
+### `init.sh`
+
+**Run by:** the `init` Compose service (one-shot, exits after completion).  
+**Can also be run directly** on the host for local (non-Docker) setups.
+
+**What it does:**
+
+1. **Config generation** — reads each `*.example.json` from the `Source/` projects and writes a corresponding `docker/config/*.json` using `jq`. Substitutions applied to every file:
+   - MariaDB host/port and credentials in connection strings
+   - RabbitMQ AMQP URL
+   - Character API base URL
+
+   Extra per-file transforms:
+   - `WorldServer.json` — sets `Network.Internal.InputQueue` and `Realm.RealmId` from `$REALM_ID`
+   - `CharacterAPI.json` — sets `.urls` to `http://0.0.0.0:4000` so Kestrel binds on all interfaces, and sets `Database.Character[0].RealmId`
+
+2. **World database** — clones [NexusForever.WorldDatabase](https://github.com/NexusForever/NexusForever.WorldDatabase) into `docker/world-database/` (if not already present) and checks out the pinned revision defined by `$WORLD_DB_REVISION` (default: `342cb2e`). This pin targets the last commit whose tables are fully covered by the EF migrations. Set `WORLD_DB_REVISION=HEAD` in `.env` to use the latest commit.
+
+**Flags:**
+
+| Flag | Effect |
+|---|---|
+| `--force` | Overwrite existing config files and `git pull` the world DB |
+| `--no-import` | (legacy — import is now a separate service) |
+
+**Environment variables (all have defaults):**
+
+| Variable | Default | Description |
+|---|---|---|
+| `DB_HOST` | `172.26.240.10` | MariaDB host |
+| `DB_PORT` | `3306` | MariaDB port |
+| `DB_USER` | `nexusforever` | MariaDB user |
+| `DB_PASS` | `nexusforever` | MariaDB password |
+| `RABBIT_HOST` | `rabbitmq` | RabbitMQ hostname |
+| `RABBIT_PORT` | `5672` | RabbitMQ AMQP port |
+| `RABBIT_USER` | `nexusforever` | RabbitMQ user |
+| `RABBIT_PASS` | `nexusforever` | RabbitMQ password |
+| `CHAR_API_HOST` | `http://0.0.0.0:4000` | Character API base URL written into configs |
+| `REALM_ID` | `1` | Realm ID written into WorldServer and CharacterAPI configs |
+| `WORLD_DB_REPO` | `https://github.com/NexusForever/NexusForever.WorldDatabase.git` | World database git remote |
+| `WORLD_DB_REVISION` | `342cb2e` | Git revision to check out after clone |
+
+---
+
+### `import.sh`
+
+**Run by:** the `world-import` Compose service (one-shot, exits after completion).
+
+**What it does:**
+
+Finds all `*.sql` files under `docker/world-database/` (sorted, `.git/` excluded) and imports each one into the `nexus_forever_world` database using `mariadb --force`. Non-blank output lines from MariaDB (warnings or errors) are printed to stderr alongside a per-file warning. A final summary reports how many files had errors.
+
+**Environment variables:**
+
+| Variable | Default | Description |
+|---|---|---|
+| `DB_HOST` | (required) | MariaDB host |
+| `DB_PORT` | (required) | MariaDB port |
+| `DB_USER` | (required) | MariaDB user |
+| `DB_PASS` | (required) | MariaDB password |
+| `NO_IMPORT` | `false` | Set to `true` to skip the import entirely |
+
+---
+
+### `migrate/migrate.sh`
+
+**Run by:** the `migrate` Compose service using the official `mcr.microsoft.com/dotnet/sdk:10.0` image.
+
+**What it does:**
+
+1. Installs (or updates) `dotnet-ef` as a global tool.
+2. Restores the `NexusForever.slnx` solution.
+3. Runs `dotnet ef database update` for every EF Core `DbContext`:
+   - `AuthContext` — `nexus_forever_auth`
+   - `CharacterContext` — `nexus_forever_character`
+   - `WorldContext` — `nexus_forever_world`
+   - ChatServer context — `nexus_forever_chat`
+   - GroupServer context — `nexus_forever_group`
+
+EF is run from `/migrate-config` (which maps to `docker/config/`) so that design-time factories resolve `AddJsonFile("<Name>.json")` against the correct directory without modifying the source tree.
+
+> **Note:** The upstream guide references `NexusForever.Server.WorldServer`; this repository uses `NexusForever.WorldServer`.
+
+---
+
+## `init-db/01-databases.sql`
+
+**Run by:** MariaDB's `docker-entrypoint-initdb.d` mechanism — executed **once** the first time the `mariadb_data` volume is created.
+
+Creates all five databases and the `nexusforever` MariaDB user with full privileges:
+
+```sql
+CREATE DATABASE IF NOT EXISTS nexus_forever_auth;
+CREATE DATABASE IF NOT EXISTS nexus_forever_character;
+CREATE DATABASE IF NOT EXISTS nexus_forever_world;
+CREATE DATABASE IF NOT EXISTS nexus_forever_chat;
+CREATE DATABASE IF NOT EXISTS nexus_forever_group;
+
+CREATE USER IF NOT EXISTS 'nexusforever'@'%' IDENTIFIED BY 'nexusforever';
+GRANT ALL PRIVILEGES ON *.* TO 'nexusforever'@'%';
+```
+
+To reset the databases, remove the `mariadb_data` Docker volume:
+```bash
+docker compose down -v
+```
+
+---
+
+## Generated / Gitignored Paths
+
+The following paths do not exist in the repository. They are created by the setup scripts during the first run.
+
+### `config/` — Server configuration files
+
+Generated by `init.sh` from the `*.example.json` files in each `Source/` project. Mount-injected into running containers as read-only volumes.
+
+| File | Server |
+|---|---|
+| `AuthServer.json` | `NexusForever.AuthServer` |
+| `StsServer.json` | `NexusForever.StsServer` |
+| `WorldServer.json` | `NexusForever.WorldServer` |
+| `CharacterAPI.json` | `NexusForever.API.Character` |
+| `ChatServer.json` | `NexusForever.Server.ChatServer` |
+| `GroupServer.json` | `NexusForever.Server.GroupServer` |
+
+To regenerate (e.g. after changing credentials or realm ID), re-run the `init` service:
+```bash
+docker compose run --rm init --force
+```
+
+---
+
+### `game-data/` — Extracted game assets
+
+Populated by the `extractor` Compose service (profile `tools`) or manually.
+
+#### `game-data/tbl/`
+
+Contains game table files extracted from the WildStar 16042 client:
+- `*.tbl` — binary game tables
+- `*.bin` — supplemental binary data
+
+Required by: `WorldServer`, `ChatServer`.
+
+#### `game-data/map/`
+
+Contains pre-generated map data files:
+- `*.nfmap` — NexusForever map format generated by `NexusForever.MapGenerator`
+
+Required by: `WorldServer`.
+
+#### `game-data/cache/`
+
+Runtime write cache created and managed by `WorldServer` and `ChatServer`. Created automatically as an empty directory by `init.sh`. Persists across container restarts via a bind-mount.
+
+**To populate `tbl/` and `map/`**, run the extractor with the WildStar client path:
+```bash
+WILDSTAR_DIR=/path/to/WildStar docker compose --profile tools run --rm extractor
+```
+
+---
+
+### `world-database/`
+
+A clone of the [NexusForever.WorldDatabase](https://github.com/NexusForever/NexusForever.WorldDatabase) repository, checked out at the pinned revision specified by `WORLD_DB_REVISION` in the Compose environment (default: `342cb2e`).
+
+Populated by `init.sh`. Contains the SQL files that `import.sh` imports into `nexus_forever_world`.
+
+Structure mirrors the upstream repository layout:
+```
+world-database/
+├── Alizar/
+├── Instance/
+├── Isigrol/
+├── Olyssia/
+└── ...
+```
+
+To update to a newer revision, set `WORLD_DB_REVISION=HEAD` (or a specific commit hash) in `.env` and re-run:
+```bash
+docker compose run --rm init --force
+docker compose run --rm world-import
+```

--- a/docker/import.sh
+++ b/docker/import.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Imports world SQL files into nexus_forever_world after EF migrations are done.
+# Runs as a separate service so it executes AFTER migrate completes.
+#
+# Variables (passed via docker-compose environment):
+#   DB_HOST, DB_PORT, DB_USER, DB_PASS, NO_IMPORT (optional)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORLD_DB_DIR="$SCRIPT_DIR/world-database"
+NO_IMPORT="${NO_IMPORT:-false}"
+
+# ---------------------------------------------------------------------------
+# Import world SQL
+# ---------------------------------------------------------------------------
+if [[ "$NO_IMPORT" == true ]]; then
+  echo ""
+  echo "SKIP   world SQL import (--no-import)"
+else
+  mapfile -t sql_files < <(find "$WORLD_DB_DIR" -type f -name '*.sql' ! -path '*/.git/*' | LC_ALL=C sort)
+  if [[ ${#sql_files[@]} -eq 0 ]]; then
+    echo ""
+    echo "WARNING: no .sql files found in $WORLD_DB_DIR — skipping import."
+  else
+    echo ""
+    echo "Importing ${#sql_files[@]} SQL file(s) into nexus_forever_world..."
+    import_errors=0
+    for f in "${sql_files[@]}"; do
+      echo "  ${f#"$SCRIPT_DIR/"}"
+      db_output=$(mariadb --force -h"${DB_HOST}" -P"${DB_PORT}" -u"${DB_USER}" -p"${DB_PASS}" nexus_forever_world < "$f" 2>&1) || true
+      filtered=$(echo "$db_output" | grep -v "^$") || true
+      if [[ -n "$filtered" ]]; then
+        echo "  WARNING: errors in ${f#"$SCRIPT_DIR/"} (continuing)" >&2
+        echo "$filtered" >&2
+        (( import_errors++ )) || true
+      fi
+    done
+    if [[ $import_errors -gt 0 ]]; then
+      echo "World SQL import finished with $import_errors file(s) reporting errors (see above)."
+    else
+      echo "World SQL import finished."
+    fi
+  fi
+fi

--- a/docker/init-db/01-databases.sql
+++ b/docker/init-db/01-databases.sql
@@ -1,0 +1,10 @@
+-- Matches default NexusForever database names from the server guide.
+CREATE DATABASE IF NOT EXISTS nexus_forever_auth;
+CREATE DATABASE IF NOT EXISTS nexus_forever_character;
+CREATE DATABASE IF NOT EXISTS nexus_forever_world;
+CREATE DATABASE IF NOT EXISTS nexus_forever_chat;
+CREATE DATABASE IF NOT EXISTS nexus_forever_group;
+
+CREATE USER IF NOT EXISTS 'nexusforever'@'%' IDENTIFIED BY 'nexusforever';
+GRANT ALL PRIVILEGES ON *.* TO 'nexusforever'@'%';
+FLUSH PRIVILEGES;

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# One-shot setup script: generates docker/config/*.json from the *.example.json
+# files in Source/ (via jq), clones/updates the world database, and imports
+# all world SQL files into the running MariaDB container.
+#
+# Usage:
+#   ./docker/init.sh                    # skip files/steps already done
+#   ./docker/init.sh --force            # overwrite configs, git pull, re-import SQL
+#   ./docker/init.sh --no-import        # skip the SQL import step
+#
+# Customisable variables (override via environment):
+#   DB_HOST        MariaDB hostname/IP       (default: 172.26.240.10)
+#   DB_PORT        MariaDB port              (default: 3306)
+#   DB_USER        MariaDB user              (default: nexusforever)
+#   DB_PASS        MariaDB password          (default: nexusforever)
+#   RABBIT_HOST    RabbitMQ hostname         (default: rabbitmq)
+#   RABBIT_PORT    RabbitMQ AMQP port        (default: 5672)
+#   RABBIT_USER    RabbitMQ user             (default: nexusforever)
+#   RABBIT_PASS    RabbitMQ password         (default: nexusforever)
+#   CHAR_API_HOST  Character API base URL    (default: http://0.0.0.0:4000)
+#   REALM_ID       Realm ID                  (default: 1)
+#   WORLD_DB_REPO  World database git URL    (default: NexusForever/NexusForever.WorldDatabase)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SOURCE_DIR="$(dirname "$SCRIPT_DIR")/Source"
+CONFIG_DIR="$SCRIPT_DIR/config"
+
+FORCE=false
+NO_IMPORT=false
+for arg in "$@"; do
+  [[ "$arg" == "--force" ]]     && FORCE=true
+  [[ "$arg" == "--no-import" ]] && NO_IMPORT=true
+done
+
+export DB_HOST="${DB_HOST:-172.26.240.10}"
+export DB_PORT="${DB_PORT:-3306}"
+export DB_USER="${DB_USER:-nexusforever}"
+export DB_PASS="${DB_PASS:-nexusforever}"
+export RABBIT_HOST="${RABBIT_HOST:-rabbitmq}"
+export RABBIT_PORT="${RABBIT_PORT:-5672}"
+export RABBIT_USER="${RABBIT_USER:-nexusforever}"
+export RABBIT_PASS="${RABBIT_PASS:-nexusforever}"
+export CHAR_API_HOST="${CHAR_API_HOST:-http://0.0.0.0:4000}"
+export REALM_ID="${REALM_ID:-1}"
+
+mkdir -p "$CONFIG_DIR"
+# Ensure game-data subdirs exist as directories (remove any blocking placeholder files)
+for _d in "$SCRIPT_DIR/config" "$SCRIPT_DIR/game-data" "$SCRIPT_DIR/game-data/cache" "$SCRIPT_DIR/game-data/map" "$SCRIPT_DIR/game-data/tbl"; do
+  if [[ -e "$_d" ]] || [[ -L "$_d" ]]; then
+    if ! [[ -d "$_d" ]]; then
+      echo "  WARN: removing non-directory at $_d ($(ls -ld "$_d" 2>&1 | head -c 120))"
+      rm -rf "$_d"
+    fi
+  fi
+  mkdir -p "$_d"
+done
+unset _d
+
+# write_from_example <source_example> <dest_json> [extra jq filter expressions...]
+write_from_example() {
+  local src="$1"
+  local dst="$2"
+  shift 2
+  local extra=("$@")
+
+  if [[ ! -f "$src" ]]; then
+    echo "  MISSING example: $src" >&2
+    return 1
+  fi
+
+  if [[ -f "$dst" && "$FORCE" == false ]]; then
+    echo "  SKIP   $(basename "$dst") (already exists; use --force to overwrite)"
+    return
+  fi
+
+  # Base jq filter applied to every file:
+  #   DB host/port and credentials in connection strings
+  #   RabbitMQ AMQP URL
+  #   Character API URL
+  local jq_filter='walk(
+    if type == "string" then
+      gsub("server=127\\.0\\.0\\.1;port=3306";
+           "server=" + env.DB_HOST + ";port=" + env.DB_PORT) |
+      gsub("user=nexusforever;password=nexusforever";
+           "user=" + env.DB_USER + ";password=" + env.DB_PASS) |
+      gsub("amqp://nexusforever:nexusforever@localhost:5672";
+           "amqp://" + env.RABBIT_USER + ":" + env.RABBIT_PASS +
+           "@" + env.RABBIT_HOST + ":" + env.RABBIT_PORT) |
+      gsub("http://localhost:4000"; env.CHAR_API_HOST)
+    else . end
+  )'
+
+  for expr in "${extra[@]+"${extra[@]}"}"; do
+    jq_filter+=" | $expr"
+  done
+
+  jq "$jq_filter" "$src" > "$dst"
+  echo "  WRITE  $(basename "$dst")"
+}
+
+echo "Generating docker/config files from Source example JSONs..."
+echo "  DB_HOST=${DB_HOST}  RABBIT_HOST=${RABBIT_HOST}  CHAR_API_HOST=${CHAR_API_HOST}"
+echo ""
+
+write_from_example \
+  "$SOURCE_DIR/NexusForever.AuthServer/AuthServer.example.json" \
+  "$CONFIG_DIR/AuthServer.json"
+
+write_from_example \
+  "$SOURCE_DIR/NexusForever.StsServer/StsServer.example.json" \
+  "$CONFIG_DIR/StsServer.json"
+
+write_from_example \
+  "$SOURCE_DIR/NexusForever.WorldServer/WorldServer.example.json" \
+  "$CONFIG_DIR/WorldServer.json" \
+  '.Network.Internal.InputQueue = "WorldServer_" + env.REALM_ID' \
+  '.Realm.RealmId = (env.REALM_ID | tonumber)'
+
+write_from_example \
+  "$SOURCE_DIR/NexusForever.Server.ChatServer/ChatServer.example.json" \
+  "$CONFIG_DIR/ChatServer.json"
+
+write_from_example \
+  "$SOURCE_DIR/NexusForever.Server.GroupServer/GroupServer.example.json" \
+  "$CONFIG_DIR/GroupServer.json"
+
+# CharacterAPI: also fix the bind URL (CHAR_API_HOST → 0.0.0.0:4000 for the listener)
+write_from_example \
+  "$SOURCE_DIR/NexusForever.API.Character/CharacterAPI.example.json" \
+  "$CONFIG_DIR/CharacterAPI.json" \
+  '.urls = "http://0.0.0.0:4000"' \
+  '.Database.Character[0].RealmId = (env.REALM_ID | tonumber)'
+
+echo ""
+echo "Done. Config files are in $CONFIG_DIR"
+
+# ---------------------------------------------------------------------------
+# World database
+# ---------------------------------------------------------------------------
+WORLD_DB_DIR="$SCRIPT_DIR/world-database"
+WORLD_DB_REPO="${WORLD_DB_REPO:-https://github.com/NexusForever/NexusForever.WorldDatabase.git}"
+# Pin to a commit whose tables are all present in the EF migrations.
+# Newer commits reference entity_property / entity_script / entity_template which
+# don't have migrations yet. Override via WORLD_DB_REVISION=HEAD to use latest.
+WORLD_DB_REVISION="${WORLD_DB_REVISION:-342cb2e}"
+
+echo ""
+if [[ -d "$WORLD_DB_DIR/.git" ]]; then
+  if [[ "$FORCE" == true ]]; then
+    echo "Updating world database (git pull)..."
+    git -C "$WORLD_DB_DIR" fetch origin
+    git -C "$WORLD_DB_DIR" checkout "$WORLD_DB_REVISION"
+  else
+    echo "SKIP   world-database (already cloned; use --force to update)"
+  fi
+else
+  echo "Cloning world database from $WORLD_DB_REPO ..."
+  git clone "$WORLD_DB_REPO" "$WORLD_DB_DIR"
+  git -C "$WORLD_DB_DIR" checkout "$WORLD_DB_REVISION"
+fi
+echo "Done. World database is in $WORLD_DB_DIR (revision: $WORLD_DB_REVISION)"

--- a/docker/migrate/migrate.sh
+++ b/docker/migrate/migrate.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Runs EF migrations against MariaDB (first-time setup). Matches:
+# https://www.emulator.ws/installation/server-guide/server-installation/server-install-guide-linux.md
+#
+# Upstream doc paths say NexusForever.Server.WorldServer — this repository uses NexusForever.WorldServer.
+#
+# EF is run from /migrate-config (mounted from docker/config) so that design-time factories
+# resolve AddJsonFile("<Name>.json") against that directory — no files are copied into the source tree.
+set -euo pipefail
+
+export PATH="${PATH}:/root/.dotnet/tools"
+dotnet tool install dotnet-ef --global --verbosity quiet || dotnet tool update dotnet-ef --global --verbosity quiet
+
+ROOT="/src/Source"
+
+dotnet restore "${ROOT}/NexusForever.slnx"
+
+# Run EF from /migrate-config so that design-time factories find the JSON files
+# via AddJsonFile("<Name>.json") resolving against the current working directory.
+# No files are copied into the source tree.
+cd /migrate-config
+
+dotnet ef database update --context AuthContext      --project "${ROOT}/NexusForever.WorldServer"
+dotnet ef database update --context CharacterContext --project "${ROOT}/NexusForever.WorldServer"
+dotnet ef database update --context WorldContext     --project "${ROOT}/NexusForever.WorldServer"
+
+dotnet ef database update --project "${ROOT}/NexusForever.Server.ChatServer"
+
+dotnet ef database update --project "${ROOT}/NexusForever.Server.GroupServer"
+
+echo "Database migrations finished."


### PR DESCRIPTION
**Add Docker Compose stack for full server deployment**

Introduces a complete Docker-based setup that mirrors the [official NexusForever server guide](https://www.emulator.ws/installation/server-guide), allowing the entire server stack to be stood up with a single command.

## What's included

**docker-compose.yml** — Orchestrates all services with explicit dependency ordering:
- **Infrastructure:** MariaDB 11.4 (fixed IP `172.26.240.10`) and RabbitMQ 3.13
- **One-shot setup:** `init` → `migrate` → `world-import` → `check-assets` pipeline that runs automatically before game servers start
- **Game servers:** `auth`, `sts`, `character-api`, `group` (default); `world`, `chat` (`--profile game`)
- **Tools:** `extractor`, `build-artifacts`, `launcher` (`--profile tools`)
- `auth` uses `socat` to relay `127.0.0.1:24000 → world:24000` for client compatibility

**init.sh**
- Generates all `docker/config/*.json` from `Source/**/*.example.json` via `jq` (substitutes DB, RabbitMQ, Character API connection details)
- Clones `NexusForever.WorldDatabase` and checks out a pinned revision (`342cb2e`) — the last commit fully covered by EF migrations

**import.sh**
- Imports all world database SQL files into `nexus_forever_world` after migrations complete
- Runs as a separate `world-import` service to enforce correct sequencing
- Captures and prints MariaDB error output per-file with a final error count summary

**migrate.sh**
- Installs `dotnet-ef` and runs `database update` for all five `DbContext`s (`Auth`, `Character`, `World`, `Chat`, `Group`)
- Runs from `/migrate-config` (mounted config) so design-time factories resolve JSON config files without touching the source tree

**01-databases.sql**
- Bootstrapped by MariaDB on first volume creation — creates all five databases and the `nexusforever` user

**README.md**
- Full reference for every file in docker, including all generated/gitignored paths (`config/`, `game-data/`, `world-database/`) with creation instructions and per-service usage

## Usage

```bash
# First time setup + game servers
docker compose up -d                        # runs init → migrate → world-import → check-assets
docker compose --profile game up -d        # starts world + chat after assets pass

# Extract game assets from WildStar client
WILDSTAR_DIR=/path/to/WildStar docker compose --profile tools run --rm extractor
```

Port bindings, credentials, and `WILDSTAR_DIR` are all overridable via .env.