### PR TITLE
Fix Aspire setup and migrations

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "aspire.cli": {
+      "version": "13.4.6",
+      "commands": ["aspire"],
+      "rollForward": false
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 # NexusForever generated files
 *.tbl
 *.nfmap
+/data/
+**/appsettings.Local.json
 
 # User-specific files
 *.suo

--- a/README.md
+++ b/README.md
@@ -7,8 +7,11 @@ A server emulator for WildStar written in C# that supports build 16042.
 ### Getting Started
 [Server Setup Guide](https://www.emulator.ws/installation/server-guide)
 
+[Aspire setup](Source/NexusForever.Aspire.AppHost/README.md)
+
 ### Requirements
- * Visual Studio 2026 (.NET 10 and C# 14 support required)
+ * .NET 10 SDK
+ * Aspire CLI (installed automatically by `aspire.sh`) or Visual Studio 2026
  * MySQL Server (or equivalent, eg: MariaDB)
  * Message Broker (RabbitMQ or Azure Service Bus)
  * WildStar 16042 client

--- a/Source/NexusForever.API.Account/AccountAPI.cs
+++ b/Source/NexusForever.API.Account/AccountAPI.cs
@@ -3,6 +3,7 @@ using NexusForever.API.Account.Account;
 using NexusForever.API.Account.Endpoint;
 using NexusForever.Database.Auth;
 using NexusForever.Database.Configuration.Model;
+using NexusForever.Shared.Configuration;
 using NLog.Extensions.Logging;
 
 namespace NexusForever.API.Account
@@ -20,7 +21,7 @@ namespace NexusForever.API.Account
             string basePath = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
             builder.Configuration
                 .SetBasePath(basePath)
-                .AddJsonFile("AccountAPI.json", false)
+                .AddNexusForeverJson("AccountAPI.json")
                 .AddEnvironmentVariables();
 
             builder.Services
@@ -38,6 +39,7 @@ namespace NexusForever.API.Account
             WebApplication app = builder.Build();
 
             app.MapGetAccountEndpoint();
+            app.MapGet("/health", () => Results.Ok());
 
             app.Run();
         }

--- a/Source/NexusForever.API.Character/CharacterAPI.cs
+++ b/Source/NexusForever.API.Character/CharacterAPI.cs
@@ -8,6 +8,7 @@ using NexusForever.Database;
 using NexusForever.Database.Auth;
 using NexusForever.Database.Character;
 using NexusForever.Database.Configuration.Model;
+using NexusForever.Shared.Configuration;
 using NLog.Extensions.Logging;
 
 namespace NexusForever.API.Character
@@ -25,7 +26,7 @@ namespace NexusForever.API.Character
             string basePath = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
             builder.Configuration
                 .SetBasePath(basePath)
-                .AddJsonFile("CharacterAPI.json", false)
+                .AddNexusForeverJson("CharacterAPI.json")
                 .AddEnvironmentVariables();
 
             builder.Services
@@ -50,6 +51,7 @@ namespace NexusForever.API.Character
             WebApplication app = builder.Build();
 
             app.MapGetCharacterEndpoint();
+            app.MapGet("/health", () => Results.Ok());
 
             app.Run();
         }

--- a/Source/NexusForever.Aspire.AppHost/LocalSettings.cs
+++ b/Source/NexusForever.Aspire.AppHost/LocalSettings.cs
@@ -1,0 +1,57 @@
+using System.Net;
+using System.Net.Sockets;
+
+namespace NexusForever.Aspire.AppHost;
+
+internal sealed class LocalSettings
+{
+    public string ClientPath { get; set; } = "";
+    public string AssetPath { get; set; } = "../../data/assets";
+    public string WorldDatabasePath { get; set; } = "../../data/world-database";
+    public string RealmHost { get; set; } = "127.0.0.1";
+    public string RealmName { get; set; } = "NexusForever";
+    public string AccountName { get; set; } = "nexusforever";
+    public uint AccountRole { get; set; } = 1;
+    public int AuthPort { get; set; } = 23115;
+    public int StsPort { get; set; } = 6600;
+    public int WorldPort { get; set; } = 24000;
+    public bool PhpMyAdmin { get; set; } = true;
+    public string MySqlVolume { get; set; } = "nexusforever-aspire-mysql84-data";
+    public string RabbitMqVolume { get; set; } = "nexusforever-aspire-rabbitmq-data";
+
+    public void ResolvePaths(string appHostDirectory)
+    {
+        if (!string.IsNullOrWhiteSpace(ClientPath))
+            ClientPath = Path.GetFullPath(ClientPath, appHostDirectory);
+        AssetPath = Path.GetFullPath(AssetPath, appHostDirectory);
+        WorldDatabasePath = Path.GetFullPath(WorldDatabasePath, appHostDirectory);
+    }
+
+    public void Validate(bool checkPorts = true)
+    {
+        if (!IPAddress.TryParse(RealmHost, out var address) || address.AddressFamily != AddressFamily.InterNetwork
+            || address.Equals(IPAddress.Any))
+            throw new InvalidOperationException("RealmHost must be the IPv4 address clients use to reach this server.");
+        if (string.IsNullOrWhiteSpace(RealmName) || RealmName.Length > 64)
+            throw new InvalidOperationException("RealmName must contain 1 to 64 characters.");
+        if (string.IsNullOrWhiteSpace(AccountName) || AccountRole is < 1 or > 3)
+            throw new InvalidOperationException("Set AccountName and AccountRole (1: Player, 2: GameMaster, 3: Administrator).");
+
+        int[] ports = [AuthPort, StsPort, WorldPort];
+        if (ports.Any(p => p is < 1 or > 65535) || ports.Distinct().Count() != ports.Length)
+            throw new InvalidOperationException("AuthPort, StsPort, and WorldPort must be distinct ports between 1 and 65535.");
+
+        foreach (int port in checkPorts ? ports : [])
+        {
+            using var listener = new TcpListener(IPAddress.Any, port);
+            try { listener.Start(); }
+            catch (SocketException exception)
+            {
+                throw new InvalidOperationException($"Port {port} is in use. Stop the conflicting service or change the port in appsettings.Local.json.", exception);
+            }
+        }
+
+        if (!Directory.Exists(WorldDatabasePath) || !Directory.EnumerateFiles(WorldDatabasePath, "*.sql", SearchOption.AllDirectories).Any())
+            throw new InvalidOperationException($"No world SQL files in {WorldDatabasePath}. Run ./aspire.sh --setup or set WorldDatabasePath to an existing checkout.");
+    }
+}

--- a/Source/NexusForever.Aspire.AppHost/LocalSetup.cs
+++ b/Source/NexusForever.Aspire.AppHost/LocalSetup.cs
@@ -1,0 +1,135 @@
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace NexusForever.Aspire.AppHost;
+
+internal static class LocalSetup
+{
+    private const string WorldRevision = "79d836576b9da8d7f7321ec3463d3673d496f090";
+
+    public static async Task Configure(string directory, LocalSettings settings, bool hasSavedPassword)
+    {
+        if (Console.IsInputRedirected)
+            throw new InvalidOperationException("Run --setup from a terminal, or supply appsettings.Local.json and the game-password user secret.");
+
+        settings.ResolvePaths(directory);
+        settings.ClientPath = Prompt("WildStar installation or Patch directory (optional after asset preparation)", settings.ClientPath);
+        settings.AssetPath = Prompt("Asset output directory", settings.AssetPath);
+        settings.WorldDatabasePath = Prompt("World database directory (download if missing)", settings.WorldDatabasePath);
+        settings.RealmHost = Prompt("Realm IPv4 address", settings.RealmHost);
+        settings.RealmName = Prompt("Realm name", settings.RealmName);
+        settings.AccountName = Prompt("Initial account username", settings.AccountName);
+        settings.AccountRole = (uint)PromptNumber("Initial account role: 1 Player, 2 GameMaster, 3 Administrator", (int)settings.AccountRole, 1, 3);
+        settings.AuthPort = PromptNumber("Auth port", settings.AuthPort, 1, 65535);
+        settings.StsPort = PromptNumber("STS port", settings.StsPort, 1, 65535);
+        settings.WorldPort = PromptNumber("World port", settings.WorldPort, 1, 65535);
+        string password;
+        do
+        {
+            Console.Write("Initial account password (leave blank to keep the saved password): ");
+            password = ReadPassword();
+            if (password.Length == 0 && !hasSavedPassword)
+                Console.WriteLine("Enter a password for the initial account.");
+        } while (password.Length == 0 && !hasSavedPassword);
+
+        settings.ResolvePaths(directory);
+        if (password.Length > 0)
+        {
+            string secrets = JsonSerializer.Serialize(new Dictionary<string, string> { ["Parameters:game-password"] = password });
+            await Run("dotnet", directory, ["user-secrets", "set", "--project", "NexusForever.Aspire.AppHost.csproj"], secrets);
+        }
+
+        string path = Path.Combine(directory, "appsettings.Local.json");
+        var options = new JsonDocumentOptions { CommentHandling = JsonCommentHandling.Skip, AllowTrailingCommas = true };
+        var config = File.Exists(path) ? JsonNode.Parse(await File.ReadAllTextAsync(path), documentOptions: options)!.AsObject() : new JsonObject();
+        foreach (string key in config.Select(property => property.Key).Where(key =>
+            key.Equals("NexusForever", StringComparison.OrdinalIgnoreCase)
+            || key.StartsWith("NexusForever:", StringComparison.OrdinalIgnoreCase)).ToArray())
+            config.Remove(key);
+        config["NexusForever"] = JsonSerializer.SerializeToNode(settings);
+        await File.WriteAllTextAsync(path, config.ToJsonString(new JsonSerializerOptions { WriteIndented = true }) + "\n");
+        Console.WriteLine($"Saved {path}. Start with ./aspire.sh from the repository root.");
+        await DownloadWorldDatabase(settings.WorldDatabasePath);
+        settings.Validate(checkPorts: false);
+    }
+
+    private static string Prompt(string label, string current)
+    {
+        Console.Write($"{label} [{current}]: ");
+        string value = Console.ReadLine() ?? throw new EndOfStreamException();
+        return string.IsNullOrWhiteSpace(value) ? current : value.Trim();
+    }
+
+    private static int PromptNumber(string label, int current, int minimum, int maximum)
+    {
+        while (true)
+        {
+            if (int.TryParse(Prompt(label, current.ToString()), out int value) && value >= minimum && value <= maximum)
+                return value;
+            Console.WriteLine($"Enter a number between {minimum} and {maximum}.");
+        }
+    }
+
+    private static string ReadPassword()
+    {
+        var result = new StringBuilder();
+        while (true)
+        {
+            ConsoleKeyInfo key = Console.ReadKey(intercept: true);
+            if (key.Key == ConsoleKey.Enter)
+                break;
+            if (key.Key == ConsoleKey.Backspace && result.Length > 0)
+                result.Length--;
+            else if (!char.IsControl(key.KeyChar))
+                result.Append(key.KeyChar);
+        }
+        Console.WriteLine();
+        return result.ToString();
+    }
+
+    private static async Task DownloadWorldDatabase(string destination)
+    {
+        if (Directory.Exists(destination))
+            return;
+
+        string temporary = destination + ".download-" + Guid.NewGuid().ToString("N");
+        Directory.CreateDirectory(temporary);
+        try
+        {
+            Console.WriteLine($"Downloading world database {WorldRevision}...");
+            await Run("git", temporary, ["init", "--quiet"]);
+            await Run("git", temporary, ["remote", "add", "origin", "https://github.com/NexusForever/NexusForever.WorldDatabase.git"]);
+            await Run("git", temporary, ["fetch", "--depth", "1", "origin", WorldRevision]);
+            await Run("git", temporary, ["checkout", "--quiet", "--detach", "FETCH_HEAD"]);
+            Directory.Move(temporary, destination);
+        }
+        finally
+        {
+            if (Directory.Exists(temporary))
+                Directory.Delete(temporary, recursive: true);
+        }
+    }
+
+    private static async Task Run(string command, string directory, string[] arguments, string? input = null)
+    {
+        var start = new ProcessStartInfo(command)
+        {
+            WorkingDirectory = directory,
+            UseShellExecute = false,
+            RedirectStandardInput = input != null
+        };
+        foreach (string argument in arguments)
+            start.ArgumentList.Add(argument);
+        using var process = Process.Start(start) ?? throw new InvalidOperationException($"Could not start {command}.");
+        if (input != null)
+        {
+            await process.StandardInput.WriteAsync(input);
+            process.StandardInput.Close();
+        }
+        await process.WaitForExitAsync();
+        if (process.ExitCode != 0)
+            throw new InvalidOperationException($"{command} exited with code {process.ExitCode}.");
+    }
+}

--- a/Source/NexusForever.Aspire.AppHost/NexusForever.Aspire.AppHost.csproj
+++ b/Source/NexusForever.Aspire.AppHost/NexusForever.Aspire.AppHost.csproj
@@ -28,6 +28,7 @@
     <ProjectReference Include="..\NexusForever.Server.GroupServer\NexusForever.Server.GroupServer.csproj" />
     <ProjectReference Include="..\NexusForever.StsServer\NexusForever.StsServer.csproj" />
     <ProjectReference Include="..\NexusForever.WorldServer\NexusForever.WorldServer.csproj" />
+    <ProjectReference Include="..\NexusForever.MapGenerator\NexusForever.MapGenerator.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Source/NexusForever.Aspire.AppHost/Program.cs
+++ b/Source/NexusForever.Aspire.AppHost/Program.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using Microsoft.Extensions.Configuration;
 using NexusForever.Aspire.AppHost;
 using NexusForever.Database;
 using NexusForever.Network.Internal.Static;
@@ -7,16 +8,40 @@ internal class Program
 {
     private static async Task Main(string[] args)
     {
-        var builder = DistributedApplication.CreateBuilder(args);
+        bool setup = args.Contains("--setup");
+        string[] appArgs = args.Where(a => a != "--setup").ToArray();
+        var builder = DistributedApplication.CreateBuilder(appArgs);
+        builder.Configuration.AddJsonFile("appsettings.Local.json", optional: true)
+            .AddUserSecrets<Program>(optional: true)
+            .AddEnvironmentVariables()
+            .AddCommandLine(appArgs);
+        var settings = builder.Configuration.GetSection("NexusForever").Get<LocalSettings>() ?? new();
+        if (setup)
+        {
+            await LocalSetup.Configure(builder.AppHostDirectory, settings,
+                !string.IsNullOrEmpty(builder.Configuration["Parameters:game-password"]));
+            return;
+        }
+        settings.ResolvePaths(builder.AppHostDirectory);
+        settings.Validate();
 
-        //builder.AddDockerComposeEnvironment("nexus-forever");
+        var assets = builder.AddProject<Projects.NexusForever_MapGenerator>("assets")
+            .WithArgs("--prepare", "--output", settings.AssetPath);
+        if (!string.IsNullOrWhiteSpace(settings.ClientPath))
+            assets.WithArgs("--patchPath", settings.ClientPath);
+        var gamePassword = builder.AddParameter("game-password", secret: true);
 
         var rmq = builder.AddRabbitMQ("rmq")
-            .WithManagementPlugin();
+            .WithManagementPlugin()
+            .WithDataVolume(settings.RabbitMqVolume)
+            .WithEnvironment("RABBITMQ_NODENAME", "rabbit@nexusforever")
+            .WithContainerRuntimeArgs("--hostname", "nexusforever");
 
         var mysql = builder.AddMySql("mysql")
-            .WithPhpMyAdmin()
-            .WithDataVolume("mysql-data");
+            .WithImageTag("8.4")
+            .WithDataVolume(settings.MySqlVolume);
+        if (settings.PhpMyAdmin)
+            mysql.WithPhpMyAdmin();
 
         var authdb       = mysql.AddDatabase("authdb");
         var characterdb  = mysql.AddDatabase("characterdb");
@@ -27,6 +52,14 @@ internal class Program
         var querydb      = mysql.AddDatabase("querydb");
 
         IResourceBuilder<ProjectResource> dbMigration = builder.AddProject<Projects.NexusForever_Aspire_Database_Migrations>("database-migrations")
+            .WithEnvironment("WorldDatabase:Path", settings.WorldDatabasePath)
+            .WithEnvironment("AccountCreation:Username", settings.AccountName)
+            .WithEnvironment("AccountCreation:Password", gamePassword)
+            .WithEnvironment("AccountCreation:RoleId", settings.AccountRole.ToString())
+            .WithEnvironment("Realm:Host", settings.RealmHost)
+            .WithEnvironment("Realm:Name", settings.RealmName)
+            .WithEnvironment("Realm:Port", settings.WorldPort.ToString())
+            .WaitForCompletion(assets)
             .WithReference(authdb)
             .WithReference(characterdb)
             .WithReference(worlddb)
@@ -43,20 +76,23 @@ internal class Program
             .WaitFor(querydb);
 
         builder.AddProject<Projects.NexusForever_AuthServer>("auth-server")
-            .WithNexusForeverTcp(IPAddress.Any, 23115)
+            .WithNexusForeverTcp(IPAddress.Any, settings.AuthPort)
             .WithNexusForeverDatabase("Auth", DatabaseProvider.MySql, authdb.Resource)
             .WaitFor(authdb)
             .WaitForCompletion(dbMigration);
 
         builder.AddProject<Projects.NexusForever_StsServer>("sts-server")
-            .WithNexusForeverTcp(IPAddress.Any, 6600)
+            .WithNexusForeverTcp(IPAddress.Any, settings.StsPort)
             .WithNexusForeverDatabase("Auth", DatabaseProvider.MySql, authdb.Resource)
             .WaitFor(authdb)
             .WaitForCompletion(dbMigration);
 
         IResourceBuilder<ProjectResource> worldServer = builder.AddProject<Projects.NexusForever_WorldServer>("world-server")
-            .WithNexusForeverTcp(IPAddress.Any, 24000)
-            .WithNexusForeverHttp(5000)
+            .WithNexusForeverTcp(IPAddress.Any, settings.WorldPort)
+            .WithNexusForeverHttp()
+            .WithHttpHealthCheck("/console.html")
+            .WithEnvironment("GameTable:GameTablePath", Path.Combine(settings.AssetPath, "tbl"))
+            .WithEnvironment("Realm:Map:MapPath", Path.Combine(settings.AssetPath, "map"))
             .WithNexusForeverDatabase("Auth", DatabaseProvider.MySql, authdb.Resource)
             .WithNexusForeverDatabase("Character", DatabaseProvider.MySql, characterdb.Resource)
             .WithNexusForeverDatabase("World", DatabaseProvider.MySql, worlddb.Resource)
@@ -84,13 +120,15 @@ internal class Program
         });
 
         IResourceBuilder<ProjectResource> accountApi = builder.AddProject<Projects.NexusForever_API_Account>("account-api")
-            .WithNexusForeverHttp(4001)
+            .WithNexusForeverHttp()
+            .WithHttpHealthCheck("/health")
             .WithNexusForeverDatabase("Auth", DatabaseProvider.MySql, authdb.Resource)
             .WaitFor(authdb)
             .WaitForCompletion(dbMigration);
 
         IResourceBuilder<ProjectResource> characterApi = builder.AddProject<Projects.NexusForever_API_Character>("character-api")
-            .WithNexusForeverHttp(4000)
+            .WithNexusForeverHttp()
+            .WithHttpHealthCheck("/health")
             .WithNexusForeverDatabase("Auth", DatabaseProvider.MySql, authdb.Resource)
             .WithNexusForeverDatabase("Character:0", DatabaseProvider.MySql, characterdb.Resource)
             .WithEnvironment("Database:Character:0:RealmId", "1")
@@ -108,6 +146,7 @@ internal class Program
             .WaitFor(characterApi);
 
         builder.AddProject<Projects.NexusForever_Server_ChatServer>("chat-server")
+            .WithEnvironment("GameTable:GameTablePath", Path.Combine(settings.AssetPath, "tbl"))
             .WithNexusForeverDatabase("Chat", DatabaseProvider.MySql, chatdb.Resource)
             .WithNexusForeverMessageBroker("ChatServer", BrokerProvider.RabbitMQ, rmq.Resource)
             .WithNexusForeverApi("Character", characterApi.Resource)
@@ -117,6 +156,7 @@ internal class Program
             .WaitFor(characterApi);
 
         builder.AddProject<Projects.NexusForever_Server_Friendship>("friendship-server")
+            .WithEnvironment("GameTable:GameTablePath", Path.Combine(settings.AssetPath, "tbl"))
             .WithNexusForeverDatabase("Friendship", DatabaseProvider.MySql, friendshipdb.Resource)
             .WithNexusForeverMessageBroker("FriendshipServer", BrokerProvider.RabbitMQ, rmq.Resource)
             .WithNexusForeverApi("Account", accountApi.Resource)
@@ -133,7 +173,11 @@ internal class Program
             .WithNexusForeverApi("Character", characterApi.Resource)
             .WaitFor(rmq)
             .WaitFor(querydb)
+            .WaitForCompletion(dbMigration)
             .WaitFor(characterApi);
+
+        foreach (var project in builder.Resources.OfType<ProjectResource>())
+            builder.CreateResourceBuilder(project).WithEnvironment("NEXUSFOREVER_ASPIRE", "1");
 
         DistributedApplication host = builder.Build();
         await host.RunAsync();

--- a/Source/NexusForever.Aspire.AppHost/README.md
+++ b/Source/NexusForever.Aspire.AppHost/README.md
@@ -1,0 +1,44 @@
+Aspire runs the servers locally and uses Docker for MySQL 8.4, RabbitMQ, and optional phpMyAdmin.
+
+Requires the [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0), Docker, Git, and a WildStar 16042 client or compatible generated assets.
+
+Start Docker. On Linux/macOS, run from the repository root:
+
+```sh
+dotnet dev-certs https --trust
+./aspire.sh
+```
+
+On Windows, run from `Source`:
+
+```powershell
+dotnet tool restore
+dotnet dev-certs https --trust
+dotnet run --project NexusForever.Aspire.AppHost -- --setup
+dotnet aspire run
+```
+
+For Visual Studio 2026, run the setup command above once, then set `NexusForever.Aspire.AppHost` as the startup project.
+
+The script installs the pinned Aspire CLI and prompts for paths, account, realm, and ports. Use `./aspire.sh --setup` to reconfigure. Settings live under `NexusForever` in ignored `appsettings.Local.json`; passwords use .NET user secrets. AppHost command-line options override saved settings and environment variables.
+
+Choose the client installation or `Patch` directory and an asset output directory. Setup generates maps and tables in a temporary directory, validates them, then replaces old files and removes languages absent from the client. Interrupted extraction retries on the next start. Later starts check file headers and the map inventory (`.maps.json`) for missing or truncated maps. Assets without an inventory need one regeneration with the client; include `.maps.json` when copying `map/` and `tbl/` elsewhere.
+
+Setup downloads pinned world SQL if its directory is missing. Custom SQL must contain data changes only; MySQL schema changes cannot be rolled back. Relative paths start at the AppHost directory.
+
+| Setting | Default |
+| --- | --- |
+| `RealmHost`, `RealmName` | `127.0.0.1`, `NexusForever` |
+| `AuthPort`, `StsPort`, `WorldPort` | `23115`, `6600`, `24000` |
+| `AccountRole` | `1` Player; also `2` GameMaster or `3` Administrator |
+| `PhpMyAdmin` | `true`; set `false` to disable |
+
+Use a reachable IPv4 `RealmHost` for remote clients. Stop conflicting servers or change the game ports. HTTP ports are automatic.
+
+The startup link opens the dashboard at `https://localhost:17021`. It links to the world console, RabbitMQ management, and phpMyAdmin, all bound locally. RabbitMQ credentials are in its resource details. For certificate issues, run `dotnet aspire doctor` from `Source`.
+
+Startup checks assets, migrates all seven databases, imports world SQL, and creates the initial account. Existing accounts are kept; unchanged SQL is skipped. Failed setup blocks the servers; check the `assets` or `database-migrations` logs. Aspire uses example configs when runtime files are absent; standalone servers require runtime configs. Environment variables override either file.
+
+Stop with Ctrl+C. Use `./aspire.sh --detach` to run in the background and `dotnet aspire stop` from `Source` to stop it.
+
+Data persists in `nexusforever-aspire-mysql84-data` and `nexusforever-aspire-rabbitmq-data`. Override names with `MySqlVolume` and `RabbitMqVolume`. Keep the Aspire secrets with these volumes. Existing Compose data is not imported.

--- a/Source/NexusForever.Aspire.AppHost/ResourceBuilderExtensions.cs
+++ b/Source/NexusForever.Aspire.AppHost/ResourceBuilderExtensions.cs
@@ -14,23 +14,10 @@ namespace NexusForever.Aspire.AppHost
             return builder;
         }
 
