### PR TITLE
Network: resolve packet handlers and messages from a DI scope

### DIFF
--- a/Source/NexusForever.AuthServer/Network/AuthSession.cs
+++ b/Source/NexusForever.AuthServer/Network/AuthSession.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net.Sockets;
+using Microsoft.Extensions.DependencyInjection;
 using NexusForever.Network.Auth.Message.Model;
 using NexusForever.Network.Message;
 using NexusForever.Network.Message.Model;
@@ -11,8 +12,9 @@ namespace NexusForever.AuthServer.Network
         #region Dependency Injection
 
         public AuthSession(
-            IMessageManager messageManager)
-            : base(messageManager)
+            IMessageManager messageManager,
+            IServiceScopeFactory serviceScopeFactory)
+            : base(messageManager, serviceScopeFactory)
         {
         }
 

--- a/Source/NexusForever.Network/Session/GameSession.cs
+++ b/Source/NexusForever.Network/Session/GameSession.cs
@@ -29,11 +29,14 @@ namespace NexusForever.Network.Session
         #region Dependency Injection
 
         private readonly IMessageManager messageManager;
+        private readonly IServiceScopeFactory serviceScopeFactory;
 
         public GameSession(
-            IMessageManager messageManager)
+            IMessageManager messageManager,
+            IServiceScopeFactory serviceScopeFactory)
         {
-            this.messageManager = messageManager;
+            this.messageManager    = messageManager;
+            this.serviceScopeFactory = serviceScopeFactory;
         }
 
         #endregion
@@ -180,15 +183,13 @@ namespace NexusForever.Network.Session
         {
             try
             {
-                //using IServiceScope serviceScope = CreateHandlePacketScope();
-                var serviceProvider = LegacyServiceProvider.Provider;
+                using IServiceScope serviceScope = serviceScopeFactory.CreateScope();
 
                 using var reader = new ClientGamePacketReader();
                 reader.Initialise(packet, encryption);
                 GameMessageOpcode opcode = reader.ReadHeader();
 
-                //IReadable message = serviceScope.ServiceProvider.GetKeyedService<IReadable>(opcode);
-                IReadable message = serviceProvider.GetKeyedService<IReadable>(opcode);
+                IReadable message = serviceScope.ServiceProvider.GetKeyedService<IReadable>(opcode);
                 if (message == null)
                 {
                     log.Warn($"Received unknown packet {opcode}(0x{opcode:X}.");
@@ -202,8 +203,7 @@ namespace NexusForever.Network.Session
                     return;
                 }
 
-                //object handler = serviceScope.ServiceProvider.GetService(handlerType);
-                object handler = serviceProvider.GetService(handlerType);
+                object handler = serviceScope.ServiceProvider.GetService(handlerType);
                 if (handler == null)
                 {
                     log.Warn($"Received unhandled packet {opcode}(0x{opcode:X}).");
@@ -242,11 +242,6 @@ namespace NexusForever.Network.Session
             {
                 log.Error(exception);
             }
-        }
-
-        protected virtual IServiceScope CreateHandlePacketScope()
-        {
-            return LegacyServiceProvider.Provider.CreateScope();
         }
 
         /// <summary>

--- a/Source/NexusForever.WorldServer/Network/WorldSession.cs
+++ b/Source/NexusForever.WorldServer/Network/WorldSession.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Sockets;
+using Microsoft.Extensions.DependencyInjection;
 using NexusForever.Cryptography;
 using NexusForever.Database.Auth.Model;
 using NexusForever.Database.Character.Model;
@@ -40,8 +41,9 @@ namespace NexusForever.WorldServer.Network
         public WorldSession(
             IMessageManager messageManager,
             INetworkManager<IWorldSession> networkManager,
-            ILoginQueueManager loginQueueManager)
-            : base(messageManager)
+            ILoginQueueManager loginQueueManager,
+            IServiceScopeFactory serviceScopeFactory)
+            : base(messageManager, serviceScopeFactory)
         {
             this.networkManager    = networkManager;
             this.loginQueueManager = loginQueueManager;


### PR DESCRIPTION
## Summary

- Injects `IServiceScopeFactory` into `GameSession` via constructor, replacing the `LegacyServiceProvider.Provider` static lookup in `HandlePacket`
- Creates a properly scoped `IServiceScope` per packet dispatch, so both the `IReadable` message model and handler instances (and any `IDisposable` dependencies) are correctly lifetime-managed
- Removes the now-unneeded `CreateHandlePacketScope()` virtual method, which was the planned vehicle for this change but was never activated
- Updates `AuthSession` and `WorldSession` constructors to pass `IServiceScopeFactory` through to the base

## Background

The code in `GameSession.HandlePacket` already had the correct approach in commented-out form — the static `LegacyServiceProvider.Provider` was a placeholder. All handler classes and `IReadable` message types are already registered as transients in the DI container; no registration changes were needed to make the scope work.

## Test plan

- [ ] Build passes with 0 errors
- [ ] Auth flow: client connects, `ClientHelloAuth` is received and dispatched correctly
- [ ] World flow: client connects through world server, character select packets dispatch correctly
- [ ] No handler resolutions return null that previously succeeded

Closes #476

🤖 Generated with [Claude Code](https://claude.com/claude-code)