### PR TITLE
Generalise prerequisite evaluation and spell contexts

### DIFF
--- a/Source/NexusForever.Game.Abstract/Prerequisite/IPrerequisiteCheck.cs
+++ b/Source/NexusForever.Game.Abstract/Prerequisite/IPrerequisiteCheck.cs
@@ -5,6 +5,6 @@ namespace NexusForever.Game.Abstract.Prerequisite
 {
     public interface IPrerequisiteCheck
     {
-        bool Meets(IPlayer player, PrerequisiteComparison comparison, uint value, uint objectId, IPrerequisiteParameters parameters);
+        bool Meets(IUnitEntity subject, PrerequisiteComparison comparison, uint value, uint objectId, IPrerequisiteParameters parameters);
     }
 }

--- a/Source/NexusForever.Game.Abstract/Prerequisite/IPrerequisiteManager.cs
+++ b/Source/NexusForever.Game.Abstract/Prerequisite/IPrerequisiteManager.cs
@@ -5,13 +5,18 @@ namespace NexusForever.Game.Abstract.Prerequisite
     public interface IPrerequisiteManager
     {
         /// <summary>
-        /// Checks if <see cref="IPlayer"/> meets supplied prerequisite.
+        /// Checks if <see cref="IUnitEntity"/> meets supplied prerequisite.
         /// </summary>
-        bool Meets(IPlayer player, uint prerequisiteId);
+        bool Meets(IUnitEntity subject, uint prerequisiteId);
 
         /// <summary>
-        /// Checks if <see cref="IPlayer"/> meets supplied prerequisite.
+        /// Checks if <see cref="IUnitEntity"/> meets supplied prerequisite with a secondary unit context.
         /// </summary>
-        bool Meets(IPlayer player, uint prerequisiteId, IPrerequisiteParameters parameters);
+        bool Meets(IUnitEntity subject, uint prerequisiteId, IUnitEntity secondaryUnit);
+
+        /// <summary>
+        /// Checks if <see cref="IUnitEntity"/> meets supplied prerequisite.
+        /// </summary>
+        bool Meets(IUnitEntity subject, uint prerequisiteId, IPrerequisiteParameters parameters);
     }
 }

--- a/Source/NexusForever.Game.Abstract/Prerequisite/IPrerequisiteManager.cs
+++ b/Source/NexusForever.Game.Abstract/Prerequisite/IPrerequisiteManager.cs
@@ -10,9 +10,9 @@ namespace NexusForever.Game.Abstract.Prerequisite
         bool Meets(IUnitEntity subject, uint prerequisiteId);
 
         /// <summary>
-        /// Checks if <see cref="IUnitEntity"/> meets supplied prerequisite with a secondary unit context.
+        /// Checks if <see cref="IUnitEntity"/> meets supplied prerequisite with a target context.
         /// </summary>
-        bool Meets(IUnitEntity subject, uint prerequisiteId, IUnitEntity secondaryUnit);
+        bool Meets(IUnitEntity subject, uint prerequisiteId, IUnitEntity target);
 
         /// <summary>
         /// Checks if <see cref="IUnitEntity"/> meets supplied prerequisite.

--- a/Source/NexusForever.Game.Abstract/Prerequisite/IPrerequisiteParameters.cs
+++ b/Source/NexusForever.Game.Abstract/Prerequisite/IPrerequisiteParameters.cs
@@ -1,9 +1,12 @@
 ﻿using NexusForever.Game.Abstract.Entity;
+using NexusForever.Network.World.Message.Static;
 
 namespace NexusForever.Game.Abstract.Prerequisite
 {
     public interface IPrerequisiteParameters
     {
-        public IUnitEntity SecondaryUnit { get; set; }
+        public CastResult? CastResult { get; set; }
+        public IUnitEntity Target { get; set; }
+        public ushort? TaxiNode { get; set; }
     }
 }

--- a/Source/NexusForever.Game.Abstract/Prerequisite/IPrerequisiteParameters.cs
+++ b/Source/NexusForever.Game.Abstract/Prerequisite/IPrerequisiteParameters.cs
@@ -1,12 +1,9 @@
 ﻿using NexusForever.Game.Abstract.Entity;
-using NexusForever.Network.World.Message.Static;
 
 namespace NexusForever.Game.Abstract.Prerequisite
 {
     public interface IPrerequisiteParameters
     {
-        public CastResult? CastResult { get; set; }
-        public IUnitEntity Target { get; set; }
-        public ushort? TaxiNode { get; set; }
+        public IUnitEntity SecondaryUnit { get; set; }
     }
 }

--- a/Source/NexusForever.Game.Abstract/Spell/Info/ISpellInfo.cs
+++ b/Source/NexusForever.Game.Abstract/Spell/Info/ISpellInfo.cs
@@ -15,9 +15,9 @@ namespace NexusForever.Game.Abstract.Spell.Info
         SpellCoolDownEntry GlobalCooldown { get; }
         Spell4StackGroupEntry StackGroup { get; }
         PrerequisiteEntry CasterCastPrerequisite { get; }
-        PrerequisiteEntry TargetCastPrerequisites { get; }
-        PrerequisiteEntry CasterPersistencePrerequisites { get; }
-        PrerequisiteEntry TargetPersistencePrerequisites { get; }
+        PrerequisiteEntry TargetCastPrerequisite { get; }
+        PrerequisiteEntry CasterPersistencePrerequisite { get; }
+        PrerequisiteEntry TargetPersistencePrerequisite { get; }
         List<PrerequisiteEntry> PrerequisiteRunners { get; }
 
         List<TelegraphDamageEntry> Telegraphs { get; }

--- a/Source/NexusForever.Game.Static/Prerequisite/PrerequisiteComparison.cs
+++ b/Source/NexusForever.Game.Static/Prerequisite/PrerequisiteComparison.cs
@@ -4,9 +4,9 @@
     {
         Equal              = 1,
         NotEqual           = 2,
-        GreaterThanOrEqual = 3,
-        GreaterThan        = 4,
-        LessThanOrEqual    = 5,
-        LessThan           = 6
+        GreaterThan        = 3,
+        GreaterThanOrEqual = 4,
+        LessThan           = 5,
+        LessThanOrEqual    = 6
     }
 }

--- a/Source/NexusForever.Game/Prerequisite/Check/PrerequisiteCheckAchievementState.cs
+++ b/Source/NexusForever.Game/Prerequisite/Check/PrerequisiteCheckAchievementState.cs
@@ -20,8 +20,11 @@ namespace NexusForever.Game.Prerequisite.Check
 
         #endregion
 