-        public static IResourceBuilder<T> WithNexusForeverHttp<T>(this IResourceBuilder<T> builder, int port) where T : IResourceWithEnvironment, IResourceWithEndpoints
+        public static IResourceBuilder<T> WithNexusForeverHttp<T>(this IResourceBuilder<T> builder) where T : IResourceWithEnvironment, IResourceWithEndpoints
         {
-            builder.WithHttpEndpoint(targetPort: port);
-
-            builder.WithEnvironment(c =>
-            {
-                if (!c.Resource.TryGetEndpoints(out var endpoints))
-                    return;
-
-                foreach (EndpointAnnotation endpoint in endpoints)
-                {
-                    if (endpoint.Name != "http")
-                        continue;
-
-                    c.EnvironmentVariables["urls"] = $"{endpoint.UriScheme}://{endpoint.TargetHost}:{endpoint.TargetPort}";
-                }
-            });
+            builder.WithHttpEndpoint();
+            builder.WithEnvironment("urls", ReferenceExpression.Create($"http://127.0.0.1:{builder.GetEndpoint("http").Property(EndpointProperty.TargetPort)}"));
 
             return builder;
         }

--- a/Source/NexusForever.Aspire.Database.Migrations/AspireMigrations.example.json
+++ b/Source/NexusForever.Aspire.Database.Migrations/AspireMigrations.example.json
@@ -1,9 +1,15 @@
 {
     "AccountCreation": {
         "Username": "nexusforever",
-        "Password": "nexusforever"
+        "Password": "",
+        "RoleId": 1
     },
     "WorldDatabase": {
         "Path": "C:\\nexusforever-database"
+    },
+    "Realm": {
+        "Host": "127.0.0.1",
+        "Name": "NexusForever",
+        "Port": 24000
     }
 }

