### PR TITLE
Implement chase behavior in CombatAI

### DIFF
--- a/Source/NexusForever.Script.Main/AI/CombatAI.cs
+++ b/Source/NexusForever.Script.Main/AI/CombatAI.cs
@@ -1,4 +1,5 @@
-﻿using NexusForever.Game.Abstract.Combat;
+using System.Numerics;
+using NexusForever.Game.Abstract.Combat;
 using NexusForever.Game.Abstract.Entity;
 using NexusForever.Script.Template;
 using NexusForever.Script.Template.Filter;
@@ -10,6 +11,10 @@ namespace NexusForever.Script.Main.AI
     {
         private ICreatureEntity owner;
 
+        // Interval in seconds between chase path recalculations.
+        private const double ChaseUpdateInterval = 0.5d;
+        private double chaseTimer = 0d;
+
         public void OnLoad(ICreatureEntity owner)
         {
             this.owner = owner;
@@ -20,7 +25,21 @@ namespace NexusForever.Script.Main.AI
             if (!owner.IsAlive)
                 return;
 
-            // TODO
+            if (!owner.InCombat || owner.TargetGuid == null)
+                return;
+
+            chaseTimer -= lastTick;
+            if (chaseTimer > 0d)
+                return;
+            chaseTimer = ChaseUpdateInterval;
+
+            IUnitEntity target = owner.GetVisible<IUnitEntity>(owner.TargetGuid.Value);
+            if (target == null || !target.IsAlive)
+                return;
+
+            float distance = Vector3.Distance(owner.Position, target.Position);
+            if (distance > owner.HitRadius + target.HitRadius)
+                owner.MovementManager.Follow(target, target.HitRadius);
         }
 
         public void OnThreatAddTarget(IHostileEntity hostile)


### PR DESCRIPTION
## Summary

- `CombatAI.Update()` now moves a creature toward its current target when in combat and out of melee range, using the existing `MovementManager.Follow()` / `DirectMovementGenerator` infrastructure
- Chase paths are recalculated every 500 ms so the creature tracks a moving target without flooding the client with movement commands
- The `IsAlive`, `InCombat`, and `TargetGuid` guards ensure the path is only recalculated when the creature has a valid live target

## What this doesn't include

Spell casting is intentionally deferred. `Creature2Entry.Spell4IdActivate00–03` are interaction/activation spells (used when a player right-clicks an NPC), not combat abilities. The actual per-creature combat AI is defined via `Creature2Entry.Creature2ActionSetId → Creature2ActionEntry`, and that action set system has no game-layer implementation yet. Adding spell casting without that system would use the wrong data source.

## Test plan

- [ ] Spawn a hostile creature near a player — creature should walk toward the player once it enters combat
- [ ] Confirm creature stops when it reaches melee range (hit radii touching)
- [ ] Confirm creature re-chases if the player moves away
- [ ] Confirm creature does nothing when out of combat (threat list empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)