-        public bool Meets(IPlayer player, PrerequisiteComparison comparison, uint value, uint objectId, IPrerequisiteParameters parameters)
+        public bool Meets(IUnitEntity subject, PrerequisiteComparison comparison, uint value, uint objectId, IPrerequisiteParameters parameters)
         {
+            if (subject is not IPlayer player)
+                return false;
+
             switch (comparison)
             {
                 case PrerequisiteComparison.NotEqual:

--- a/Source/NexusForever.Game/Prerequisite/Check/PrerequisiteCheckActionSetSpell.cs
+++ b/Source/NexusForever.Game/Prerequisite/Check/PrerequisiteCheckActionSetSpell.cs
@@ -22,8 +22,11 @@ namespace NexusForever.Game.Prerequisite.Check
 
         #endregion
 
-        public bool Meets(IPlayer player, PrerequisiteComparison comparison, uint value, uint objectId, IPrerequisiteParameters parameters)
+        public bool Meets(IUnitEntity subject, PrerequisiteComparison comparison, uint value, uint objectId, IPrerequisiteParameters parameters)
         {
+            if (subject is not IPlayer player)
+                return false;
+
             IActionSet actionSet = player.SpellManager.GetActionSet(player.SpellManager.ActiveActionSet);
             if (actionSet == null)
                 return false;

--- a/Source/NexusForever.Game/Prerequisite/Check/PrerequisiteCheckBaseFaction.cs
+++ b/Source/NexusForever.Game/Prerequisite/Check/PrerequisiteCheckBaseFaction.cs
@@ -21,14 +21,14 @@ namespace NexusForever.Game.Prerequisite.Check
 
         #endregion
 
-        public bool Meets(IPlayer player, PrerequisiteComparison comparison, uint value, uint objectId, IPrerequisiteParameters parameters)
+        public bool Meets(IUnitEntity subject, PrerequisiteComparison comparison, uint value, uint objectId, IPrerequisiteParameters parameters)
         {
             switch (comparison)
             {
                 case PrerequisiteComparison.Equal:
-                    return player.Faction1 == (Faction)value;
+                    return subject.Faction1 == (Faction)value;
                 case PrerequisiteComparison.NotEqual:
-                    return player.Faction1 != (Faction)value;
+                    return subject.Faction1 != (Faction)value;
                 default:
                     log.LogWarning($"Unhandled PrerequisiteComparison {comparison} for {PrerequisiteType.BaseFaction}!");
                     return false;

--- a/Source/NexusForever.Game/Prerequisite/Check/PrerequisiteCheckClass.cs
+++ b/Source/NexusForever.Game/Prerequisite/Check/PrerequisiteCheckClass.cs
@@ -21,8 +21,11 @@ namespace NexusForever.Game.Prerequisite.Check
 
         #endregion
 
-        public bool Meets(IPlayer player, PrerequisiteComparison comparison, uint value, uint objectId, IPrerequisiteParameters parameters)
+        public bool Meets(IUnitEntity subject, PrerequisiteComparison comparison, uint value, uint objectId, IPrerequisiteParameters parameters)
         {
+            if (subject is not IPlayer player)
+                return false;
+
             switch (comparison)
             {
                 case PrerequisiteComparison.Equal:
@@ -31,7 +34,7 @@ namespace NexusForever.Game.Prerequisite.Check
                     return player.Class != (Class)value;
                 default:
                     log.LogWarning($"Unhandled PrerequisiteComparison {comparison} for {PrerequisiteType.Class}!");
-                    return true;
+                    return false;
             }
         }
     }

--- a/Source/NexusForever.Game/Prerequisite/Check/PrerequisiteCheckGender.cs
+++ b/Source/NexusForever.Game/Prerequisite/Check/PrerequisiteCheckGender.cs
@@ -21,8 +21,11 @@ namespace NexusForever.Game.Prerequisite.Check
 
         #endregion
 
-        public bool Meets(IPlayer player, PrerequisiteComparison comparison, uint value, uint objectId, IPrerequisiteParameters parameters)
+        public bool Meets(IUnitEntity subject, PrerequisiteComparison comparison, uint value, uint objectId, IPrerequisiteParameters parameters)
         {
+            if (subject is not IPlayer player)
+                return false;
+
             switch (comparison)
             {
                 case PrerequisiteComparison.NotEqual:

--- a/Source/NexusForever.Game/Prerequisite/Check/PrerequisiteCheckHoverboardUsage.cs
+++ b/Source/NexusForever.Game/Prerequisite/Check/PrerequisiteCheckHoverboardUsage.cs
@@ -7,7 +7,7 @@ namespace NexusForever.Game.Prerequisite.Check
     [PrerequisiteCheck(PrerequisiteType.HoverboardUsage)]
     public class PrerequisiteCheckHoverboardUsage : IPrerequisiteCheck
     {
-        public bool Meets(IPlayer player, PrerequisiteComparison comparison, uint value, uint objectId, IPrerequisiteParameters parameters)
+        public bool Meets(IUnitEntity subject, PrerequisiteComparison comparison, uint value, uint objectId, IPrerequisiteParameters parameters)
         {
             // TODO: Only used in Mount check prerequisites. Its use is unknown.
 

--- a/Source/NexusForever.Game/Prerequisite/Check/PrerequisiteCheckInCombat.cs
+++ b/Source/NexusForever.Game/Prerequisite/Check/PrerequisiteCheckInCombat.cs
@@ -20,14 +20,14 @@ namespace NexusForever.Game.Prerequisite.Check
 
         #endregion
 
-        public bool Meets(IPlayer player, PrerequisiteComparison comparison, uint value, uint objectId, IPrerequisiteParameters parameters)
+        public bool Meets(IUnitEntity subject, PrerequisiteComparison comparison, uint value, uint objectId, IPrerequisiteParameters parameters)
         {
             switch (comparison)
             {
                 case PrerequisiteComparison.Equal:
-                    return player.InCombat;
+                    return subject.InCombat;
                 case PrerequisiteComparison.NotEqual:
-                    return !player.InCombat; 
+                    return !subject.InCombat;
                 default:
                     log.LogWarning($"Unhandled PrerequisiteComparison {comparison} for {PrerequisiteType.InCombat}!");
                     return false;

--- a/Source/NexusForever.Game/Prerequisite/Check/PrerequisiteCheckItemProficiency.cs
+++ b/Source/NexusForever.Game/Prerequisite/Check/PrerequisiteCheckItemProficiency.cs
@@ -21,8 +21,11 @@ namespace NexusForever.Game.Prerequisite.Check
 
         #endregion
 
-        public bool Meets(IPlayer player, PrerequisiteComparison comparison, uint value, uint objectId, IPrerequisiteParameters parameters)
+        public bool Meets(IUnitEntity subject, PrerequisiteComparison comparison, uint value, uint objectId, IPrerequisiteParameters parameters)
         {
+            if (subject is not IPlayer player)
+                return false;
+
             switch (comparison)
             {
                 case PrerequisiteComparison.NotEqual:

--- a/Source/NexusForever.Game/Prerequisite/Check/PrerequisiteCheckLevel.cs
+++ b/Source/NexusForever.Game/Prerequisite/Check/PrerequisiteCheckLevel.cs
@@ -20,22 +20,22 @@ namespace NexusForever.Game.Prerequisite.Check
 
         #endregion
 
-        public bool Meets(IPlayer player, PrerequisiteComparison comparison, uint value, uint objectId, IPrerequisiteParameters parameters)
+        public bool Meets(IUnitEntity subject, PrerequisiteComparison comparison, uint value, uint objectId, IPrerequisiteParameters parameters)
         {
             switch (comparison)
             {
                 case PrerequisiteComparison.Equal:
-                    return player.Level == value;
+                    return subject.Level == value;
                 case PrerequisiteComparison.NotEqual:
-                    return player.Level != value;
+                    return subject.Level != value;
                 case PrerequisiteComparison.GreaterThan:
-                    return player.Level > value;
+                    return subject.Level > value;
                 case PrerequisiteComparison.GreaterThanOrEqual:
-                    return player.Level >= value;
+                    return subject.Level >= value;
                 case PrerequisiteComparison.LessThan:
-                    return player.Level < value;
+                    return subject.Level < value;
                 case PrerequisiteComparison.LessThanOrEqual:
-                    return player.Level <= value;
+                    return subject.Level <= value;
                 default:
                     log.LogWarning($"Unhandled PrerequisiteComparison {comparison} for {PrerequisiteType.Level}!");
                     return false;

--- a/Source/NexusForever.Game/Prerequisite/Check/PrerequisiteCheckMountUsage.cs
+++ b/Source/NexusForever.Game/Prerequisite/Check/PrerequisiteCheckMountUsage.cs
@@ -7,7 +7,7 @@ namespace NexusForever.Game.Prerequisite.Check
     [PrerequisiteCheck(PrerequisiteType.MountUsage)]
     public class PrerequisiteCheckMountUsage : IPrerequisiteCheck
     {
-        public bool Meets(IPlayer player, PrerequisiteComparison comparison, uint value, uint objectId, IPrerequisiteParameters parameters)
+        public bool Meets(IUnitEntity subject, PrerequisiteComparison comparison, uint value, uint objectId, IPrerequisiteParameters parameters)
         {
             // TODO: Only used in Mount check prerequisites. Its use is unknown.
 

--- a/Source/NexusForever.Game/Prerequisite/Check/PrerequisiteCheckOtherPrerequisite.cs
+++ b/Source/NexusForever.Game/Prerequisite/Check/PrerequisiteCheckOtherPrerequisite.cs
@@ -23,14 +23,14 @@ namespace NexusForever.Game.Prerequisite.Check
 
         #endregion
 
-        public bool Meets(IPlayer player, PrerequisiteComparison comparison, uint value, uint objectId, IPrerequisiteParameters parameters)
+        public bool Meets(IUnitEntity subject, PrerequisiteComparison comparison, uint value, uint objectId, IPrerequisiteParameters parameters)
         {
             switch (comparison)
             {
                 case PrerequisiteComparison.NotEqual:
-                    return !prerequisiteManager.Meets(player, objectId);
+                    return !prerequisiteManager.Meets(subject, objectId, parameters);
                 case PrerequisiteComparison.Equal:
-                    return prerequisiteManager.Meets(player, objectId);
+                    return prerequisiteManager.Meets(subject, objectId, parameters);
                 default:
                     log.LogWarning($"Unhandled {comparison} for {PrerequisiteType.OtherPrerequisite}!");
                     return false;

--- a/Source/NexusForever.Game/Prerequisite/Check/PrerequisiteCheckPath.cs
+++ b/Source/NexusForever.Game/Prerequisite/Check/PrerequisiteCheckPath.cs
@@ -20,8 +20,11 @@ namespace NexusForever.Game.Prerequisite.Check
 
         #endregion
 
-        public bool Meets(IPlayer player, PrerequisiteComparison comparison, uint value, uint objectId, IPrerequisiteParameters parameters)
+        public bool Meets(IUnitEntity subject, PrerequisiteComparison comparison, uint value, uint objectId, IPrerequisiteParameters parameters)
         {
+            if (subject is not IPlayer player)
+                return false;
+
             switch (comparison)
             {
                 case PrerequisiteComparison.Equal:

--- a/Source/NexusForever.Game/Prerequisite/Check/PrerequisiteCheckPetFlair.cs
+++ b/Source/NexusForever.Game/Prerequisite/Check/PrerequisiteCheckPetFlair.cs
@@ -21,8 +21,11 @@ namespace NexusForever.Game.Prerequisite.Check
 
         #endregion
 
-        public bool Meets(IPlayer player, PrerequisiteComparison comparison, uint value, uint objectId, IPrerequisiteParameters parameters)
+        public bool Meets(IUnitEntity subject, PrerequisiteComparison comparison, uint value, uint objectId, IPrerequisiteParameters parameters)
         {
+            if (subject is not IPlayer player)
+                return false;
+
             switch (comparison)
             {
                 case PrerequisiteComparison.Equal:

--- a/Source/NexusForever.Game/Prerequisite/Check/PrerequisiteCheckPlane.cs
+++ b/Source/NexusForever.Game/Prerequisite/Check/PrerequisiteCheckPlane.cs
@@ -7,7 +7,7 @@ namespace NexusForever.Game.Prerequisite.Check
     [PrerequisiteCheck(PrerequisiteType.Plane)]
     public class PrerequisiteCheckPlane : IPrerequisiteCheck
     {
-        public bool Meets(IPlayer player, PrerequisiteComparison comparison, uint value, uint objectId, IPrerequisiteParameters parameters)
+        public bool Meets(IUnitEntity subject, PrerequisiteComparison comparison, uint value, uint objectId, IPrerequisiteParameters parameters)
         {
             // Unknown how this works at this time, but there is a Spell Effect called "ChangePlane". Could be related.
             // TODO: Investigate further.

--- a/Source/NexusForever.Game/Prerequisite/Check/PrerequisiteCheckPositionalRequirement.cs
+++ b/Source/NexusForever.Game/Prerequisite/Check/PrerequisiteCheckPositionalRequirement.cs
@@ -25,18 +25,18 @@ namespace NexusForever.Game.Prerequisite.Check
 
         public bool Meets(IUnitEntity subject, PrerequisiteComparison comparison, uint value, uint objectId, IPrerequisiteParameters parameters)
         {
-            if (parameters.SecondaryUnit == null || objectId == 0)
+            if (parameters.Target == null || objectId == 0)
                 return false;
 
             PositionalRequirementEntry entry = gameTableManager.PositionalRequirement.GetEntry(objectId);
             if (entry == null)
                 return false;
 
-            float x = MathF.Cos(-parameters.SecondaryUnit.Rotation.X);
-            float z = MathF.Sin(-parameters.SecondaryUnit.Rotation.X);
+            float x = MathF.Cos(-parameters.Target.Rotation.X);
+            float z = MathF.Sin(-parameters.Target.Rotation.X);
             Vector3 forward = new Vector3(x, 0, z);
 
-            Vector3 direction = Vector3.Normalize(subject.Position - parameters.SecondaryUnit.Position);
+            Vector3 direction = Vector3.Normalize(subject.Position - parameters.Target.Position);
             float dot = Vector3.Dot(direction, forward);
             float cross = Vector3.Cross(direction, forward).Y;
 

--- a/Source/NexusForever.Game/Prerequisite/Check/PrerequisiteCheckPositionalRequirement.cs
+++ b/Source/NexusForever.Game/Prerequisite/Check/PrerequisiteCheckPositionalRequirement.cs
@@ -23,20 +23,20 @@ namespace NexusForever.Game.Prerequisite.Check
             this.gameTableManager = gameTableManager;
         }
 
-        public bool Meets(IPlayer player, PrerequisiteComparison comparison, uint value, uint objectId, IPrerequisiteParameters parameters)
+        public bool Meets(IUnitEntity subject, PrerequisiteComparison comparison, uint value, uint objectId, IPrerequisiteParameters parameters)
         {
-            if (parameters.Target == null || objectId == 0)
+            if (parameters.SecondaryUnit == null || objectId == 0)
                 return false;
 
             PositionalRequirementEntry entry = gameTableManager.PositionalRequirement.GetEntry(objectId);
             if (entry == null)
                 return false;
 
-            float x = MathF.Cos(-parameters.Target.Rotation.X);
-            float z = MathF.Sin(-parameters.Target.Rotation.X);
+            float x = MathF.Cos(-parameters.SecondaryUnit.Rotation.X);
+            float z = MathF.Sin(-parameters.SecondaryUnit.Rotation.X);
             Vector3 forward = new Vector3(x, 0, z);
 
-            Vector3 direction = Vector3.Normalize(player.Position - parameters.Target.Position);
+            Vector3 direction = Vector3.Normalize(subject.Position - parameters.SecondaryUnit.Position);
             float dot = Vector3.Dot(direction, forward);
             float cross = Vector3.Cross(direction, forward).Y;
 

--- a/Source/NexusForever.Game/Prerequisite/Check/PrerequisiteCheckPurchasedTitle.cs
+++ b/Source/NexusForever.Game/Prerequisite/Check/PrerequisiteCheckPurchasedTitle.cs
@@ -20,8 +20,11 @@ namespace NexusForever.Game.Prerequisite.Check
 
         #endregion
 
-        public bool Meets(IPlayer player, PrerequisiteComparison comparison, uint value, uint objectId, IPrerequisiteParameters parameters)
+        public bool Meets(IUnitEntity subject, PrerequisiteComparison comparison, uint value, uint objectId, IPrerequisiteParameters parameters)
         {
+            if (subject is not IPlayer player)
+                return false;
+
             switch (comparison)
             {
                 case PrerequisiteComparison.Equal:
@@ -30,7 +33,7 @@ namespace NexusForever.Game.Prerequisite.Check
                     return !player.TitleManager.HasTitle((ushort)objectId);
                 default:
                     log.LogWarning($"Unhandled PrerequisiteComparison {comparison} for {PrerequisiteType.PurchasedTitle}!");
-                    return true;
+                    return false;
             }
         }
     }

--- a/Source/NexusForever.Game/Prerequisite/Check/PrerequisiteCheckQuestState.cs
+++ b/Source/NexusForever.Game/Prerequisite/Check/PrerequisiteCheckQuestState.cs
@@ -21,8 +21,11 @@ namespace NexusForever.Game.Prerequisite.Check
 
         #endregion
 
-        public bool Meets(IPlayer player, PrerequisiteComparison comparison, uint value, uint objectId, IPrerequisiteParameters parameters)
+        public bool Meets(IUnitEntity subject, PrerequisiteComparison comparison, uint value, uint objectId, IPrerequisiteParameters parameters)
         {
+            if (subject is not IPlayer player)
+                return false;
+
             switch (comparison)
             {
                 case PrerequisiteComparison.Equal:

--- a/Source/NexusForever.Game/Prerequisite/Check/PrerequisiteCheckRace.cs
+++ b/Source/NexusForever.Game/Prerequisite/Check/PrerequisiteCheckRace.cs
@@ -21,8 +21,11 @@ namespace NexusForever.Game.Prerequisite.Check
 
         #endregion
 
-        public bool Meets(IPlayer player, PrerequisiteComparison comparison, uint value, uint objectId, IPrerequisiteParameters parameters)
+        public bool Meets(IUnitEntity subject, PrerequisiteComparison comparison, uint value, uint objectId, IPrerequisiteParameters parameters)
         {
+            if (subject is not IPlayer player)
+                return false;
+
             switch (comparison)
             {
                 case PrerequisiteComparison.Equal:

--- a/Source/NexusForever.Game/Prerequisite/Check/PrerequisiteCheckRapidTransport.cs
+++ b/Source/NexusForever.Game/Prerequisite/Check/PrerequisiteCheckRapidTransport.cs
@@ -1,94 +1,18 @@
-﻿using System.Numerics;
-using NexusForever.Game.Abstract;
-using NexusForever.Game.Abstract.Entity;
+﻿using NexusForever.Game.Abstract.Entity;
 using NexusForever.Game.Abstract.Prerequisite;
-using NexusForever.Game.Static.Account;
-using NexusForever.Game.Static.Entity;
 using NexusForever.Game.Static.Prerequisite;
-using NexusForever.GameTable;
-using NexusForever.GameTable.Model;
-using NexusForever.Network.World.Message.Static;
 
 namespace NexusForever.Game.Prerequisite.Check
 {
     [PrerequisiteCheck(PrerequisiteType.RapidTransport)]
     public class PrerequisiteCheckRapidTransport : IPrerequisiteCheck
     {
-        #region Dependency Injection
-
-        private readonly IGameTableManager gameTableManager;
-        private readonly IRapidTransportCostCalculator rapidTransportCostCalculator;
-
-        public PrerequisiteCheckRapidTransport(
-            IGameTableManager gameTableManager,
-            IRapidTransportCostCalculator rapidTransportCostCalculator)
+        public bool Meets(IUnitEntity subject, PrerequisiteComparison comparison, uint value, uint objectId, IPrerequisiteParameters parameters)
         {
-            this.gameTableManager             = gameTableManager;
-            this.rapidTransportCostCalculator = rapidTransportCostCalculator;
-        }
+            // TODO: Prerequisite 37806 is the only known type 269 use. It prevents recall while the client is
+            // in its "Unhealthy Time" state. The corresponding server state and operand semantics are unknown.
 
-        #endregion
-
-        public bool Meets(IPlayer player, PrerequisiteComparison comparison, uint value, uint objectId, IPrerequisiteParameters parameters)
-        {
-            if (!CanAffordRapidTransport(player, parameters))
-            {
-                parameters.CastResult ??= CastResult.RapidTransportInvalid;
-                return false;
-            }
-
-            return true;
-        }
-
-        private bool CanAffordRapidTransport(IPlayer player, IPrerequisiteParameters parameters)
-        {
-            if (parameters.TaxiNode == null)
-                return false;
-
-            TaxiNodeEntry taxiNodeEntry = gameTableManager.TaxiNode.GetEntry(parameters.TaxiNode.Value);
-            if (taxiNodeEntry == null)
-                return false;
-
-            if (player.Level < taxiNodeEntry.AutoUnlockLevel)
-                return false;
-
-            WorldLocation2Entry worldLocation = gameTableManager.WorldLocation2.GetEntry(taxiNodeEntry.WorldLocation2Id);
-            if (worldLocation == null)
-                return false;
-
-            var destinationPosition = new Vector3(worldLocation.Position0, worldLocation.Position1, worldLocation.Position2);
-            if (Vector3.Distance(player.Position, destinationPosition) < 200f)
-                return false;
-
-            GameFormulaEntry spellEntry = gameTableManager.GameFormula.GetEntry(1307);
-            if (spellEntry == null)
-                return false;
-
-            if (player.SpellManager.GetSpellCooldown(spellEntry.Dataint0) > 0d)
-            {
-                ulong? serviceTokenPrice = rapidTransportCostCalculator.CalculateServiceTokenCost(parameters.TaxiNode.Value);
-                if (serviceTokenPrice == null)
-                    return false;
-
-                if (!player.Account.CurrencyManager.CanAfford(AccountCurrencyType.ServiceToken, serviceTokenPrice.Value))
-                {
-                    parameters.CastResult = CastResult.ServiceTokensInsufficentFunds;
-                    return false;
-                }
-            }
-            else
-            {
-                ulong? creditPrice = rapidTransportCostCalculator.CalculateCreditCost(parameters.TaxiNode.Value, player.Map.Entry.Id, player.Position);
-                if (creditPrice == null)
-                    return false;
-
-                if (!player.CurrencyManager.CanAfford(CurrencyType.Credits, creditPrice.Value))
-                {
-                    parameters.CastResult = CastResult.CasterVitalCostMoney;
-                    return false;
-                }
-            }
-
+            // Return true until implemented so unsupported prerequisites do not block spell casts.
             return true;
         }
     }

--- a/Source/NexusForever.Game/Prerequisite/Check/PrerequisiteCheckRapidTransport.cs
+++ b/Source/NexusForever.Game/Prerequisite/Check/PrerequisiteCheckRapidTransport.cs
@@ -1,18 +1,97 @@
-﻿using NexusForever.Game.Abstract.Entity;
+﻿using System.Numerics;
+using NexusForever.Game.Abstract;
+using NexusForever.Game.Abstract.Entity;
 using NexusForever.Game.Abstract.Prerequisite;
+using NexusForever.Game.Static.Account;
+using NexusForever.Game.Static.Entity;
 using NexusForever.Game.Static.Prerequisite;
+using NexusForever.GameTable;
+using NexusForever.GameTable.Model;
+using NexusForever.Network.World.Message.Static;
 
 namespace NexusForever.Game.Prerequisite.Check
 {
     [PrerequisiteCheck(PrerequisiteType.RapidTransport)]
     public class PrerequisiteCheckRapidTransport : IPrerequisiteCheck
     {
+        #region Dependency Injection
+
+        private readonly IGameTableManager gameTableManager;
+        private readonly IRapidTransportCostCalculator rapidTransportCostCalculator;
+
+        public PrerequisiteCheckRapidTransport(
+            IGameTableManager gameTableManager,
+            IRapidTransportCostCalculator rapidTransportCostCalculator)
+        {
+            this.gameTableManager             = gameTableManager;
+            this.rapidTransportCostCalculator = rapidTransportCostCalculator;
+        }
+
+        #endregion
+
         public bool Meets(IUnitEntity subject, PrerequisiteComparison comparison, uint value, uint objectId, IPrerequisiteParameters parameters)
         {
-            // TODO: Prerequisite 37806 is the only known type 269 use. It prevents recall while the client is
-            // in its "Unhealthy Time" state. The corresponding server state and operand semantics are unknown.
+            if (subject is not IPlayer player)
+                return false;
 
-            // Return true until implemented so unsupported prerequisites do not block spell casts.
+            if (!CanAffordRapidTransport(player, parameters))
+            {
+                parameters.CastResult ??= CastResult.RapidTransportInvalid;
+                return false;
+            }
+
+            return true;
+        }
+
+        private bool CanAffordRapidTransport(IPlayer player, IPrerequisiteParameters parameters)
+        {
+            if (parameters.TaxiNode == null)
+                return false;
+
+            TaxiNodeEntry taxiNodeEntry = gameTableManager.TaxiNode.GetEntry(parameters.TaxiNode.Value);
+            if (taxiNodeEntry == null)
+                return false;
+
+            if (player.Level < taxiNodeEntry.AutoUnlockLevel)
+                return false;
+
+            WorldLocation2Entry worldLocation = gameTableManager.WorldLocation2.GetEntry(taxiNodeEntry.WorldLocation2Id);
+            if (worldLocation == null)
+                return false;
+
+            var destinationPosition = new Vector3(worldLocation.Position0, worldLocation.Position1, worldLocation.Position2);
+            if (Vector3.Distance(player.Position, destinationPosition) < 200f)
+                return false;
+
+            GameFormulaEntry spellEntry = gameTableManager.GameFormula.GetEntry(1307);
+            if (spellEntry == null)
+                return false;
+
+            if (player.SpellManager.GetSpellCooldown(spellEntry.Dataint0) > 0d)
+            {
+                ulong? serviceTokenPrice = rapidTransportCostCalculator.CalculateServiceTokenCost(parameters.TaxiNode.Value);
+                if (serviceTokenPrice == null)
+                    return false;
+
+                if (!player.Account.CurrencyManager.CanAfford(AccountCurrencyType.ServiceToken, serviceTokenPrice.Value))
+                {
+                    parameters.CastResult = CastResult.ServiceTokensInsufficentFunds;
+                    return false;
+                }
+            }
+            else
+            {
+                ulong? creditPrice = rapidTransportCostCalculator.CalculateCreditCost(parameters.TaxiNode.Value, player.Map.Entry.Id, player.Position);
+                if (creditPrice == null)
+                    return false;
+
+                if (!player.CurrencyManager.CanAfford(CurrencyType.Credits, creditPrice.Value))
+                {
+                    parameters.CastResult = CastResult.CasterVitalCostMoney;
+                    return false;
+                }
+            }
+
             return true;
         }
     }

--- a/Source/NexusForever.Game/Prerequisite/Check/PrerequisiteCheckSpell.cs
+++ b/Source/NexusForever.Game/Prerequisite/Check/PrerequisiteCheckSpell.cs
@@ -21,7 +21,7 @@ namespace NexusForever.Game.Prerequisite.Check
 
         #endregion
 
-        public bool Meets(IPlayer player, PrerequisiteComparison comparison, uint value, uint objectId, IPrerequisiteParameters parameters)
+        public bool Meets(IUnitEntity subject, PrerequisiteComparison comparison, uint value, uint objectId, IPrerequisiteParameters parameters)
         {
             if (value == 0 && objectId == 0)
                 return false;
@@ -29,9 +29,9 @@ namespace NexusForever.Game.Prerequisite.Check
             switch (comparison)
             {
                 case PrerequisiteComparison.Equal:
-                    return player.HasSpell(s => s.Spell4Id == value, out ISpell equalSpell);
+                    return subject.HasSpell(s => s.Spell4Id == value, out ISpell equalSpell);
                 case PrerequisiteComparison.NotEqual:
-                    return !player.HasSpell(s => s.Spell4Id == value, out ISpell notEqualSpell);
+                    return !subject.HasSpell(s => s.Spell4Id == value, out ISpell notEqualSpell);
                 default:
                     log.LogWarning($"Unhandled PrerequisiteComparison {comparison} for {PrerequisiteType.UnderSpell}!");
                     return false;

--- a/Source/NexusForever.Game/Prerequisite/Check/PrerequisiteCheckSpellBaseId.cs
+++ b/Source/NexusForever.Game/Prerequisite/Check/PrerequisiteCheckSpellBaseId.cs
@@ -20,8 +20,11 @@ namespace NexusForever.Game.Prerequisite.Check
 
         #endregion
 
-        public bool Meets(IPlayer player, PrerequisiteComparison comparison, uint value, uint objectId, IPrerequisiteParameters parameters)
+        public bool Meets(IUnitEntity subject, PrerequisiteComparison comparison, uint value, uint objectId, IPrerequisiteParameters parameters)
         {
+            if (subject is not IPlayer player)
+                return false;
+
             switch (comparison)
             {
                 case PrerequisiteComparison.NotEqual:

--- a/Source/NexusForever.Game/Prerequisite/Check/PrerequisiteCheckSpellObj.cs
+++ b/Source/NexusForever.Game/Prerequisite/Check/PrerequisiteCheckSpellObj.cs
@@ -20,8 +20,11 @@ namespace NexusForever.Game.Prerequisite.Check
 
         #endregion
 
-        public bool Meets(IPlayer player, PrerequisiteComparison comparison, uint value, uint objectId, IPrerequisiteParameters parameters)
+        public bool Meets(IUnitEntity subject, PrerequisiteComparison comparison, uint value, uint objectId, IPrerequisiteParameters parameters)
         {
+            if (subject is not IPlayer player)
+                return false;
+
             // TODO: Confirm how the objectId is calculated. It seems like this check always checks for a Spell that is determined by an objectId.
 
             // Error message is "Spell requirement not met"

--- a/Source/NexusForever.Game/Prerequisite/Check/PrerequisiteCheckVital.cs
+++ b/Source/NexusForever.Game/Prerequisite/Check/PrerequisiteCheckVital.cs
@@ -21,22 +21,22 @@ namespace NexusForever.Game.Prerequisite.Check
 
         #endregion
 
-        public bool Meets(IPlayer player, PrerequisiteComparison comparison, uint value, uint objectId, IPrerequisiteParameters parameters)
+        public bool Meets(IUnitEntity subject, PrerequisiteComparison comparison, uint value, uint objectId, IPrerequisiteParameters parameters)
         {
             switch (comparison)
             {
                 case PrerequisiteComparison.Equal:
-                    return player.GetVitalValue((Vital)objectId) == value;
+                    return subject.GetVitalValue((Vital)objectId) == value;
                 case PrerequisiteComparison.NotEqual:
-                    return player.GetVitalValue((Vital)objectId) != value;
+                    return subject.GetVitalValue((Vital)objectId) != value;
                 case PrerequisiteComparison.GreaterThanOrEqual:
-                    return player.GetVitalValue((Vital)objectId) >= value;
+                    return subject.GetVitalValue((Vital)objectId) >= value;
                 case PrerequisiteComparison.GreaterThan:
-                    return player.GetVitalValue((Vital)objectId) > value;
+                    return subject.GetVitalValue((Vital)objectId) > value;
                 case PrerequisiteComparison.LessThanOrEqual:
-                    return player.GetVitalValue((Vital)objectId) <= value;
+                    return subject.GetVitalValue((Vital)objectId) <= value;
                 case PrerequisiteComparison.LessThan:
-                    return player.GetVitalValue((Vital)objectId) < value;
+                    return subject.GetVitalValue((Vital)objectId) < value;
                 default:
                     log.LogWarning($"Unhandled {comparison} for {PrerequisiteType.Vital}!");
                     return false;

--- a/Source/NexusForever.Game/Prerequisite/PrerequisiteManager.cs
+++ b/Source/NexusForever.Game/Prerequisite/PrerequisiteManager.cs
@@ -33,18 +33,28 @@ namespace NexusForever.Game.Prerequisite
         #endregion
 
         /// <summary>
-        /// Checks if <see cref="IPlayer"/> meets supplied prerequisite.
+        /// Checks if <see cref="IUnitEntity"/> meets supplied prerequisite.
         /// </summary>
-        public bool Meets(IPlayer player, uint prerequisiteId)
+        public bool Meets(IUnitEntity subject, uint prerequisiteId)
         {
             IPrerequisiteParameters parameters = prerequisiteParametersFactory.Resolve();
-            return Meets(player, prerequisiteId, parameters);
+            return Meets(subject, prerequisiteId, parameters);
         }
 
         /// <summary>
-        /// Checks if <see cref="IPlayer"/> meets supplied prerequisite.
+        /// Checks if <see cref="IUnitEntity"/> meets supplied prerequisite with a secondary unit context.
         /// </summary>
-        public bool Meets(IPlayer player, uint prerequisiteId, IPrerequisiteParameters parameters)
+        public bool Meets(IUnitEntity subject, uint prerequisiteId, IUnitEntity secondaryUnit)
+        {
+            IPrerequisiteParameters parameters = prerequisiteParametersFactory.Resolve();
+            parameters.SecondaryUnit = secondaryUnit;
+            return Meets(subject, prerequisiteId, parameters);
+        }
+
+        /// <summary>
+        /// Checks if <see cref="IUnitEntity"/> meets supplied prerequisite.
+        /// </summary>
+        public bool Meets(IUnitEntity subject, uint prerequisiteId, IPrerequisiteParameters parameters)
         {
             PrerequisiteEntry entry = gameTableManager.Prerequisite.GetEntry(prerequisiteId);
             if (entry == null)
@@ -53,16 +63,16 @@ namespace NexusForever.Game.Prerequisite
             switch (entry.Flags)
             {
                 case EvaluationMode.EvaluateAND:
-                    return MeetsEvaluateAnd(player, prerequisiteId, entry, parameters);
+                    return MeetsEvaluateAnd(subject, prerequisiteId, entry, parameters);
                 case EvaluationMode.EvaluateOR:
-                    return MeetsEvaluateOr(player, prerequisiteId, entry, parameters);
+                    return MeetsEvaluateOr(subject, prerequisiteId, entry, parameters);
                 default:
                     log.LogTrace($"Unhandled EvaluationMode {entry.Flags}");
                     return false;
             }
         }
 
-        private bool MeetsEvaluateAnd(IPlayer player, uint prerequisiteId, PrerequisiteEntry entry, IPrerequisiteParameters parameters)
+        private bool MeetsEvaluateAnd(IUnitEntity subject, uint prerequisiteId, PrerequisiteEntry entry, IPrerequisiteParameters parameters)
         {
             for (int i = 0; i < entry.PrerequisiteTypeId.Length; i++)
             {
@@ -71,9 +81,9 @@ namespace NexusForever.Game.Prerequisite
                     continue;
 
                 PrerequisiteComparison comparison = entry.PrerequisiteComparisonId[i];
-                if (!Meets(player, type, comparison, entry.Value[i], entry.ObjectId[i], parameters))
+                if (!Meets(subject, type, comparison, entry.Value[i], entry.ObjectId[i], parameters))
                 {
-                    log.LogTrace($"Player {player.Name} failed prerequisite AND check ({prerequisiteId}) {type}, {comparison}, {entry.Value[i]}, {entry.ObjectId[i]}");
+                    log.LogTrace($"Unit {subject.Guid} failed prerequisite AND check ({prerequisiteId}) {type}, {comparison}, {entry.Value[i]}, {entry.ObjectId[i]}");
                     return false;
                 }
             }
@@ -81,7 +91,7 @@ namespace NexusForever.Game.Prerequisite
             return true;
         }
 
-        private bool MeetsEvaluateOr(IPlayer player, uint prerequisiteId, PrerequisiteEntry entry, IPrerequisiteParameters parameters)
+        private bool MeetsEvaluateOr(IUnitEntity subject, uint prerequisiteId, PrerequisiteEntry entry, IPrerequisiteParameters parameters)
         {
             for (int i = 0; i < entry.PrerequisiteTypeId.Length; i++)
             {
@@ -89,15 +99,15 @@ namespace NexusForever.Game.Prerequisite
                 if (type == PrerequisiteType.None)
                     continue;
 
-                if (Meets(player, type, entry.PrerequisiteComparisonId[i], entry.Value[i], entry.ObjectId[i], parameters))
+                if (Meets(subject, type, entry.PrerequisiteComparisonId[i], entry.Value[i], entry.ObjectId[i], parameters))
                     return true;
             }
 
-            log.LogTrace($"Player {player.Name} failed prerequisite OR check ({prerequisiteId})");
+            log.LogTrace($"Unit {subject.Guid} failed prerequisite OR check ({prerequisiteId})");
             return false;
         }
 
-        private bool Meets(IPlayer player, PrerequisiteType type, PrerequisiteComparison comparison, uint value, uint objectId, IPrerequisiteParameters parameters)
+        private bool Meets(IUnitEntity subject, PrerequisiteType type, PrerequisiteComparison comparison, uint value, uint objectId, IPrerequisiteParameters parameters)
         {
             IPrerequisiteCheck handler = serviceProvider.GetKeyedService<IPrerequisiteCheck>(type);
             if (handler == null)
@@ -106,7 +116,7 @@ namespace NexusForever.Game.Prerequisite
                 return false;
             }
 
-            return handler.Meets(player, comparison, value, objectId, parameters);
+            return handler.Meets(subject, comparison, value, objectId, parameters);
         }
     }
 }

--- a/Source/NexusForever.Game/Prerequisite/PrerequisiteManager.cs
+++ b/Source/NexusForever.Game/Prerequisite/PrerequisiteManager.cs
@@ -42,12 +42,12 @@ namespace NexusForever.Game.Prerequisite
         }
 
         /// <summary>
-        /// Checks if <see cref="IUnitEntity"/> meets supplied prerequisite with a secondary unit context.
+        /// Checks if <see cref="IUnitEntity"/> meets supplied prerequisite with a target context.
         /// </summary>
-        public bool Meets(IUnitEntity subject, uint prerequisiteId, IUnitEntity secondaryUnit)
+        public bool Meets(IUnitEntity subject, uint prerequisiteId, IUnitEntity target)
         {
             IPrerequisiteParameters parameters = prerequisiteParametersFactory.Resolve();
-            parameters.SecondaryUnit = secondaryUnit;
+            parameters.Target = target;
             return Meets(subject, prerequisiteId, parameters);
         }
 

--- a/Source/NexusForever.Game/Prerequisite/PrerequisiteParameters.cs
+++ b/Source/NexusForever.Game/Prerequisite/PrerequisiteParameters.cs
@@ -1,10 +1,13 @@
 ﻿using NexusForever.Game.Abstract.Entity;
 using NexusForever.Game.Abstract.Prerequisite;
+using NexusForever.Network.World.Message.Static;
 
 namespace NexusForever.Game.Prerequisite
 {
     public class PrerequisiteParameters : IPrerequisiteParameters
     {
-        public IUnitEntity SecondaryUnit { get; set; }
+        public CastResult? CastResult { get; set; }
+        public IUnitEntity Target { get; set; }
+        public ushort? TaxiNode { get; set; }
     }
 }

--- a/Source/NexusForever.Game/Prerequisite/PrerequisiteParameters.cs
+++ b/Source/NexusForever.Game/Prerequisite/PrerequisiteParameters.cs
@@ -1,13 +1,10 @@
 ﻿using NexusForever.Game.Abstract.Entity;
 using NexusForever.Game.Abstract.Prerequisite;
-using NexusForever.Network.World.Message.Static;
 
 namespace NexusForever.Game.Prerequisite
 {
     public class PrerequisiteParameters : IPrerequisiteParameters
     {
-        public CastResult? CastResult { get; set; }
-        public IUnitEntity Target { get; set; }
-        public ushort? TaxiNode { get; set; }
+        public IUnitEntity SecondaryUnit { get; set; }
     }
 }

--- a/Source/NexusForever.Game/Spell/Info/SpellInfo.cs
+++ b/Source/NexusForever.Game/Spell/Info/SpellInfo.cs
@@ -29,9 +29,9 @@ namespace NexusForever.Game.Spell.Info
         public SpellCoolDownEntry GlobalCooldown { get; private set; }
         public Spell4StackGroupEntry StackGroup { get; private set; }
         public PrerequisiteEntry CasterCastPrerequisite { get; private set; }
-        public PrerequisiteEntry TargetCastPrerequisites { get; private set; }
-        public PrerequisiteEntry CasterPersistencePrerequisites { get; private set; }
-        public PrerequisiteEntry TargetPersistencePrerequisites { get; private set; }
+        public PrerequisiteEntry TargetCastPrerequisite { get; private set; }
+        public PrerequisiteEntry CasterPersistencePrerequisite { get; private set; }
+        public PrerequisiteEntry TargetPersistencePrerequisite { get; private set; }
         public List<PrerequisiteEntry> PrerequisiteRunners { get; private set; } = [];
 
         public List<TelegraphDamageEntry> Telegraphs { get; private set; }
@@ -80,9 +80,9 @@ namespace NexusForever.Game.Spell.Info
             GlobalCooldown                 = gameTableManager.SpellCoolDown.GetEntry(spell4Entry.SpellCoolDownIdGlobal);
             StackGroup                     = gameTableManager.Spell4StackGroup.GetEntry(spell4Entry.Spell4StackGroupId);
             CasterCastPrerequisite         = gameTableManager.Prerequisite.GetEntry(spell4Entry.PrerequisiteIdCasterCast);
-            TargetCastPrerequisites        = gameTableManager.Prerequisite.GetEntry(spell4Entry.PrerequisiteIdTargetCast);
-            CasterPersistencePrerequisites = gameTableManager.Prerequisite.GetEntry(spell4Entry.PrerequisiteIdCasterPersistence);
-            TargetPersistencePrerequisites = gameTableManager.Prerequisite.GetEntry(spell4Entry.PrerequisiteIdTargetPersistence);
+            TargetCastPrerequisite         = gameTableManager.Prerequisite.GetEntry(spell4Entry.PrerequisiteIdTargetCast);
+            CasterPersistencePrerequisite  = gameTableManager.Prerequisite.GetEntry(spell4Entry.PrerequisiteIdCasterPersistence);
+            TargetPersistencePrerequisite  = gameTableManager.Prerequisite.GetEntry(spell4Entry.PrerequisiteIdTargetPersistence);
 
             Telegraphs                     = spellInfoCache.GetTelegraphDamageEntries(spell4Entry.Id).ToList();
             Effects                        = spellInfoCache.GetSpell4EffectEntries(spell4Entry.Id).ToList();

--- a/Source/NexusForever.Game/Spell/Proc/ProcInfo.cs
+++ b/Source/NexusForever.Game/Spell/Proc/ProcInfo.cs
@@ -15,6 +15,7 @@ namespace NexusForever.Game.Spell.Proc
         public ProcType Type { get; private set; }
 
         private UpdateTimer triggerTimer;
+        private uint pendingTargetId;
 
         #region Dependency Injection
 
@@ -57,11 +58,16 @@ namespace NexusForever.Game.Spell.Proc
 
             triggerTimer.Reset(false);
 
+            // grab stored target and clear
+            uint targetId = pendingTargetId;
+            pendingTargetId = 0;
+
             log.LogTrace($"Triggering Proc {Data.Entry.Id} of {Type}.");
 
             Owner.CastSpell(Data.SpellId, new SpellParameters
             {
-                UserInitiatedSpellCast = false
+                UserInitiatedSpellCast = false,
+                PrimaryTargetId        = targetId
             });
         }
 
@@ -73,21 +79,24 @@ namespace NexusForever.Game.Spell.Proc
             log.LogWarning($"Attempting to trigger proc {Data.Entry.Id} of {Type}.");
 
             if (CanTrigger(parameters))
+            {
+                // store target for next trigger
+                pendingTargetId = parameters.Target?.Guid ?? 0;
                 triggerTimer.Reset(true);
+            }
         }
 
         private bool CanTrigger(IProcParameters parameters)
         {
             if (Data.TargetPrerequisiteId != 0)
             {
-                // TODO: once the prerequisite system is updated to handle IUnitEntity, this needs to be updated
-                if (parameters.Target is IPlayer player && !prerequisiteManager.Meets(player, Data.TargetPrerequisiteId))
+                if (parameters.Target == null || !prerequisiteManager.Meets(parameters.Target, Data.TargetPrerequisiteId, Owner))
                     return false;
             }
 
             if (Data.CasterPrerequisiteId != 0)
             {
-                if (Owner is IPlayer player && !prerequisiteManager.Meets(player, Data.CasterPrerequisiteId))
+                if (!prerequisiteManager.Meets(Owner, Data.CasterPrerequisiteId, parameters.Target))
                     return false;
             }
 

--- a/Source/NexusForever.Game/Spell/Spell.cs
+++ b/Source/NexusForever.Game/Spell/Spell.cs
@@ -303,33 +303,22 @@ namespace NexusForever.Game.Spell
 
         private CastResult CheckPrerequisites()
         {
-            // TODO: Remove below line and evaluate PreReq's for Non-Player Entities
-            if (Caster is not IPlayer player)
-                return CastResult.Ok;
+            IUnitEntity target = GetExplicitTarget();
 
             // Runners override the Caster Check, allowing the Caster to Cast the spell due to this Prerequisite being met
-            if (Parameters.SpellInfo.CasterCastPrerequisite != null && !CheckRunnerOverride(player))
+            if (Parameters.SpellInfo.CasterCastPrerequisite != null && !CheckRunnerOverride(Caster))
             {
-                var parameters = new PrerequisiteParameters
-                {
-                    TaxiNode = Parameters.TaxiNode,
-                };
-                if (!PrerequisiteManager.Instance.Meets(player, Parameters.SpellInfo.CasterCastPrerequisite.Id, parameters))
-                    return parameters.CastResult != null ? parameters.CastResult.Value : CastResult.PrereqCasterCast;
+                if (!PrerequisiteManager.Instance.Meets(Caster, Parameters.SpellInfo.CasterCastPrerequisite.Id, target))
+                    return CastResult.PrereqCasterCast;
             }
 
-            // not sure if this should be for explicit and/or implicit targets
-            if (Parameters.SpellInfo.TargetCastPrerequisites != null)
+            if (Parameters.SpellInfo.TargetCastPrerequisite != null)
             {
-            }
+                if (target == null)
+                    return CastResult.PrereqTargetCast;
 
-            // this probably isn't the correct place, name implies this should be constantly checked
-            if (Parameters.SpellInfo.CasterPersistencePrerequisites != null)
-            {
-            }
-
-            if (Parameters.SpellInfo.TargetPersistencePrerequisites != null)
-            {
+                if (!PrerequisiteManager.Instance.Meets(target, Parameters.SpellInfo.TargetCastPrerequisite.Id, Caster))
+                    return CastResult.PrereqTargetCast;
             }
 
             return CastResult.Ok;
@@ -338,10 +327,10 @@ namespace NexusForever.Game.Spell
         /// <summary>
         /// Returns whether the Caster is in a state where they can ignore Resource or other constraints.
         /// </summary>
-        private bool CheckRunnerOverride(IPlayer player)
+        private bool CheckRunnerOverride(IUnitEntity subject)
         {
             foreach (PrerequisiteEntry runnerPrereq in Parameters.SpellInfo.PrerequisiteRunners)
-                if (PrerequisiteManager.Instance.Meets(player, runnerPrereq.Id))
+                if (PrerequisiteManager.Instance.Meets(subject, runnerPrereq.Id))
                     return true;
 
             return false;
@@ -517,20 +506,23 @@ namespace NexusForever.Game.Spell
             }
         }
 
+        private IUnitEntity GetExplicitTarget()
+        {
+            if (Parameters.PrimaryTargetId == 0)
+                return Caster;
+
+            return Caster.GetVisible<IUnitEntity>(Parameters.PrimaryTargetId);
+        }
+
         protected virtual void SelectTargets(ISpellExecutionContext executionContext)
         {
             // Add Caster Entity with the appropriate SpellEffectTargetFlags.
             executionContext.TargetCollection.AddTarget(SpellEffectTargetFlags.Caster, Caster);
 
             // Add Targeted Entity with the appropriate SpellEffectTargetFlags.
-            if (Parameters.PrimaryTargetId > 0)
-            {
-                IUnitEntity explicitTargetEntity = Caster.GetVisible<IUnitEntity>(Parameters.PrimaryTargetId);
-                if (explicitTargetEntity != null)
-                    executionContext.TargetCollection.AddTarget(SpellEffectTargetFlags.ExplicitTarget, explicitTargetEntity);
-            }
-            else
-                executionContext.TargetCollection.AddTarget(SpellEffectTargetFlags.ExplicitTarget, Caster);
+            IUnitEntity explicitTarget = GetExplicitTarget();
+            if (explicitTarget != null)
+                executionContext.TargetCollection.AddTarget(SpellEffectTargetFlags.ExplicitTarget, explicitTarget);
 
             // TODO: this might not be entirely correct, research this more...
             if (Parameters.SpellInfo.BaseInfo.TargetMechanics.TargetType
@@ -576,13 +568,6 @@ namespace NexusForever.Game.Spell
             if (disableManager.IsDisabled(DisableType.SpellEffect, spell4EffectsEntry.Id))
                 return false;
 
-            if (Caster is IPlayer player)
-            {
-                // Ensure caster can apply this effect
-                if (spell4EffectsEntry.PrerequisiteIdCasterApply > 0 && !PrerequisiteManager.Instance.Meets(player, spell4EffectsEntry.PrerequisiteIdCasterApply))
-                    return false;
-            }
-
             if (delayedEffects.TryGetValue(spell4EffectsEntry, out UpdateTimer updateTimer)
                 && !updateTimer.HasElapsed)
                 return false;
@@ -603,7 +588,7 @@ namespace NexusForever.Game.Spell
 
             foreach (ISpellTarget spellTarget in executionContext.TargetCollection.GetTargets(spell4EffectsEntry.TargetFlags))
             {
-                if (!CheckEffectApplyPrerequisites(spell4EffectsEntry, spellTarget.Entity, spellTarget.Flags))
+                if (!CheckEffectApplyPrerequisites(spell4EffectsEntry, spellTarget.Entity))
                     continue;
 
                 ISpellTargetInfo spellTargetInfo =
@@ -620,32 +605,17 @@ namespace NexusForever.Game.Spell
             }
         }
 
-        private bool CheckEffectApplyPrerequisites(Spell4EffectsEntry spell4EffectsEntry, IUnitEntity unit, SpellEffectTargetFlags targetFlags)
+        private bool CheckEffectApplyPrerequisites(Spell4EffectsEntry spell4EffectsEntry, IUnitEntity target)
         {
-            bool effectCanApply = true;
+            if (spell4EffectsEntry.PrerequisiteIdCasterApply > 0
+                && !PrerequisiteManager.Instance.Meets(Caster, spell4EffectsEntry.PrerequisiteIdCasterApply, target))
+                return false;
 
-            // TODO: Possibly update Prereq Manager to handle other Units
-            if (unit is not IPlayer player)
-                return true;
+            if (spell4EffectsEntry.PrerequisiteIdTargetApply > 0
+                && !PrerequisiteManager.Instance.Meets(target, spell4EffectsEntry.PrerequisiteIdTargetApply, Caster))
+                return false;
 
-            if ((targetFlags & SpellEffectTargetFlags.Caster) != 0)
-            {
-                // TODO
-                if (spell4EffectsEntry.PrerequisiteIdCasterApply > 0)
-                {
-                    effectCanApply = PrerequisiteManager.Instance.Meets(player, spell4EffectsEntry.PrerequisiteIdCasterApply);
-                }
-            }
-
-            if (effectCanApply && (targetFlags & SpellEffectTargetFlags.Caster) == 0)
-            {
-                if (spell4EffectsEntry.PrerequisiteIdTargetApply > 0)
-                {
-                    effectCanApply = PrerequisiteManager.Instance.Meets(player, spell4EffectsEntry.PrerequisiteIdTargetApply);
-                }
-            }
-
-            return effectCanApply;
+            return true;
         }
 
         public bool IsMovingInterrupted()
@@ -881,25 +851,39 @@ namespace NexusForever.Game.Spell
 
         private void CheckPersistance(double lastTick)
         {
-            if (Caster is not IPlayer player)
-                return;
-
-            if (Parameters.SpellInfo.Entry.PrerequisiteIdCasterPersistence == 0 && Parameters.SpellInfo.Entry.PrerequisiteIdTargetPersistence == 0)
+            if (Parameters.SpellInfo.CasterPersistencePrerequisite == null
+                && Parameters.SpellInfo.TargetPersistencePrerequisite == null)
                 return;
 
             persistCheck.Update(lastTick);
-            if (persistCheck.HasElapsed)
+            if (!persistCheck.HasElapsed)
+                return;
+
+            persistCheck.Reset();
+
+            IUnitEntity target = GetExplicitTarget();
+            if (Parameters.SpellInfo.CasterPersistencePrerequisite != null)
             {
-                var parameters = new PrerequisiteParameters
+                if (!PrerequisiteManager.Instance.Meets(Caster, Parameters.SpellInfo.CasterPersistencePrerequisite.Id, target))
                 {
-                    TaxiNode = Parameters.TaxiNode,
-                };
-                if (Parameters.SpellInfo.Entry.PrerequisiteIdCasterPersistence > 0 && !PrerequisiteManager.Instance.Meets(player, Parameters.SpellInfo.Entry.PrerequisiteIdCasterPersistence, parameters))
                     Finish();
+                    return;
+                }
+            }
 
-                // TODO: Check if target can still persist
+            if (Parameters.SpellInfo.TargetPersistencePrerequisite != null)
+            {
+                if (target == null)
+                {
+                    Finish();
+                    return;
+                }
 
-                persistCheck.Reset();
+                if (!PrerequisiteManager.Instance.Meets(target, Parameters.SpellInfo.TargetPersistencePrerequisite.Id, Caster))
+                {
+                    Finish();
+                    return;
+                }
             }
         }
 

--- a/Source/NexusForever.Game/Spell/Spell.cs
+++ b/Source/NexusForever.Game/Spell/Spell.cs
@@ -308,8 +308,13 @@ namespace NexusForever.Game.Spell
             // Runners override the Caster Check, allowing the Caster to Cast the spell due to this Prerequisite being met
             if (Parameters.SpellInfo.CasterCastPrerequisite != null && !CheckRunnerOverride(Caster))
             {
-                if (!PrerequisiteManager.Instance.Meets(Caster, Parameters.SpellInfo.CasterCastPrerequisite.Id, target))
-                    return CastResult.PrereqCasterCast;
+                var prerequisiteParameters = new PrerequisiteParameters
+                {
+                    Target   = target,
+                    TaxiNode = Parameters.TaxiNode
+                };
+                if (!PrerequisiteManager.Instance.Meets(Caster, Parameters.SpellInfo.CasterCastPrerequisite.Id, prerequisiteParameters))
+                    return prerequisiteParameters.CastResult ?? CastResult.PrereqCasterCast;
             }
 
             if (Parameters.SpellInfo.TargetCastPrerequisite != null)
@@ -317,8 +322,13 @@ namespace NexusForever.Game.Spell
                 if (target == null)
                     return CastResult.PrereqTargetCast;
 
-                if (!PrerequisiteManager.Instance.Meets(target, Parameters.SpellInfo.TargetCastPrerequisite.Id, Caster))
-                    return CastResult.PrereqTargetCast;
+                var prerequisiteParameters = new PrerequisiteParameters
+                {
+                    Target   = Caster,
+                    TaxiNode = Parameters.TaxiNode
+                };
+                if (!PrerequisiteManager.Instance.Meets(target, Parameters.SpellInfo.TargetCastPrerequisite.Id, prerequisiteParameters))
+                    return prerequisiteParameters.CastResult ?? CastResult.PrereqTargetCast;
             }
 
             return CastResult.Ok;
@@ -864,7 +874,12 @@ namespace NexusForever.Game.Spell
             IUnitEntity target = GetExplicitTarget();
             if (Parameters.SpellInfo.CasterPersistencePrerequisite != null)
             {
-                if (!PrerequisiteManager.Instance.Meets(Caster, Parameters.SpellInfo.CasterPersistencePrerequisite.Id, target))
+                var prerequisiteParameters = new PrerequisiteParameters
+                {
+                    Target   = target,
+                    TaxiNode = Parameters.TaxiNode
+                };
+                if (!PrerequisiteManager.Instance.Meets(Caster, Parameters.SpellInfo.CasterPersistencePrerequisite.Id, prerequisiteParameters))
                 {
                     Finish();
                     return;
@@ -879,7 +894,12 @@ namespace NexusForever.Game.Spell
                     return;
                 }
 
-                if (!PrerequisiteManager.Instance.Meets(target, Parameters.SpellInfo.TargetPersistencePrerequisite.Id, Caster))
+                var prerequisiteParameters = new PrerequisiteParameters
+                {
+                    Target   = Caster,
+                    TaxiNode = Parameters.TaxiNode
+                };
+                if (!PrerequisiteManager.Instance.Meets(target, Parameters.SpellInfo.TargetPersistencePrerequisite.Id, prerequisiteParameters))
                 {
                     Finish();
                     return;


### PR DESCRIPTION
## Summary

This updates the prerequisite system to evaluate any `IUnitEntity` and provides explicit target context for relationship-based prerequisite checks.

It also completes the existing spell-level cast, persistence, effect-application, and proc prerequisite paths, while retaining the expedition branch's existing RapidTransport prerequisite validation behavior. No new prerequisite handlers or testing infrastructure are introduced.

## Changes

### Prerequisite evaluation

- Changed `IPrerequisiteCheck` and `IPrerequisiteManager` subjects from `IPlayer` to `IUnitEntity`.
- Added a manager overload accepting a target-context unit.
- Continued using the existing prerequisite-parameter factory for context creation.
- Added `Target`, `TaxiNode`, and nullable `CastResult` prerequisite parameters.
- Preserved the same parameter context through nested prerequisite evaluation.
- Updated existing handlers:
  - Unit-compatible handlers operate directly on `IUnitEntity`.
  - Player-specific handlers explicitly require an `IPlayer`.
  - Existing unimplemented handlers remain pass-through so they do not block spell casts.
- Corrected the native raw comparison mapping:
  - `3` is greater than.
  - `4` is greater than or equal.
  - `5` is less than.
  - `6` is less than or equal.
- Changed unsupported comparison branches in implemented handlers to fail closed.

### Spell prerequisite lifecycle

- Removed the player-only prerequisite bypass.
- Added caster-cast evaluation using `(caster, explicit target)`.
- Added target-cast evaluation using `(explicit target, caster)`.
- Added caster-persistence evaluation using `(caster, explicit target)`.
- Added target-persistence evaluation using `(explicit target, caster)`.
- Reused one explicit-target resolution path for validation, persistence, and execution.
- Missing required targets now fail the appropriate target-stage check or finish the active spell.
- Propagated `TaxiNode` into cast and persistence prerequisite parameters.
- Allowed caster- and target-cast prerequisite handlers to return a specific `CastResult`, with the existing stage-specific result retained as the fallback.

### Effect application

- Completed per-target effect prerequisite evaluation.
- Caster-apply prerequisites use `(caster, affected target)`.
- Target-apply prerequisites use `(affected target, caster)`.
- Removed the earlier context-free caster-apply check.
- Effect prerequisite failure skips application to that target rather than rejecting the entire cast.

### Proc integration

- Proc target prerequisites use `(trigger target, proc owner)`.
- Proc caster prerequisites use `(proc owner, trigger target)`.
- The accepted trigger target GUID is retained across the proc delay.
- Triggered spells receive the original target through `PrimaryTargetId`, preserving the correct context for downstream spell prerequisites.

### Spell metadata naming

Renamed the cached prerequisite properties to match the singular GameTable fields:

- `TargetCastPrerequisite`
- `CasterPersistencePrerequisite`
- `TargetPersistencePrerequisite`

### RapidTransport prerequisite

- Restored the existing `PrerequisiteType.RapidTransport` eligibility and affordability validation.
- Requires a player subject and valid taxi-node context.
- Validates taxi-node availability, auto-unlock level, destination data, minimum distance, and the RapidTransport cooldown formula.
- Uses the existing `IRapidTransportCostCalculator` and currency managers to check service-token or credit affordability.
- Returns `ServiceTokensInsufficentFunds` or `CasterVitalCostMoney` for the corresponding insufficient-funds cases, with `RapidTransportInvalid` as the general failure result.

This restores the expedition branch's server behavior; it does not claim that prerequisite type 269's client semantics have been confirmed by reverse engineering.

## Compatibility notes

- `Target` is the contextual counterpart to the evaluated `subject`; for target-side checks it therefore contains the caster.
- Runner overrides remain limited to the existing caster-cast stage.
- Cast-time target prerequisites apply only to the explicit target.
- Implicit AoE candidates are not evaluated with `TargetCastPrerequisite`.
- Unknown prerequisite types without a registered handler retain the manager's existing behavior.
- This does not implement new prerequisite handlers.

## Out of scope

- AoE target and preferred-target prerequisites.
- Effect persistence and target-suspend prerequisites.
- New test projects or prerequisite test infrastructure.
- Further interpretation of prerequisite type 269 beyond restoring the existing server behavior.

## Validation

- `dotnet build Source/NexusForever.slnx --no-restore --nologo --verbosity:minimal`
- Build completed with 0 errors.
- The existing 127 warnings remain.
- `git diff --check` passes.
- No tests were added or modified.