--- a/Source/NexusForever.Aspire.Database.Migrations/Configuration/Model/AccountCreationOptions.cs
+++ b/Source/NexusForever.Aspire.Database.Migrations/Configuration/Model/AccountCreationOptions.cs
@@ -4,5 +4,6 @@
     {
         public string UserName { get; set; }
         public string Password { get; set; }
+        public uint RoleId { get; set; } = 1;
     }
 }

--- a/Source/NexusForever.Aspire.Database.Migrations/Configuration/Model/RealmOptions.cs
+++ b/Source/NexusForever.Aspire.Database.Migrations/Configuration/Model/RealmOptions.cs
@@ -1,0 +1,9 @@
+namespace NexusForever.Aspire.Database.Migrations.Configuration.Model
+{
+    public class RealmOptions
+    {
+        public string Host { get; set; } = "127.0.0.1";
+        public string Name { get; set; } = "NexusForever";
+        public ushort Port { get; set; } = 24000;
+    }
+}

--- a/Source/NexusForever.Aspire.Database.Migrations/Program.cs
+++ b/Source/NexusForever.Aspire.Database.Migrations/Program.cs
@@ -13,13 +13,15 @@ using NexusForever.Database.Friendship;
 using NexusForever.Database.Group;
 using NexusForever.Database.Query;
 using NexusForever.Database.World;
+using NexusForever.Shared.Configuration;
 using NLog.Extensions.Logging;
+using MySqlConnector;
 
 namespace NexusForever.Aspire.Database.Migrations
 {
     internal class Program
     {
-        static async Task Main(string[] args)
+        static async Task<int> Main(string[] args)
         {
             string basePath = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
 
@@ -27,7 +29,7 @@ namespace NexusForever.Aspire.Database.Migrations
                 .ConfigureAppConfiguration(cb =>
                 {
                     cb.SetBasePath(basePath)
-                        .AddJsonFile("AspireMigrations.json", false)
+                        .AddNexusForeverJson("AspireMigrations.json")
                         .AddEnvironmentVariables();
                 })
                 .ConfigureLogging(l =>
@@ -43,9 +45,18 @@ namespace NexusForever.Aspire.Database.Migrations
                     sc.AddOptions<WorldDatabaseOptions>()
                         .Bind(hb.Configuration.GetSection("WorldDatabase"));
 
+                    sc.AddOptions<RealmOptions>()
+                        .Bind(hb.Configuration.GetSection("Realm"));
+
+                    string Connection(string name) => new MySqlConnectionStringBuilder(hb.Configuration.GetConnectionString(name))
+                    {
+                        AllowUserVariables = true
+                    }.ConnectionString;
+
                     sc.AddHostedService<DatabaseMigrationHostedService>();
-                    sc.AddHostedService<AccountCreationHostedService>();
                     sc.AddHostedService<WorldDatabaseHostedService>();
+                    sc.AddHostedService<AccountCreationHostedService>();
+                    sc.AddHostedService<RealmHostedService>();
                     sc.AddHostedService<FinishHostedService>();
 
                     sc.AddScoped(sp =>
@@ -66,43 +77,52 @@ namespace NexusForever.Aspire.Database.Migrations
 
                     sc.AddDbContext<AuthContext>(options =>
                     {
-                        var connectionString = hb.Configuration.GetConnectionString("authdb");
+                        var connectionString = Connection("authdb");
                         options.UseMySql(connectionString, ServerVersion.AutoDetect(connectionString));
                     });
                     sc.AddDbContext<CharacterContext>(options =>
                     {
-                        var connectionString = hb.Configuration.GetConnectionString("characterdb");
+                        var connectionString = Connection("characterdb");
                         options.UseMySql(connectionString, ServerVersion.AutoDetect(connectionString));
                     });
                     sc.AddDbContext<WorldContext>(options =>
                     {
-                        var connectionString = hb.Configuration.GetConnectionString("worlddb");
+                        var connectionString = Connection("worlddb");
                         options.UseMySql(connectionString, ServerVersion.AutoDetect(connectionString));
                     });
                     sc.AddDbContext<GroupContext>(options =>
                     {
-                        var connectionString = hb.Configuration.GetConnectionString("groupdb");
+                        var connectionString = Connection("groupdb");
                         options.UseMySql(connectionString, ServerVersion.AutoDetect(connectionString));
                     });
                     sc.AddDbContext<ChatContext>(options =>
                     {
-                        var connectionString = hb.Configuration.GetConnectionString("chatdb");
+                        var connectionString = Connection("chatdb");
                         options.UseMySql(connectionString, ServerVersion.AutoDetect(connectionString));
                     });
                     sc.AddDbContext<FriendshipContext>(options =>
                     {
-                        var connectionString = hb.Configuration.GetConnectionString("friendshipdb");
+                        var connectionString = Connection("friendshipdb");
                         options.UseMySql(connectionString, ServerVersion.AutoDetect(connectionString));
                     });
                     sc.AddDbContext<QueryContext>(options =>
                     {
-                        var connectionString = hb.Configuration.GetConnectionString("querydb");
+                        var connectionString = Connection("querydb");
                         options.UseMySql(connectionString, ServerVersion.AutoDetect(connectionString));
                     });
                 });
 
-            IHost host = builder.Build();
-            await host.RunAsync();
+            try
+            {
+                using IHost host = builder.Build();
+                await host.RunAsync();
+                return 0;
+            }
+            catch (Exception exception)
+            {
+                Console.Error.WriteLine($"Database setup failed: {exception}");
+                return 1;
+            }
         }
     }
 }

--- a/Source/NexusForever.Aspire.Database.Migrations/Service/AccountCreationHostedService.cs
+++ b/Source/NexusForever.Aspire.Database.Migrations/Service/AccountCreationHostedService.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Hosting;
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NexusForever.Aspire.Database.Migrations.Configuration.Model;
@@ -30,35 +31,37 @@ namespace NexusForever.Aspire.Database.Migrations.Service
 
         public async Task StartAsync(CancellationToken cancellationToken)
         {
-            if (_options.UserName == null || _options.Password == null)
-            {
-                _log.LogWarning("Account creation options are not configured, skipping account creation.");
-                return;
-            }
+            if (string.IsNullOrWhiteSpace(_options.UserName) || string.IsNullOrEmpty(_options.Password))
+                throw new InvalidOperationException("Set the initial account username and password.");
+            if (_options.RoleId is < 1 or > 3)
+                throw new InvalidOperationException("Account role must be 1 (Player), 2 (GameMaster), or 3 (Administrator).");
 
-            AccountModel accountModel = _context.Account.SingleOrDefault(a => a.Email == _options.UserName);
+            string userName = _options.UserName.ToLowerInvariant();
+            AccountModel accountModel = await _context.Account.SingleOrDefaultAsync(a => a.Email == userName, cancellationToken);
             if (accountModel != null)
             {
                 _log.LogInformation("Account with username '{UserName}' already exists, skipping account creation.", _options.UserName);
                 return;
             }
 
-            (string salt, string vertifier) = PasswordProvider.GenerateSaltAndVerifier(_options.UserName, _options.Password);
+            (string salt, string verifier) = PasswordProvider.GenerateSaltAndVerifier(userName, _options.Password);
             _context.Account.Add(new AccountModel
             {
-                Email = _options.UserName,
+                Email = userName,
                 S     = salt,
-                V     = vertifier
+                V     = verifier,
+                AccountRole = [new AccountRoleModel { RoleId = _options.RoleId }]
             });
 
             try
             {
-                await _context.SaveChangesAsync();
+                await _context.SaveChangesAsync(cancellationToken);
                 _log.LogInformation("Account with username '{UserName}' created successfully.", _options.UserName);
             }
             catch (Exception ex)
             {
                 _log.LogError(ex, "Failed to create account with username '{UserName}'.", _options.UserName);
+                throw;
             }
         }
 

--- a/Source/NexusForever.Aspire.Database.Migrations/Service/DatabaseMigrationHostedService.cs
+++ b/Source/NexusForever.Aspire.Database.Migrations/Service/DatabaseMigrationHostedService.cs
@@ -44,13 +44,13 @@ namespace NexusForever.Aspire.Database.Migrations.Service
 
         public async Task StartAsync(CancellationToken cancellationToken)
         {
-            await _authContext.Database.MigrateAsync();
-            await _characterContext.Database.MigrateAsync();
-            await _worldContext.Database.MigrateAsync();
-            await _groupContext.Database.MigrateAsync();
-            await _chatContext.Database.MigrateAsync();
-            await _friendshipContext.Database.MigrateAsync();
-            await _queryContext.Database.MigrateAsync();
+            await _authContext.Database.MigrateAsync(cancellationToken);
+            await _characterContext.Database.MigrateAsync(cancellationToken);
+            await _worldContext.Database.MigrateAsync(cancellationToken);
+            await _groupContext.Database.MigrateAsync(cancellationToken);
+            await _chatContext.Database.MigrateAsync(cancellationToken);
+            await _friendshipContext.Database.MigrateAsync(cancellationToken);
+            await _queryContext.Database.MigrateAsync(cancellationToken);
         }
 
         public Task StopAsync(CancellationToken cancellationToken)

--- a/Source/NexusForever.Aspire.Database.Migrations/Service/RealmHostedService.cs
+++ b/Source/NexusForever.Aspire.Database.Migrations/Service/RealmHostedService.cs
@@ -1,0 +1,37 @@
+using System.Net;
+using System.Net.Sockets;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using NexusForever.Aspire.Database.Migrations.Configuration.Model;
+using NexusForever.Database.Auth;
+using NexusForever.Database.Auth.Model;
+
+namespace NexusForever.Aspire.Database.Migrations.Service
+{
+    public class RealmHostedService(AuthContext context, IOptions<RealmOptions> options) : IHostedService
+    {
+        public async Task StartAsync(CancellationToken cancellationToken)
+        {
+            RealmOptions realm = options.Value;
+            if (!IPAddress.TryParse(realm.Host, out var address) || address.AddressFamily != AddressFamily.InterNetwork
+                || address.Equals(IPAddress.Any) || realm.Port == 0)
+                throw new InvalidOperationException("Set a reachable realm IPv4 address and a port between 1 and 65535.");
+            if (string.IsNullOrWhiteSpace(realm.Name) || realm.Name.Length > 64)
+                throw new InvalidOperationException("Realm name must contain 1 to 64 characters.");
+
+            var server = await context.Server.SingleOrDefaultAsync(s => s.Id == 1, cancellationToken);
+            if (server == null)
+            {
+                server = new ServerModel { Id = 1 };
+                context.Server.Add(server);
+            }
+            server.Host = realm.Host;
+            server.Port = realm.Port;
+            server.Name = realm.Name;
+            await context.SaveChangesAsync(cancellationToken);
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    }
+}

--- a/Source/NexusForever.Aspire.Database.Migrations/Service/WorldDatabaseHostedService.cs
+++ b/Source/NexusForever.Aspire.Database.Migrations/Service/WorldDatabaseHostedService.cs
@@ -1,7 +1,7 @@
 ﻿using System.Security.Cryptography;
 using System.Text;
-using System.Text.RegularExpressions;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -33,54 +33,56 @@ namespace NexusForever.Aspire.Database.Migrations.Service
 
         public async Task StartAsync(CancellationToken cancellationToken)
         {
-            if (_options.Path == null)
-            {
-                _log.LogWarning("World database options are not configured. Skipping migration.");
-                return;
-            }
+            if (string.IsNullOrWhiteSpace(_options.Path) || !Directory.Exists(_options.Path))
+                throw new DirectoryNotFoundException($"World database directory does not exist: {_options.Path}");
 
-            if (!Directory.Exists(_options.Path))
-            {
-                _log.LogWarning("World database migrations path does not exist. Skipping migration.");
-                return;
-            }
+            string[] files = Directory.GetFiles(_options.Path, "*.sql", SearchOption.AllDirectories)
+                .Order(StringComparer.Ordinal).ToArray();
+            if (files.Length == 0)
+                throw new InvalidOperationException($"No world SQL files found in {_options.Path}.");
 
-            foreach (string filePath in Directory.GetFiles(_options.Path, "*.sql", SearchOption.AllDirectories))
+            var nameCounts = files.GroupBy(Path.GetFileName).ToDictionary(g => g.Key, g => g.Count());
+            foreach (string filePath in files)
             {
-                string fileName    = Path.GetFileName(filePath);
-                string fileContent = File.ReadAllText(filePath);
+                string fileName    = Path.GetRelativePath(_options.Path, filePath).Replace('\\', '/');
+                string legacyName  = nameCounts[Path.GetFileName(filePath)] == 1 ? Path.GetFileName(filePath) : fileName;
+                string fileContent = await File.ReadAllTextAsync(filePath, cancellationToken);
                 string fileHash    = Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(fileContent)));
 
-                if (_context.Version.Any(v => v.FileName == fileName && v.FileHash == fileHash))
+                var versions = _context.Version.Where(v => v.FileName == fileName || v.FileName == legacyName);
+                var latest = await versions.OrderByDescending(v => v.AppliedOn).FirstOrDefaultAsync(cancellationToken);
+                if (latest?.FileHash == fileHash)
                 {
                     _log.LogInformation("Skipping already applied world database migration: {FileName}", fileName);
                     continue;
                 }
 
-                fileContent = Regex.Replace(fileContent, @"/\*.*?\*/", "", RegexOptions.Singleline);
-                fileContent = Regex.Replace(fileContent, @"--.*?$", "", RegexOptions.Multiline);
-                fileContent = fileContent.Trim();
-
                 _log.LogInformation("Applying world database migration: {FileName}", fileName);
+                await using var transaction = await _context.Database.BeginTransactionAsync(cancellationToken);
                 try
                 {
-                    await _context.Database.ExecuteSqlRawAsync(fileContent);
+                    await using var command = _context.Database.GetDbConnection().CreateCommand();
+                    command.Transaction = transaction.GetDbTransaction();
+                    command.CommandTimeout = 600;
+                    command.CommandText = fileContent;
+                    await command.ExecuteNonQueryAsync(cancellationToken);
+
+                    await versions.ExecuteDeleteAsync(cancellationToken);
+                    _context.Version.Add(new VersionModel
+                    {
+                        FileName = fileName,
+                        FileHash = fileHash,
+                        AppliedOn = DateTime.UtcNow
+                    });
+                    await _context.SaveChangesAsync(cancellationToken);
+                    await transaction.CommitAsync(cancellationToken);
                 }
                 catch (Exception ex)
                 {
                     _log.LogError(ex, "Failed to apply world database migration: {FileName}", fileName);
-                    continue;
+                    throw;
                 }
                 _log.LogInformation("Applied world database migration: {FileName}", fileName);
-
-                _context.Version.Add(new VersionModel
-                {
-                    FileName = fileName,
-                    FileHash = fileHash,
-                    AppliedOn = DateTime.UtcNow
-                });
-
-                await _context.SaveChangesAsync(cancellationToken);
             }
         }
 

--- a/Source/NexusForever.AuthServer/AuthServer.cs
+++ b/Source/NexusForever.AuthServer/AuthServer.cs
@@ -38,7 +38,7 @@ namespace NexusForever.AuthServer
                 })
                 .ConfigureAppConfiguration(cb =>
                 {
-                    cb.AddJsonFile("AuthServer.json", false)
+                    cb.AddNexusForeverJson("AuthServer.json")
                         .AddEnvironmentVariables();
                 })
                 .ConfigureServices((hb, sc) =>

--- a/Source/NexusForever.MapGenerator/AssetPreparation.cs
+++ b/Source/NexusForever.MapGenerator/AssetPreparation.cs
@@ -1,0 +1,217 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using NexusForever.GameTable;
+using NexusForever.IO.Map;
+
+namespace NexusForever.MapGenerator
+{
+    internal static class AssetPreparation
+    {
+        private const string InventoryFile = ".maps.json";
+
+        private static readonly string[] textFiles = typeof(NexusForever.GameTable.GameTableManager).GetProperties()
+            .Where(property => property.PropertyType == typeof(TextTable))
+            .Select(property => property.GetCustomAttribute<GameDataAttribute>()?.FileName)
+            .Where(name => name != null).ToArray();
+
+        public static void Run(Parameters parameters, Action<Parameters> generate)
+        {
+            if (string.IsNullOrWhiteSpace(parameters.OutputDir))
+                throw new ArgumentException("Set an asset output directory with --output.");
+            if (parameters.WorldId.HasValue || parameters.GridX.HasValue || parameters.GridY.HasValue)
+                throw new ArgumentException("--prepare requires a complete extraction; omit world and grid filters.");
+
+            Directory.CreateDirectory(parameters.OutputDir);
+            using var fileLock = LockDirectory(parameters.OutputDir);
+            string marker = Path.Combine(parameters.OutputDir, ".extracting");
+            if (!File.Exists(marker))
+            {
+                try
+                {
+                    Validate(parameters.OutputDir);
+                    Console.WriteLine("Using existing maps and tables.");
+                    return;
+                }
+                catch (Exception exception) when (exception is IOException or InvalidDataException or JsonException or TargetInvocationException)
+                {
+                    Console.WriteLine($"Assets need extraction: {exception.GetBaseException().Message}");
+                }
+            }
+
+            string patch = parameters.PatchPath;
+            if (Directory.Exists(Path.Combine(patch ?? "", "Patch")))
+                patch = Path.Combine(patch, "Patch");
+            if (!File.Exists(Path.Combine(patch ?? "", "ClientData.index")))
+                throw new FileNotFoundException("Set ClientPath to a WildStar installation or its Patch directory.");
+
+            parameters.PatchPath = patch;
+            parameters.Extract = true;
+            parameters.Generate = true;
+            File.WriteAllText(marker, "Extraction is incomplete. Run asset preparation again.\n");
+            string destination = parameters.OutputDir;
+            string staging = Path.GetFullPath(Path.Combine(destination, ".prepare"));
+            try
+            {
+                if (Directory.Exists(staging))
+                    Directory.Delete(staging, recursive: true);
+                Directory.CreateDirectory(staging);
+                parameters.OutputDir = staging;
+                generate(parameters);
+                Validate(staging, full: true, checkInventory: false);
+
+                var inventory = Directory.GetFiles(Path.Combine(staging, "map"), "*.nfmap")
+                    .ToDictionary(Path.GetFileName, path => new FileInfo(path).Length, StringComparer.Ordinal);
+                File.WriteAllText(Path.Combine(staging, InventoryFile), JsonSerializer.Serialize(inventory));
+
+                string maps = Path.Combine(destination, "map");
+                Directory.CreateDirectory(maps);
+                foreach (string path in Directory.GetFiles(maps, "*.nfmap"))
+                    if (!inventory.ContainsKey(Path.GetFileName(path)))
+                        File.Delete(path);
+
+                string tables = Path.Combine(destination, "tbl");
+                Directory.CreateDirectory(tables);
+                foreach (string name in textFiles)
+                    if (!File.Exists(Path.Combine(staging, "tbl", name)))
+                        File.Delete(Path.Combine(tables, name));
+
+                foreach (string folder in new[] { "map", "tbl" })
+                {
+                    Directory.CreateDirectory(Path.Combine(destination, folder));
+                    foreach (string path in Directory.GetFiles(Path.Combine(staging, folder)))
+                        File.Move(path, Path.Combine(destination, folder, Path.GetFileName(path)), overwrite: true);
+                }
+                File.Move(Path.Combine(staging, InventoryFile), Path.Combine(destination, InventoryFile), overwrite: true);
+            }
+            finally
+            {
+                parameters.OutputDir = destination;
+                if (Directory.Exists(staging))
+                    Directory.Delete(staging, recursive: true);
+            }
+            File.Delete(marker);
+        }
+
+        private static FileStream LockDirectory(string directory)
+        {
+            try
+            {
+                return File.Open(Path.Combine(directory, ".prepare.lock"), FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+            }
+            catch (IOException exception)
+            {
+                throw new IOException($"Cannot lock asset directory {directory}; another setup may be preparing it.", exception);
+            }
+        }
+
+        private static void Validate(string directory, bool full = false, bool checkInventory = true)
+        {
+            string[] maps = Directory.GetFiles(Path.Combine(directory, "map"), "*.nfmap");
+            if (maps.Length == 0)
+                throw new InvalidDataException("No map files found.");
+            if (checkInventory)
+            {
+                string inventoryPath = Path.Combine(directory, InventoryFile);
+                if (!File.Exists(inventoryPath))
+                    throw new InvalidDataException("No map inventory found. Regenerate these assets once with --prepare and a client path.");
+                var inventory = JsonSerializer.Deserialize<Dictionary<string, long>>(File.ReadAllText(inventoryPath));
+                if (inventory == null || !maps.Select(Path.GetFileName).ToHashSet(StringComparer.Ordinal).SetEquals(inventory.Keys))
+                    throw new InvalidDataException("Map files do not match the generated inventory.");
+                foreach (string path in maps)
+                    if (new FileInfo(path).Length != inventory[Path.GetFileName(path)])
+                        throw new InvalidDataException($"Map file size has changed: {path}");
+            }
+            foreach (string path in maps)
+            {
+                using var reader = new BinaryReader(File.OpenRead(path));
+                try
+                {
+                    var map = new MapFile();
+                    if (full)
+                        map.Read(reader);
+                    else
+                        map.ReadHeader(reader);
+                }
+                catch (Exception exception) when (exception is IOException or InvalidDataException)
+                {
+                    throw new InvalidDataException($"{path}: {exception.Message}", exception);
+                }
+            }
+
+            foreach (var property in typeof(NexusForever.GameTable.GameTableManager).GetProperties())
+            {
+                var attribute = property.GetCustomAttribute<GameDataAttribute>();
+                if (attribute == null || property.PropertyType == typeof(TextTable))
+                    continue;
+                string path = Path.Combine(directory, "tbl", attribute.FileName ?? $"{property.Name}.tbl");
+                if (!File.Exists(path))
+                    throw new FileNotFoundException($"Missing required table: {path}");
+                ValidateTableHeader(path);
+                if (full)
+                    Activator.CreateInstance(property.PropertyType, path);
+            }
+
+            foreach (string name in textFiles)
+            {
+                string path = Path.Combine(directory, "tbl", name);
+                if (!File.Exists(path))
+                {
+                    if (name == "en-US.bin")
+                        throw new FileNotFoundException($"Missing English text table: {path}");
+                    continue;
+                }
+                ValidateTableHeader(path, text: true);
+                if (full)
+                    _ = new TextTable(path);
+            }
+        }
+
+        private static void ValidateTableHeader(string path, bool text = false)
+        {
+            using var stream = File.OpenRead(path);
+            try
+            {
+                if (text)
+                {
+                    var header = ReadHeader<TextTableHeader>(stream);
+                    if (header.Signature != 0x4C544558 || header.RecordCount == 0)
+                        throw new InvalidDataException("Invalid text table header.");
+                    RequireRange(stream, header.RecordOffset, header.RecordCount, (ulong)Marshal.SizeOf<TextTableField>());
+                    RequireRange(stream, header.StringTableOffset, header.StringTableLength, 2);
+                }
+                else
+                {
+                    var header = ReadHeader<GameTableHeader>(stream);
+                    if (header.Signature != 0x4454424C || (header.RecordCount > 0
+                        && (header.RecordSize == 0 || header.RecordCount > header.TotalRecordSize / header.RecordSize)))
+                        throw new InvalidDataException("Invalid game table header.");
+                    RequireRange(stream, header.FieldOffset, header.FieldCount, (ulong)Marshal.SizeOf<GameTableField>());
+                    RequireRange(stream, header.RecordOffset, header.TotalRecordSize, 1);
+                }
+            }
+            catch (Exception exception) when (exception is IOException or InvalidDataException)
+            {
+                throw new InvalidDataException($"{path}: {exception.Message}", exception);
+            }
+        }
+
+        private static T ReadHeader<T>(Stream stream) where T : unmanaged
+        {
+            Span<byte> bytes = stackalloc byte[Marshal.SizeOf<T>()];
+            stream.ReadExactly(bytes);
+            return MemoryMarshal.Read<T>(bytes);
+        }
+
+        private static void RequireRange(Stream stream, ulong offset, ulong count, ulong size)
+        {
+            ulong available = (ulong)(stream.Length - stream.Position);
+            if (offset > available || count > (available - offset) / size)
+                throw new InvalidDataException("Table data extends beyond the end of the file.");
+        }
+    }
+}

--- a/Source/NexusForever.MapGenerator/ExtractionManager.cs
+++ b/Source/NexusForever.MapGenerator/ExtractionManager.cs
@@ -66,7 +66,7 @@ namespace NexusForever.MapGenerator
             string filePath = Path.Combine(outputDir, fileEntry.FileName);
 
             using (Stream archiveStream = archive.OpenFileStream(fileEntry))
-            using (FileStream fileStream = File.OpenWrite(filePath))
+            using (FileStream fileStream = File.Create(filePath))
             {
                 archiveStream.CopyTo(fileStream);
             }

--- a/Source/NexusForever.MapGenerator/GenerationManager.cs
+++ b/Source/NexusForever.MapGenerator/GenerationManager.cs
@@ -143,7 +143,7 @@ namespace NexusForever.MapGenerator
                 }
                 catch (Exception e)
                 {
-                    log.Error(e);
+                    log.Error(e, $"Skipping {map.Asset} grid {gridX},{gridY}.");
                 }
             }
         }

--- a/Source/NexusForever.MapGenerator/MapGenerator.cs
+++ b/Source/NexusForever.MapGenerator/MapGenerator.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
 using CommandLine;
-using CommandLine.Text;
 using Microsoft.Extensions.DependencyInjection;
 using NexusForever.MapGenerator.GameTable;
 using NexusForever.Shared;
@@ -20,7 +20,7 @@ namespace NexusForever.MapGenerator
         private const string Title = "NexusForever: Map Generator (RELEASE)";
         #endif
 
-        private static void Main(string[] args)
+        private static int Main(string[] args)
         {
             IServiceCollection services = new ServiceCollection();
             services.AddSingleton<ArchiveManager>();
@@ -33,21 +33,33 @@ namespace NexusForever.MapGenerator
             Console.Title = Title;
 
             parserResult = Parser.Default.ParseArguments<Parameters>(args);
-            parserResult.WithParsed(ParameterOk);
-
-            log.Info("Finished!");
+            return parserResult.MapResult(parameters =>
+            {
+                try
+                {
+                    if (parameters.Prepare)
+                        AssetPreparation.Run(parameters, ParameterOk);
+                    else
+                        ParameterOk(parameters);
+                    log.Info("Finished!");
+                    return 0;
+                }
+                catch (Exception exception)
+                {
+                    log.Error(exception, "Asset preparation failed.");
+                    return 1;
+                }
+            }, errors => errors.All(e => e is HelpRequestedError or VersionRequestedError) ? 0 : 1);
         }
 
         private static void ParameterOk(Parameters parameters)
         {
             if (!Directory.Exists(parameters.PatchPath))
-                throw new DirectoryNotFoundException();
+                throw new DirectoryNotFoundException($"Client Patch directory does not exist: {parameters.PatchPath}");
 
             if (!parameters.Extract && !parameters.Generate)
             {
-                log.Warn("Please specify the Extract or Generate parameter");
-                log.Info(GetHelp());
-                return;
+                throw new ArgumentException("Specify --extract, --generate, or --prepare.");
             }
 
             if ((parameters.Extract || parameters.Generate) && !string.IsNullOrEmpty(parameters.OutputDir))
@@ -74,11 +86,6 @@ namespace NexusForever.MapGenerator
                 TimeSpan span = DateTime.UtcNow - start;
                 log.Info($"Generated base maps in {span.TotalSeconds}s.");
             }
-        }
-
-        private static string GetHelp()
-        {
-            return HelpText.AutoBuild(parserResult, h => h, e => e);
         }
     }
 }

--- a/Source/NexusForever.MapGenerator/NexusForever.MapGenerator.csproj
+++ b/Source/NexusForever.MapGenerator/NexusForever.MapGenerator.csproj
@@ -17,4 +17,8 @@
     <ProjectReference Include="..\NexusForever.Shared\NexusForever.Shared.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="nlog.config" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
 </Project>

--- a/Source/NexusForever.MapGenerator/Parameters.cs
+++ b/Source/NexusForever.MapGenerator/Parameters.cs
@@ -4,7 +4,7 @@ namespace NexusForever.MapGenerator
 {
     public class Parameters
     {
-        [Option('i', "patchPath", Required = true,
+        [Option('i', "patchPath",
             HelpText = "The location of the WildStar client patch folder.")]
         public string PatchPath { get; set; }
 
@@ -19,6 +19,9 @@ namespace NexusForever.MapGenerator
         [Option('o', "output",
             HelpText = "The base directory where output files will be created.", Default = "")]
         public string OutputDir { get; set; }
+
+        [Option("prepare", HelpText = "Reuse valid assets or extract and generate them from the client.")]
+        public bool Prepare { get; set; }
 
         [Option("debug")]
         public bool Debug { get; set; }

--- a/Source/NexusForever.MapGenerator/nlog.config
+++ b/Source/NexusForever.MapGenerator/nlog.config
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <targets>
+    <target xsi:type="Console" name="console" layout="${message} ${exception:format=Message}" />
+  </targets>
+  <rules>
+    <logger name="*" minlevel="Info" writeTo="console" />
+  </rules>
+</nlog>

--- a/Source/NexusForever.Server.Character/CharacterServer.cs
+++ b/Source/NexusForever.Server.Character/CharacterServer.cs
@@ -16,6 +16,7 @@ using NexusForever.Network.Internal.Configuration;
 using NexusForever.Server.Character.Configuration;
 using NexusForever.Server.Character.Game;
 using NexusForever.Server.Character.Network.Internal.Handler;
+using NexusForever.Shared.Configuration;
 using NLog.Extensions.Logging;
 
 namespace NexusForever.Server.Character
@@ -43,7 +44,7 @@ namespace NexusForever.Server.Character
                 .ConfigureAppConfiguration(cb =>
                 {
                     cb.SetBasePath(basePath)
-                        .AddJsonFile("CharacterServer.json", false)
+                        .AddNexusForeverJson("CharacterServer.json")
                         .AddEnvironmentVariables();
                 })
                 .ConfigureServices((hb, sc) =>

--- a/Source/NexusForever.Server.ChatServer/ChatServer.cs
+++ b/Source/NexusForever.Server.ChatServer/ChatServer.cs
@@ -16,6 +16,7 @@ using NexusForever.Server.ChatServer.Character;
 using NexusForever.Server.ChatServer.Chat;
 using NexusForever.Server.ChatServer.Job;
 using NexusForever.Server.ChatServer.Network.Internal.Handler;
+using NexusForever.Shared.Configuration;
 using NLog.Extensions.Logging;
 using Quartz;
 
@@ -44,7 +45,7 @@ namespace NexusForever.Server.ChatServer
                 .ConfigureAppConfiguration(cb =>
                 {
                     cb.SetBasePath(basePath)
-                        .AddJsonFile("ChatServer.json", false)
+                        .AddNexusForeverJson("ChatServer.json")
                         .AddEnvironmentVariables();
                 })
                 .ConfigureServices((hb, sc) =>

--- a/Source/NexusForever.Server.Friendship/FriendshipServer.cs
+++ b/Source/NexusForever.Server.Friendship/FriendshipServer.cs
@@ -20,6 +20,7 @@ using NexusForever.Server.Friendship.Game.Friend;
 using NexusForever.Server.Friendship.Job;
 using NexusForever.Server.Friendship.Network.Internal;
 using NexusForever.Server.Friendship.Network.Internal.Handler;
+using NexusForever.Shared.Configuration;
 using NLog.Extensions.Logging;
 using Quartz;
 
@@ -48,7 +49,7 @@ namespace NexusForever.Server.Friendship
                 .ConfigureAppConfiguration(cb =>
                 {
                     cb.SetBasePath(basePath)
-                        .AddJsonFile("FriendshipServer.json", false)
+                        .AddNexusForeverJson("FriendshipServer.json")
                         .AddEnvironmentVariables();
                 })
                 .ConfigureServices((hb, sc) =>

--- a/Source/NexusForever.Server.GroupServer/GroupServer.cs
+++ b/Source/NexusForever.Server.GroupServer/GroupServer.cs
@@ -15,6 +15,7 @@ using NexusForever.Server.GroupServer.Character;
 using NexusForever.Server.GroupServer.Group;
 using NexusForever.Server.GroupServer.Job;
 using NexusForever.Server.GroupServer.Network.Internal;
+using NexusForever.Shared.Configuration;
 using NLog.Extensions.Logging;
 using Quartz;
 
@@ -43,7 +44,7 @@ namespace NexusForever.Server.GroupServer
                 .ConfigureAppConfiguration(cb =>
                 {
                     cb.SetBasePath(basePath)
-                        .AddJsonFile("GroupServer.json", false)
+                        .AddNexusForeverJson("GroupServer.json")
                         .AddEnvironmentVariables();
                 })
                 .ConfigureServices((hb, sc) =>

--- a/Source/NexusForever.Shared/Configuration/ConfigurationBuilderExtensions.cs
+++ b/Source/NexusForever.Shared/Configuration/ConfigurationBuilderExtensions.cs
@@ -1,0 +1,18 @@
+using System;
+using System.IO;
+using Microsoft.Extensions.Configuration;
+
+namespace NexusForever.Shared.Configuration
+{
+    public static class ConfigurationBuilderExtensions
+    {
+        public static IConfigurationBuilder AddNexusForeverJson(this IConfigurationBuilder builder, string path)
+        {
+            if (Environment.GetEnvironmentVariable("NEXUSFOREVER_ASPIRE") == "1"
+                && !builder.GetFileProvider().GetFileInfo(path).Exists)
+                path = Path.ChangeExtension(path, "example.json");
+
+            return builder.AddJsonFile(path, optional: false);
+        }
+    }
+}

--- a/Source/NexusForever.StsServer/StsServer.cs
+++ b/Source/NexusForever.StsServer/StsServer.cs
@@ -37,7 +37,7 @@ namespace NexusForever.StsServer
                 })
                 .ConfigureAppConfiguration(cb =>
                 {
-                    cb.AddJsonFile("StsServer.json", false)
+                    cb.AddNexusForeverJson("StsServer.json")
                         .AddEnvironmentVariables();
                 })
                 .ConfigureServices((hb, sc) =>

--- a/Source/NexusForever.WorldServer/WorldServer.cs
+++ b/Source/NexusForever.WorldServer/WorldServer.cs
@@ -50,7 +50,7 @@ namespace NexusForever.WorldServer
                 })
                 .ConfigureAppConfiguration(cb =>
                 {
-                    cb.AddJsonFile("WorldServer.json", false)
+                    cb.AddNexusForeverJson("WorldServer.json")
                         .AddEnvironmentVariables();
                 })
                 .ConfigureServices((hb, sc) =>

--- a/aspire.sh
+++ b/aspire.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/Source"
+command -v dotnet >/dev/null || { echo "Install the .NET 10 SDK first." >&2; exit 1; }
+command -v docker >/dev/null || { echo "Install Docker first." >&2; exit 1; }
+docker info >/dev/null 2>&1 || { echo "Docker is unavailable. Start Docker and check access with docker info." >&2; exit 1; }
+
+if [[ -z ${DOTNET_ROOT:-} ]]; then
+    runtime_path=$(dotnet --list-runtimes | awk '$1 == "Microsoft.NETCore.App" { sub(/^.*\[/, ""); sub(/\].*$/, ""); print; exit }')
+    [[ -n "$runtime_path" ]] || { echo "Install the .NET 10 SDK first." >&2; exit 1; }
+    export DOTNET_ROOT="${runtime_path%/shared/Microsoft.NETCore.App}"
+fi
+
+dotnet tool restore
+apphost=NexusForever.Aspire.AppHost/NexusForever.Aspire.AppHost.csproj
+if [[ ${1:-} == --setup ]]; then
+    exec dotnet run --project "$apphost" -- --setup
+fi
+if [[ ! -f NexusForever.Aspire.AppHost/appsettings.Local.json ]]; then
+    dotnet run --project "$apphost" -- --setup
+fi
+exec dotnet aspire run "$@"


### PR DESCRIPTION
The existing AppHost needs manual configuration and asset setup before it can start. This adds ./aspire.sh to install the pinned Aspire CLI and prompt for client paths, account details, realm settings, and ports. Settings stay local; passwords use .NET user secrets.

Startup prepares maps and tables, downloads the pinned world SQL when needed, migrates all seven databases, and creates the initial account. Valid assets and unchanged SQL are reused. Failed preparation or migrations block server startup.

Also fixes SQL user-variable handling, rolls back failed imports, and repairs incomplete asset extraction. The README covers setup, configuration, and the local web interfaces, including optional phpMyAdmin.

